### PR TITLE
fix(pkg): update npm install script

### DIFF
--- a/packages/nodejs/package.json
+++ b/packages/nodejs/package.json
@@ -18,7 +18,7 @@
     "test:watch": "jest --watch",
     "versionfile": "node scripts/create-versionfile.js",
     "version": "yarn versionfile",
-    "install": "node scripts/extension.js && yarn build:ext"
+    "install": "node scripts/extension.js && node-gyp rebuild"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Right now the install script calls `yarn` which is not a requirement, and can therefore fail after installing:

```sh
[:~/Projects/system76/nuxt-appsignal] master* ± npm install --save @appsignal/nodejs
npm WARN deprecated request@2.88.2: request has been deprecated, see https://github.com/request/request/issues/3142

> @appsignal/nodejs@0.1.0-alpha.7 install /home/btkostner/Projects/system76/nuxt-appsignal/node_modules/@appsignal/nodejs
> node scripts/extension.js && yarn build:ext

The agent has installed successfully!
sh: 1: yarn: not found
npm WARN optional SKIPPING OPTIONAL DEPENDENCY: fsevents@2.1.2 (node_modules/fsevents):
npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for fsevents@2.1.2: wanted {"os":"darwin","arch":"any"} (current: {"os":"linux","arch":"x64"})

npm ERR! code ELIFECYCLE
npm ERR! syscall spawn
npm ERR! file sh
npm ERR! errno ENOENT
npm ERR! @appsignal/nodejs@0.1.0-alpha.7 install: `node scripts/extension.js && yarn build:ext`
npm ERR! spawn ENOENT
npm ERR! 
npm ERR! Failed at the @appsignal/nodejs@0.1.0-alpha.7 install script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/btkostner/.npm/_logs/2020-02-17T18_04_41_087Z-debug.log
```

Alternatively, this could be `npm run build:ext` which has a higher change of working because `npm` is bundled with node.