### PR TITLE
Add incoming HTTP instrumentation, plugin system

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@types/express": "^4.17.2",
     "@types/jest": "^25.1.3",
     "@types/node": "^13.7.7",
+    "@types/semver": "^7.1.0",
     "@types/shimmer": "^1.0.1",
     "husky": "^4.2.3",
     "jest": "^25.1.0",
@@ -44,5 +45,6 @@
     "*.{ts,js}": [
       "prettier --write"
     ]
-  }
+  },
+  "dependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@types/express": "^4.17.2",
     "@types/jest": "^25.1.3",
     "@types/node": "^13.7.7",
+    "@types/shimmer": "^1.0.1",
     "husky": "^4.2.3",
     "jest": "^25.1.0",
     "lerna": "^3.20.2",

--- a/packages/express/src/index.ts
+++ b/packages/express/src/index.ts
@@ -1,36 +1,26 @@
-import * as asyncHooks from "async_hooks"
 import { Appsignal } from "@appsignal/nodejs"
-import { Request, Response, NextFunction, RequestHandler } from "express"
+import { Request, Response, NextFunction, ErrorRequestHandler } from "express"
 
-function expressMiddleware(appsignal: Appsignal): RequestHandler {
-  return function(req: Request, res: Response, next: NextFunction) {
-    const tracer = appsignal.tracer()
-    const rootSpan = tracer.createSpan(`${req.method} ${req.url}`)
+function expressMiddleware(appsignal: Appsignal): ErrorRequestHandler {
+  return function(err: Error, req: Request, res: Response, next: NextFunction) {
+    const span = appsignal.tracer().currentSpan()
 
-    rootSpan.setNamespace("web").set("method", req.method)
+    if (!span) {
+      return next()
+    }
+
+    if (err) {
+      span.addError(err)
+    }
 
     if (req.params.password) {
-      rootSpan.setSampleData("params", {
+      span.setSampleData("params", {
         ...req.params,
         password: "[FILTERED]"
       })
     } else {
-      rootSpan.setSampleData("params", req.params)
+      span.setSampleData("params", req.params)
     }
-
-    req.on("error", (err: Error) => rootSpan.addError(err))
-
-    // HACK! super dirty, but gives the span a scope which is required for
-    // the `ScopeManager` to recall it later (duh).
-    // @TODO: needs a more permanent solution
-    ;(tracer as any)._scopeManager._scopes.set(
-      asyncHooks.executionAsyncId(),
-      rootSpan
-    )
-
-    res.once("finish", () => {
-      rootSpan.close()
-    })
 
     return next()
   }

--- a/packages/express/tsconfig.json
+++ b/packages/express/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["src/**/*"],
+  "include": ["src/**/*", "../../vendor.d.ts"],
   "exclude": [
     "src/**/__tests__",
     "src/**/__mocks__"

--- a/packages/nodejs/package.json
+++ b/packages/nodejs/package.json
@@ -8,6 +8,7 @@
     "node-gyp": "^6.1.0",
     "tslib": "^1.11.1",
     "require-in-the-middle": "^5.0.3",
+    "semver": "^7.1.3",
     "shimmer": "^1.2.1"
   },
   "scripts": {

--- a/packages/nodejs/package.json
+++ b/packages/nodejs/package.json
@@ -6,7 +6,9 @@
   "dependencies": {
     "node-addon-api": "^2.0.0",
     "node-gyp": "^6.1.0",
-    "tslib": "^1.11.1"
+    "tslib": "^1.11.1",
+    "require-in-the-middle": "^5.0.3",
+    "shimmer": "^1.2.1"
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",

--- a/packages/nodejs/src/__tests__/scope.test.ts
+++ b/packages/nodejs/src/__tests__/scope.test.ts
@@ -32,15 +32,15 @@ describe("ScopeManager", () => {
     })
   })
 
-  describe(".with()", () => {
+  describe(".withContext()", () => {
     it("should run the callback (null as target)", done => {
-      scopeManager.with(null!, done)
+      scopeManager.withContext(null!, done)
     })
 
     it("should run the callback (object as target)", done => {
       const test = new RootSpan("test")
 
-      scopeManager.with(test, () => {
+      scopeManager.withContext(test, () => {
         expect(scopeManager.active()).toStrictEqual(test)
         return done()
       })
@@ -49,7 +49,7 @@ describe("ScopeManager", () => {
     it("should run the callback (when disabled)", done => {
       scopeManager.disable()
 
-      scopeManager.with(null!, () => {
+      scopeManager.withContext(null!, () => {
         scopeManager.enable()
         return done()
       })
@@ -57,7 +57,7 @@ describe("ScopeManager", () => {
 
     it("should rethrow errors", done => {
       expect(() =>
-        scopeManager.with(null!, () => {
+        scopeManager.withContext(null!, () => {
           throw new Error("This should be rethrown")
         })
       ).rejects
@@ -69,27 +69,10 @@ describe("ScopeManager", () => {
       const scope1 = new RootSpan("scope1")
       const scope2 = new RootSpan("scope2")
 
-      scopeManager.with(scope1, () => {
+      scopeManager.withContext(scope1, () => {
         expect(scopeManager.active()).toStrictEqual(scope1)
 
-        scopeManager.with(scope2, () => {
-          expect(scopeManager.active()).toStrictEqual(scope2)
-        })
-
-        expect(scopeManager.active()).toStrictEqual(scope1)
-
-        return done()
-      })
-    })
-
-    it("should finally restore an old scope (async)", async done => {
-      const scope1 = new RootSpan("scope1")
-      const scope2 = new RootSpan("scope2")
-
-      await scopeManager.with(scope1, async () => {
-        expect(scopeManager.active()).toStrictEqual(scope1)
-
-        await scopeManager.with(scope2, async () => {
+        scopeManager.withContext(scope2, () => {
           expect(scopeManager.active()).toStrictEqual(scope2)
         })
 

--- a/packages/nodejs/src/__tests__/span.test.ts
+++ b/packages/nodejs/src/__tests__/span.test.ts
@@ -1,4 +1,4 @@
-import { Span, ChildSpan, RootSpan } from "../span"
+import { ChildSpan, RootSpan } from "../span"
 
 type SpanData = {
   name: string

--- a/packages/nodejs/src/__tests__/tracer.test.ts
+++ b/packages/nodejs/src/__tests__/tracer.test.ts
@@ -20,17 +20,6 @@ describe("Tracer", () => {
   })
 
   describe("Span instrumentation", () => {
-    it("can instrument a function", done => {
-      tracer.withSpanSync(tracer.createSpan(name), span => {
-        const internal = JSON.parse(span.toJSON())
-        expect(internal.name).toEqual(name)
-
-        span.close()
-      })
-
-      return done()
-    })
-
     it("can instrument a function (async)", async done => {
       await tracer.withSpan(tracer.createSpan(name), async span => {
         const internal = JSON.parse(span.toJSON())

--- a/packages/nodejs/src/client.ts
+++ b/packages/nodejs/src/client.ts
@@ -4,9 +4,11 @@ import { Tracer } from "./tracer"
 import { NoopTracer } from "./noops"
 import { VERSION } from "./version"
 
-import { ITracer } from "./interfaces/ITracer"
-import { AppsignalOptions } from "./types/options"
 import { Metrics } from "./metrics"
+import { Instrumentation } from "./instrument"
+import { instrumentHttp } from "./instrumentation/http"
+import { AppsignalOptions } from "./types/options"
+import { Tracer as ITracer } from "./interfaces/tracer"
 
 /**
  * AppSignal for Node.js's main class.
@@ -21,6 +23,7 @@ export class Client {
 
   public config: Configuration
   public extension: Extension
+  public instrumentation: Instrumentation
 
   private _tracer: Tracer
   private _metrics: Metrics
@@ -37,6 +40,9 @@ export class Client {
 
     this.config = new Configuration(options)
     this.extension = new Extension({ active })
+    this.instrumentation = new Instrumentation(this._tracer)
+
+    this.instrumentation.load("http", instrumentHttp)
   }
 
   /**

--- a/packages/nodejs/src/client.ts
+++ b/packages/nodejs/src/client.ts
@@ -6,7 +6,8 @@ import { VERSION } from "./version"
 
 import { Metrics } from "./metrics"
 import { Instrumentation } from "./instrument"
-import { instrumentHttp } from "./instrumentation/http"
+import * as http from "./instrumentation/http"
+
 import { AppsignalOptions } from "./types/options"
 import { Tracer as ITracer } from "./interfaces/tracer"
 
@@ -42,7 +43,7 @@ export class Client {
     this.extension = new Extension({ active })
     this.instrumentation = new Instrumentation(this._tracer)
 
-    this.instrumentation.load("http", instrumentHttp)
+    this.instrumentation.load(http.PLUGIN_NAME, http.instrument)
   }
 
   /**

--- a/packages/nodejs/src/index.ts
+++ b/packages/nodejs/src/index.ts
@@ -4,4 +4,5 @@
  */
 
 export { Client as Appsignal } from "./client"
+export { Plugin } from "./interfaces/plugin"
 export { EXPERIMENTAL } from "./experimental"

--- a/packages/nodejs/src/instrument.ts
+++ b/packages/nodejs/src/instrument.ts
@@ -1,16 +1,18 @@
-import path from "path"
 import Hook from "require-in-the-middle"
 import semver from "semver"
 
 import { Tracer } from "./tracer"
+import { getPackageVerson } from "./utils"
 import { Plugin } from "./interfaces/plugin"
+
+type InstrumentedModule<T> = { name: string; plugin: Plugin<T>; hook: Hook }
 
 /**
  * The Instrumentation class.
  * @class
  */
 export class Instrumentation {
-  public active: { name: string; plugin: Plugin<any>; hook: Hook }[]
+  public active: InstrumentedModule<any>[]
   private _tracer: Tracer
 
   constructor(tracer: Tracer) {
@@ -22,14 +24,17 @@ export class Instrumentation {
    * Loads custom instrumentation for a given module. The instrumentation is
    * loaded when a modules is required using the global `require` function.
    */
-  public load<T>(name: string, fn: (module: T, tracer: Tracer) => Plugin<T>) {
+  public load<T>(
+    name: string,
+    fn: (module: T, tracer: Tracer) => Plugin<T>
+  ): InstrumentedModule<T>[] {
     let plugin: Plugin<T> | undefined
 
     const hook = Hook([name], (mod: T, _, basedir: string) => {
       // we use the current node version as the given version
       // if the module is internal (i.e. no `package.json`)
       const version = basedir
-        ? this._getPackageVerson(basedir)
+        ? getPackageVerson(basedir)
         : process.versions.node
 
       // init the plugin
@@ -58,10 +63,32 @@ export class Instrumentation {
   }
 
   /**
+   * Removes all custom instrumentation for a given module name. Any
+   * subsequent calls to `require` for this instrumentation after calling
+   * this method will not include instrumentation.
+   */
+  public unload(name: string): InstrumentedModule<any>[] {
+    this.active = this.active.filter(active => {
+      if (active.name !== name) {
+        return true
+      } else {
+        const { plugin, hook } = active
+
+        plugin.uninstall()
+        hook.unhook()
+
+        return false
+      }
+    })
+
+    return this.active
+  }
+
+  /**
    * Removes all custom instrumentation. Any subsequent calls to `require`
    * after calling this method will not include instrumentation.
    */
-  public unloadAll() {
+  public unloadAll(): InstrumentedModule<any>[] {
     this.active.forEach(active => {
       const { plugin, hook } = active
 
@@ -71,16 +98,5 @@ export class Instrumentation {
 
     this.active = []
     return this.active
-  }
-
-  /**
-   * Retrieve a valid version number from a `package.json` in a given
-   * `basedir`.
-   *
-   * @private
-   */
-  private _getPackageVerson(basedir: string): string {
-    const { version } = require(path.join(basedir, "package.json"))
-    return version
   }
 }

--- a/packages/nodejs/src/instrument.ts
+++ b/packages/nodejs/src/instrument.ts
@@ -1,0 +1,51 @@
+import Hook from "require-in-the-middle"
+
+import { Tracer } from "./tracer"
+import { Plugin } from "./interfaces/plugin"
+
+/**
+ * The Instrumentation class.
+ * @class
+ */
+export class Instrumentation {
+  public active: { name: string; plugin: Plugin<any>; hook: Hook }[]
+  private _tracer: Tracer
+
+  constructor(tracer: Tracer) {
+    this.active = []
+    this._tracer = tracer
+  }
+
+  /**
+   * Loads custom instrumentation for a given module. The instrumentation is
+   * loaded when a modules is required using the global `require` function.
+   */
+  public load<T>(name: string, fn: (module: T, tracer: Tracer) => Plugin<T>) {
+    let plugin: Plugin<T>
+
+    const hook = Hook([name], (mod: T) => {
+      plugin = fn(mod, this._tracer)
+      return plugin.install()
+    })
+
+    // @ts-ignore: `plugin` is really assigned before being used
+    this.active.push({ name, plugin, hook })
+    return this.active
+  }
+
+  /**
+   * Removes all custom instrumentation. Any subsequent calls to `require`
+   * after calling this method will not include instrumentation.
+   */
+  public unloadAll() {
+    this.active.forEach(active => {
+      const { plugin, hook } = active
+
+      plugin.uninstall()
+      hook.unhook()
+    })
+
+    this.active = []
+    return this.active
+  }
+}

--- a/packages/nodejs/src/instrumentation/http/index.ts
+++ b/packages/nodejs/src/instrumentation/http/index.ts
@@ -14,7 +14,7 @@ export const instrument = (
   mod: HttpModule,
   tracer: Tracer
 ): Plugin<HttpModule> => ({
-  version: ">= 12",
+  version: ">= 10",
   install(): HttpModule {
     // wrap incoming requests
     if (mod?.Server?.prototype) {

--- a/packages/nodejs/src/instrumentation/http/index.ts
+++ b/packages/nodejs/src/instrumentation/http/index.ts
@@ -5,16 +5,18 @@ import { Tracer } from "../../tracer"
 import { getPatchIncomingRequestFunction } from "../http/lifecycle/request"
 import { Plugin } from "../../interfaces/plugin"
 
-// quick patch to expose a type for the entire module
+// quick alias to expose a type for the entire module
 type HttpModule = typeof http
 
-export const instrumentHttp = (
+export const PLUGIN_NAME = "http"
+
+export const instrument = (
   mod: HttpModule,
   tracer: Tracer
 ): Plugin<HttpModule> => ({
-  name: "http",
-  version: process.versions.node,
+  version: ">= 12",
   install(): HttpModule {
+    // wrap incoming requests
     if (mod?.Server?.prototype) {
       shimmer.wrap(
         mod.Server.prototype,
@@ -25,7 +27,8 @@ export const instrumentHttp = (
 
     return mod
   },
-  uninstall() {
+  uninstall(): void {
+    // unwrap incoming requests
     if (mod?.Server?.prototype) {
       shimmer.unwrap(mod.Server.prototype, "emit")
     }

--- a/packages/nodejs/src/instrumentation/http/index.ts
+++ b/packages/nodejs/src/instrumentation/http/index.ts
@@ -1,0 +1,33 @@
+import shimmer from "shimmer"
+import http from "http"
+
+import { Tracer } from "../../tracer"
+import { getPatchIncomingRequestFunction } from "../http/lifecycle/request"
+import { Plugin } from "../../interfaces/plugin"
+
+// quick patch to expose a type for the entire module
+type HttpModule = typeof http
+
+export const instrumentHttp = (
+  mod: HttpModule,
+  tracer: Tracer
+): Plugin<HttpModule> => ({
+  name: "http",
+  version: process.versions.node,
+  install(): HttpModule {
+    if (mod?.Server?.prototype) {
+      shimmer.wrap(
+        mod.Server.prototype,
+        "emit",
+        getPatchIncomingRequestFunction(tracer)
+      )
+    }
+
+    return mod
+  },
+  uninstall() {
+    if (mod?.Server?.prototype) {
+      shimmer.unwrap(mod.Server.prototype, "emit")
+    }
+  }
+})

--- a/packages/nodejs/src/instrumentation/http/lifecycle/request.ts
+++ b/packages/nodejs/src/instrumentation/http/lifecycle/request.ts
@@ -1,0 +1,47 @@
+import { IncomingMessage, ServerResponse } from "http"
+
+import url from "url"
+import { Tracer } from "../../../tracer"
+
+function incomingRequest(
+  original: (event: string, ...args: unknown[]) => boolean,
+  tracer: Tracer
+) {
+  return function(this: {}, event: string, ...args: unknown[]): boolean {
+    if (event !== "request") {
+      return original.apply(this, [event, ...args])
+    }
+
+    const [request, response] = args as [IncomingMessage, ServerResponse]
+    const { url: reqUrl = "/", method = "GET" } = request
+
+    const rootSpan = tracer
+      .createSpan(`${method} ${url.parse(reqUrl).pathname || "/"}`)
+      .setNamespace("web")
+      .set("method", method)
+
+    return tracer.withSpan(rootSpan, span => {
+      tracer.wrapEmitter(request)
+      tracer.wrapEmitter(response)
+
+      const originalEnd = response.end
+
+      response.end = function(this: ServerResponse, ...args: unknown[]) {
+        response.end = originalEnd
+
+        const result = response.end.apply(this, [...args] as any)
+        span.close()
+
+        return result
+      }
+
+      return original.apply(this, [event, ...args])
+    })
+  }
+}
+
+export function getPatchIncomingRequestFunction(tracer: Tracer) {
+  return function(original: (event: string, ...args: unknown[]) => boolean) {
+    return incomingRequest(original, tracer)
+  }
+}

--- a/packages/nodejs/src/instrumentation/http/lifecycle/request.ts
+++ b/packages/nodejs/src/instrumentation/http/lifecycle/request.ts
@@ -1,6 +1,12 @@
-import { IncomingMessage, ServerResponse } from "http"
+/**
+ * Uses portions of `opentelemetry-js`
+ * https://github.com/open-telemetry/opentelemetry-js/blob/master/packages/opentelemetry-scope-async-hooks/src/AsyncHooksScopeManager.ts
+ * Copyright 2019, OpenTelemetry Authors
+ */
 
 import url from "url"
+import { IncomingMessage, ServerResponse } from "http"
+
 import { Tracer } from "../../../tracer"
 
 function incomingRequest(
@@ -23,11 +29,14 @@ function incomingRequest(
       .set("path", pathname || "/")
 
     return tracer.withSpan(rootSpan, span => {
+      // calling this binds the event handlers to our current
+      // async context
       tracer.wrapEmitter(request)
       tracer.wrapEmitter(response)
 
       const originalEnd = response.end
 
+      // wraps the "end" event to close the span
       response.end = function(this: ServerResponse, ...args: unknown[]) {
         response.end = originalEnd
 

--- a/packages/nodejs/src/instrumentation/http/lifecycle/request.ts
+++ b/packages/nodejs/src/instrumentation/http/lifecycle/request.ts
@@ -14,11 +14,13 @@ function incomingRequest(
 
     const [request, response] = args as [IncomingMessage, ServerResponse]
     const { url: reqUrl = "/", method = "GET" } = request
+    const { pathname } = url.parse(reqUrl)
 
     const rootSpan = tracer
-      .createSpan(`${method} ${url.parse(reqUrl).pathname || "/"}`)
+      .createSpan(`${method} ${pathname}`)
       .setNamespace("web")
       .set("method", method)
+      .set("path", pathname || "/")
 
     return tracer.withSpan(rootSpan, span => {
       tracer.wrapEmitter(request)

--- a/packages/nodejs/src/instrumentation/index.ts
+++ b/packages/nodejs/src/instrumentation/index.ts
@@ -1,0 +1,1 @@
+export * from "./http"

--- a/packages/nodejs/src/interfaces/plugin.ts
+++ b/packages/nodejs/src/interfaces/plugin.ts
@@ -1,5 +1,4 @@
 export interface Plugin<T> {
-  name: string
   version: string
   install: () => T
   uninstall: () => void

--- a/packages/nodejs/src/interfaces/plugin.ts
+++ b/packages/nodejs/src/interfaces/plugin.ts
@@ -1,0 +1,6 @@
+export interface Plugin<T> {
+  name: string
+  version: string
+  install: () => T
+  uninstall: () => void
+}

--- a/packages/nodejs/src/interfaces/span.ts
+++ b/packages/nodejs/src/interfaces/span.ts
@@ -1,9 +1,9 @@
-export interface ISpan {
+export interface Span {
   /**
    * The current ID of the trace.
    */
   traceId: string
-  
+
   /**
    * The current ID of the Span.
    */
@@ -17,7 +17,7 @@ export interface ISpan {
   /**
    * Returns a new `Span` object that is a child of the current `Span`.
    */
-  child(name: string): ISpan
+  child(name: string): Span
 
   /**
    * Sets a namespace for the current `Span`. Namespaces allow grouping of `Span`s

--- a/packages/nodejs/src/interfaces/tracer.ts
+++ b/packages/nodejs/src/interfaces/tracer.ts
@@ -1,17 +1,20 @@
-import { ISpan } from "./ISpan"
+import { EventEmitter } from "events"
 
-export interface ITracer {
+import { Span } from "./span"
+import { Func } from "../types/utils"
+
+export interface Tracer {
   /**
    * Creates a new `Span` instance.
    */
-  createSpan(name: string, span?: ISpan): ISpan
+  createSpan(name: string, span?: Span): Span
 
   /**
    * Returns the current Span.
    *
    * If there is no current Span available, `undefined` is returned.
    */
-  currentSpan(): ISpan | undefined
+  currentSpan(): Span | undefined
 
   /**
    * Executes a given function asynchronously within the context of a given
@@ -23,8 +26,5 @@ export interface ITracer {
    * allows you to create children of the `Span` for instrumenting nested
    * operations.
    */
-  withSpan(
-    span: ISpan,
-    fn: (s: ISpan) => Promise<any> | any
-  ): Promise<any> | any
+  withSpan<T>(span: Span, fn: (s: Span) => T): T
 }

--- a/packages/nodejs/src/noops/span.ts
+++ b/packages/nodejs/src/noops/span.ts
@@ -1,6 +1,6 @@
-import { ISpan } from "../interfaces/ISpan"
+import { Span } from "../interfaces/span"
 
-export class NoopSpan implements ISpan {
+export class NoopSpan implements Span {
   public get traceId(): string {
     return "0"
   }

--- a/packages/nodejs/src/noops/tracer.ts
+++ b/packages/nodejs/src/noops/tracer.ts
@@ -1,21 +1,17 @@
 import { NoopSpan } from "./span"
-import { ISpan } from "../interfaces/ISpan"
-import { ITracer } from "../interfaces/ITracer"
+import { Span } from "../interfaces/span"
+import { Tracer } from "../interfaces/tracer"
 
-export class NoopTracer implements ITracer {
-  public createSpan(name: string, span?: ISpan): ISpan {
+export class NoopTracer implements Tracer {
+  public createSpan(name: string, span?: Span): Span {
     return new NoopSpan()
   }
 
-  public currentSpan(): ISpan | undefined {
+  public currentSpan(): Span | undefined {
     return
   }
 
-  public instrument(span: ISpan, fn: (s: ISpan) => any): Promise<any> {
-    return Promise.resolve()
-  }
-
-  public withSpan(span: ISpan, fn: (s: ISpan) => any): Promise<any> {
-    return Promise.resolve()
+  public withSpan<T>(span: Span, fn: (s: Span) => T): T {
+    return {} as T
   }
 }

--- a/packages/nodejs/src/scope.ts
+++ b/packages/nodejs/src/scope.ts
@@ -119,7 +119,7 @@ export class ScopeManager {
     try {
       return fn(span)
     } catch (err) {
-      span.addError(err)
+      span?.addError(err)
       throw err
     } finally {
       // revert to the previous span

--- a/packages/nodejs/src/scope.ts
+++ b/packages/nodejs/src/scope.ts
@@ -1,34 +1,77 @@
-import * as asyncHooks from "async_hooks"
+/**
+ * Uses portions of `opentelemetry-js`
+ * https://github.com/open-telemetry/opentelemetry-js/blob/master/packages/opentelemetry-scope-async-hooks/src/AsyncHooksScopeManager.ts
+ * Copyright 2019, OpenTelemetry Authors
+ *
+ * Uses portions of `cloud-trace-nodejs`
+ * https://github.com/googleapis/cloud-trace-nodejs/blob/master/src/cls/async-hooks.ts
+ * Copyright 2018, Google LLC
+ */
 
-import { ISpan } from "./interfaces/ISpan"
-import { Span } from './span'
+import * as asyncHooks from "async_hooks"
+import { EventEmitter } from "events"
+import shimmer from "shimmer"
+
+import { Func } from "./types/utils"
+import { Span } from "./interfaces/span"
+
+// A list of well-known EventEmitter methods that add event listeners.
+const EVENT_EMITTER_METHODS: Array<keyof EventEmitter> = [
+  "addListener",
+  "on",
+  "once",
+  "prependListener",
+  "prependOnceListener"
+]
+
+const WRAPPED = Symbol("@appsignal/nodejs:WRAPPED")
+
+type ContextWrapped<T> = T & { [WRAPPED]?: boolean }
 
 /**
  * Propagates specific scope between function calls and async operations.
  *
  * @class
- *
- * @copyright
- * Uses portions of `opentelemetry-js`
- * https://github.com/open-telemetry/opentelemetry-js/blob/master/packages/opentelemetry-scope-async-hooks/src/AsyncHooksScopeManager.ts
- * Copyright 2019, OpenTelemetry Authors
  */
 export class ScopeManager {
-  private _scopes: Map<number, ISpan | undefined>
+  private _scopes: Map<number, Span | undefined>
   private _asyncHook: asyncHooks.AsyncHook
 
   constructor() {
     this._scopes = new Map()
 
-    const init = (uid: number) => {
-      this._scopes.set(
-        uid,
-        this._scopes.get(asyncHooks.executionAsyncId()) || undefined
-      )
+    const init = (id: number, type: string, triggerId: number) => {
+      /**
+       * We use the `executionAsyncId` here, as using the `triggerId` causes context
+       * confusion in applications using async/await.
+       */
+      if (type === "PROMISE") {
+        const currentId = asyncHooks.executionAsyncId()
+
+        if (this._scopes.get(currentId)) {
+          this._scopes.set(id, this._scopes.get(currentId))
+        }
+      } else {
+        /**
+         * `triggerId` usually equal the ID of the AsyncResource in whose scope we are
+         * currently running (the "current" `AsyncResource`), or that of one
+         * of its ancestors, so the behavior is not expected to be different
+         * from using the ID of the current AsyncResource instead.
+         *
+         * However, as the `triggerId` can be defined in userland, we choose to respect th
+         */
+        if (this._scopes.get(triggerId)) {
+          this._scopes.set(id, this._scopes.get(triggerId))
+        }
+      }
     }
 
-    const destroy = (uid: number) => {
-      this._scopes.delete(uid)
+    /**
+     * When the `AsyncResource` is destroyed, we destroy the reference to the `Span`. The same
+     * callback is called when a promise is resolved.
+     */
+    const destroy = (id: number) => {
+      this._scopes.delete(id)
     }
 
     this._asyncHook = asyncHooks.createHook({
@@ -59,42 +102,15 @@ export class ScopeManager {
   /**
    * Returns the current active `Span`.
    */
-  public active(): ISpan | undefined {
+  public active(): Span | undefined {
     const uid = asyncHooks.executionAsyncId()
     return this._scopes.get(uid) || undefined
   }
 
   /**
-   * Executes a given function asynchronously within the context of a given `Span`.
+   * Executes a given function within the context of a given `Span`.
    */
-  public async with(
-    span: ISpan,
-    fn: (s: ISpan) => Promise<any> | any
-  ): Promise<any> {
-    const uid = asyncHooks.executionAsyncId()
-    const oldScope = this._scopes.get(uid)
-
-    this._scopes.set(uid, span)
-
-    try {
-      return await fn(span)
-    } catch (err) {
-      span.addError(err)
-      throw err
-    } finally {
-      // revert to the previous span
-      if (oldScope === undefined) {
-        this._scopes.delete(uid)
-      } else {
-        this._scopes.set(uid, oldScope)
-      }
-    }
-  }
-
-  /**
-   * Executes a given function synchronously within the context of a given `Span`.
-   */
-  public withSync(span: ISpan, fn: (s: ISpan) => any): any {
+  public withContext<T>(span: Span, fn: (s: Span) => T): T {
     const uid = asyncHooks.executionAsyncId()
     const oldScope = this._scopes.get(uid)
 
@@ -113,5 +129,59 @@ export class ScopeManager {
         this._scopes.set(uid, oldScope)
       }
     }
+  }
+
+  public bindContext<T>(fn: Func<T>): Func<T> {
+    // return if we have already wrapped the function
+    if ((fn as ContextWrapped<Func<T>>)[WRAPPED]) {
+      return fn
+    }
+
+    // capture the context of the current `AsyncResource`
+    const boundContext = this._scopes.get(asyncHooks.executionAsyncId())
+
+    // return if there is no current context to bind
+    if (!boundContext) {
+      return fn
+    }
+
+    const self = this
+
+    // wrap `fn` so that any AsyncResource objects that are created in `fn` will
+    // share context with that of the `AsyncResource` with the given ID.
+    const contextWrapper: ContextWrapped<Func<T>> = function(
+      this: {},
+      ...args: unknown[]
+    ) {
+      return self.withContext(boundContext, () => fn.apply(this, args))
+    }
+
+    // prevent re-wrapping
+    contextWrapper[WRAPPED] = true
+
+    // explicitly inherit the original function's length, because it is
+    // otherwise zero-ed out
+    Object.defineProperty(contextWrapper, "length", {
+      enumerable: false,
+      configurable: true,
+      writable: false,
+      value: fn.length
+    })
+
+    return contextWrapper
+  }
+
+  public emitWithContext(ee: EventEmitter): void {
+    const that = this
+
+    EVENT_EMITTER_METHODS.forEach(method => {
+      if (ee[method]) {
+        shimmer.wrap(ee, method, (oldFn: Func<any>) => {
+          return function(this: {}, event: string, cb: Func<void>) {
+            return oldFn.call(this, event, that.bindContext(cb))
+          }
+        })
+      }
+    })
   }
 }

--- a/packages/nodejs/src/span.ts
+++ b/packages/nodejs/src/span.ts
@@ -4,7 +4,7 @@
 const { span } = require("../build/Release/extension.node")
 
 import { DataArray, DataMap } from "./internal"
-import { ISpan } from "./interfaces/ISpan"
+import { Span } from "./interfaces/span"
 
 /**
  * The `Span` object represents a length of time in the flow of execution
@@ -15,7 +15,7 @@ import { ISpan } from "./interfaces/ISpan"
  *
  * @class
  */
-export class Span implements ISpan {
+export class BaseSpan implements Span {
   protected _ref: any
 
   /**
@@ -145,7 +145,7 @@ export class Span implements ISpan {
  * A `ChildSpan` is a descendent of a `RootSpan`. A `ChildSpan` can also
  * be a parent to many `ChildSpan`s.
  */
-export class ChildSpan extends Span {
+export class ChildSpan extends BaseSpan {
   constructor(name: string, traceId: string, parentSpanId: string) {
     super()
     this._ref = span.createChildSpan(name, traceId, parentSpanId)
@@ -156,7 +156,7 @@ export class ChildSpan extends Span {
  * A `RootSpan` is the top-level `Span`, from which all `ChildSpan`s are
  * created from.
  */
-export class RootSpan extends Span {
+export class RootSpan extends BaseSpan {
   constructor(name: string) {
     super()
     this._ref = span.createRootSpan(name)

--- a/packages/nodejs/src/tracer.ts
+++ b/packages/nodejs/src/tracer.ts
@@ -20,7 +20,8 @@ export class Tracer implements ITracer {
   }
 
   /**
-   * Creates a new `Span` instance.
+   * Creates a new `Span` instance. If a `Span` is passed as the optional second
+   * argument, then the returned `Span` will be a `ChildSpan`.
    */
   public createSpan(name: string, span?: Span): Span {
     if (!span) {
@@ -48,25 +49,20 @@ export class Tracer implements ITracer {
    * The `Span` is passed as the single argument to the given function. This
    * allows you to create children of the `Span` for instrumenting nested
    * operations.
-   *
-   * The given function will be assumed to be either an async function, or a
-   * function that returns a `Promise`. If a synchronous function (i.e. does
-   * not return a `Promise`) is given, its returned value is wrapped in a
-   * resolved `Promise`.
    */
   public withSpan<T>(span: Span, fn: (s: Span) => T): T {
     return this._scopeManager.withContext(span, fn)
   }
 
   /**
-   * Wraps a given function in the current context.
+   * Wraps a given function in the current `Span`s scope.
    */
   public wrap<T>(fn: Func<T>): Func<T> {
     return this._scopeManager.bindContext(fn)
   }
 
   /**
-   * Wraps an `EventEmitter` in the current context.
+   * Wraps an `EventEmitter` in the current `Span`s scope.
    */
   public wrapEmitter(emitter: EventEmitter): void {
     return this._scopeManager.emitWithContext(emitter)

--- a/packages/nodejs/src/types/utils.ts
+++ b/packages/nodejs/src/types/utils.ts
@@ -1,0 +1,1 @@
+export type Func<T = void> = (...args: any[]) => T

--- a/packages/nodejs/src/types/utils.ts
+++ b/packages/nodejs/src/types/utils.ts
@@ -1,1 +1,4 @@
+/**
+ * A function with a spread of arguments, returning a generic type.
+ */
 export type Func<T = void> = (...args: any[]) => T

--- a/packages/nodejs/src/utils.ts
+++ b/packages/nodejs/src/utils.ts
@@ -1,0 +1,16 @@
+import path from "path"
+
+/**
+ * Retrieve a valid version number from a `package.json` in a given
+ * `basedir`.
+ *
+ * @function
+ */
+export function getPackageVerson(basedir: string): string {
+  try {
+    const { version } = require(path.join(basedir, "package.json"))
+    return version
+  } catch (e) {
+    return "0.0.0"
+  }
+}

--- a/packages/nodejs/src/vendor.d.ts
+++ b/packages/nodejs/src/vendor.d.ts
@@ -1,0 +1,18 @@
+declare module "require-in-the-middle" {
+  interface Hook {
+    unhook(): void
+  }
+
+  function Hook<Module>(
+    modules: string[],
+    onrequire: (exports: Module, name: string, basedir: string) => Module
+  ): Hook
+
+  function Hook<Module>(
+    modules: string[],
+    options: { internals: boolean },
+    onrequire: (exports: Module, name: string, basedir: string) => Module
+  ): Hook
+
+  export = Hook
+}

--- a/packages/nodejs/tsconfig.json
+++ b/packages/nodejs/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["src/**/*"],
+  "include": ["src/**/*", "../../vendor.d.ts"],
   "exclude": [
     "src/**/__tests__",
     "src/**/__mocks__"

--- a/vendor.d.ts
+++ b/vendor.d.ts
@@ -1,3 +1,4 @@
+// @TODO: remove when "require-in-the-middle" has TS support
 declare module "require-in-the-middle" {
   interface Hook {
     unhook(): void

--- a/yarn.lock
+++ b/yarn.lock
@@ -1366,6 +1366,11 @@
     "@types/express-serve-static-core" "*"
     "@types/mime" "*"
 
+"@types/shimmer@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@types/shimmer/-/shimmer-1.0.1.tgz#b310df0b5bf466ab407aef6b9b47ea4fa0cf3788"
+  integrity sha512-I9ouuzrWLcjM1wre7f0i780W3KHk5PxFAC5KOpvpOGNaTsaKLN8p7sqRh9THwV9cpdOA/YJC+yMhG1jonQFdRQ==
+
 "@types/stack-utils@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
@@ -4856,6 +4861,11 @@ modify-values@^1.0.0:
   resolved "https://registry.yarnpkg.com/modify-values/-/modify-values-1.0.1.tgz#b3939fa605546474e3e3e3c63d64bd43b4ee6022"
   integrity sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==
 
+module-details-from-path@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/module-details-from-path/-/module-details-from-path-1.0.3.tgz#114c949673e2a8a35e9d35788527aa37b679da2b"
+  integrity sha1-EUyUlnPiqKNenTV4hSeqN7Z52is=
+
 move-concurrently@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/move-concurrently/-/move-concurrently-1.0.1.tgz#be2c005fda32e0b29af1f05d7c4b33214c701f92"
@@ -5938,6 +5948,15 @@ require-directory@^2.1.1:
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
   integrity sha1-jGStX9MNqxyXbiNE/+f3kqam30I=
 
+require-in-the-middle@^5.0.3:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/require-in-the-middle/-/require-in-the-middle-5.0.3.tgz#ef8bfd771760db573bc86d1341d8ae411a04c600"
+  integrity sha512-p/ICV8uMlqC4tjOYabLMxAWCIKa0YUQgZZ6KDM0xgXJNgdGQ1WmL2A07TwmrZw+wi6ITUFKzH5v3n+ENEyXVkA==
+  dependencies:
+    debug "^4.1.1"
+    module-details-from-path "^1.0.3"
+    resolve "^1.12.0"
+
 require-main-filename@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
@@ -5986,6 +6005,13 @@ resolve@1.x, resolve@^1.10.0, resolve@^1.3.2:
   version "1.15.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.15.0.tgz#1b7ca96073ebb52e741ffd799f6b39ea462c67f5"
   integrity sha512-+hTmAldEGE80U2wJJDC1lebb5jWqvTYAfm3YZ1ckk1gBr0MnCqUKlwK1e+anaFljIl+F5tR5IoZcm4ZDA1zMQw==
+  dependencies:
+    path-parse "^1.0.6"
+
+resolve@^1.12.0:
+  version "1.15.1"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.15.1.tgz#27bdcdeffeaf2d6244b95bb0f9f4b4653451f3e8"
+  integrity sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==
   dependencies:
     path-parse "^1.0.6"
 
@@ -6178,6 +6204,11 @@ shellwords@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
   integrity sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
+
+shimmer@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/shimmer/-/shimmer-1.2.1.tgz#610859f7de327b587efebf501fb43117f9aff337"
+  integrity sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw==
 
 signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1358,6 +1358,13 @@
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.3.tgz#7ee330ba7caafb98090bece86a5ee44115904c2c"
   integrity sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA==
 
+"@types/semver@^7.1.0":
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.1.0.tgz#c8c630d4c18cd326beff77404887596f96408408"
+  integrity sha512-pOKLaubrAEMUItGNpgwl0HMFPrSAFic8oSVIvfu1UwcgGNmNyK9gyhBHKmBnUTwwVvpZfkzUC0GaMgnL6P86uA==
+  dependencies:
+    "@types/node" "*"
+
 "@types/serve-static@*":
   version "1.13.3"
   resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-1.13.3.tgz#eb7e1c41c4468272557e897e9171ded5e2ded9d1"
@@ -6148,6 +6155,11 @@ semver@^7.1.1:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.1.1.tgz#29104598a197d6cbe4733eeecbe968f7b43a9667"
   integrity sha512-WfuG+fl6eh3eZ2qAf6goB7nhiCd7NPXhmyFxigB/TOkQyeLP8w8GsVehvtGNtnNmyboz4TgeK40B1Kbql/8c5A==
+
+semver@^7.1.3:
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.1.3.tgz#e4345ce73071c53f336445cfc19efb1c311df2a6"
+  integrity sha512-ekM0zfiA9SCBlsKa2X1hxyxiI4L3B6EbVJkkdgQXnSEEaHlGdvyodMruTiulSRWMMB4NeIuYNMC9rTKTz97GxA==
 
 set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"


### PR DESCRIPTION
This PR got a bit long and joined together, but covers the following things:

- Adds a plugin system for creating custom instrumentation
- Adds custom instrumentation for incoming (not outgoing) HTTP requests
- Updates the `ScopeManager` to bind functions and `EventEmitter`s to the current scope
- Removes Span creation functionality from `@appsignal/express`, this is superseded by the HTTP integration
- Renames some types and interfaces
- Removes `tracer.withSpanSync()`, as we now handle `AsyncResource`s better, this is no longer necessary