### PR TITLE
Fix for bug reported in #29

### DIFF
--- a/packages/nodejs-ext/scripts/extension.js
+++ b/packages/nodejs-ext/scripts/extension.js
@@ -60,12 +60,12 @@ function verify(filepath, checksum) {
 }
 
 function getMetadataForTarget(report) {
-  const { architecture, target, musl_override } = report.build
+  const { architecture, target, muslOverride } = report.build
 
   const triple = [
     architecture === "x64" ? "x86_64" : "i686",
     `-${target}`,
-    musl_override ? "-musl" : ""
+    muslOverride ? "-musl" : ""
   ]
 
   return TRIPLES[triple.join("")]

--- a/packages/nodejs-ext/scripts/report.js
+++ b/packages/nodejs-ext/scripts/report.js
@@ -12,7 +12,7 @@ function createReport() {
       architecture: process.arch,
       target: process.platform,
       muslOverride: Boolean(process.env["APPSIGNAL_BUILD_FOR_MUSL"]),
-      library_type: "static"
+      libraryType: "static"
     },
     host: {
       rootUser: process.getuid && process.getuid() === 0,


### PR DESCRIPTION
Fixes bad key lookup 'musl_override' in a report while installing the extension. Standardizes keys in report to be all camelcase.