### PR TITLE
Return NoopMetrics if agent is not started

### DIFF
--- a/packages/nodejs/src/__tests__/client.test.ts
+++ b/packages/nodejs/src/__tests__/client.test.ts
@@ -1,6 +1,7 @@
 import { Client } from "../client"
 import { Tracer } from "../tracer"
-import { NoopTracer } from "../noops"
+import { Metrics } from "../metrics"
+import { NoopTracer, NoopMetrics } from "../noops"
 
 jest.mock("../tracer")
 
@@ -34,9 +35,20 @@ describe("Client", () => {
     expect(tracer).toBeInstanceOf(NoopTracer)
   })
 
-  it("returns a tracer if the agent is started", () => {
+  it("returns a `Tracer` object if the agent is started", () => {
     client = new Client({ name, apiKey, active: true })
     const tracer = client.tracer()
     expect(tracer).toBeInstanceOf(Tracer)
+  })
+
+  it("returns a NoopMetrics if the agent isn't started", () => {
+    const meter = client.metrics()
+    expect(meter).toBeInstanceOf(NoopMetrics)
+  })
+
+  it("returns a `Metrics` object if the agent is started", () => {
+    client = new Client({ name, apiKey, active: true })
+    const meter = client.metrics()
+    expect(meter).toBeInstanceOf(Metrics)
   })
 })

--- a/packages/nodejs/src/client.ts
+++ b/packages/nodejs/src/client.ts
@@ -1,16 +1,18 @@
+import { VERSION } from "./version"
+
 import { Agent } from "./agent"
 import { Configuration } from "./config"
 import { Tracer } from "./tracer"
-import { NoopTracer } from "./noops"
-import { VERSION } from "./version"
-
 import { Metrics } from "./metrics"
+import { NoopTracer, NoopMetrics } from "./noops"
+
 import { Instrumentation } from "./instrument"
 import * as http from "./instrumentation/http"
 
 import { AppsignalOptions } from "./types/options"
 import { Plugin } from "./interfaces/plugin"
 import { Tracer as ITracer } from "./interfaces/tracer"
+import { Metrics as IMetrics } from "./interfaces/metrics"
 
 /**
  * AppSignal for Node.js's main class.
@@ -115,12 +117,9 @@ export class Client {
    * you can track any kind of data from your apps and tag them with metadata
    * to easily spot the differences between contexts.
    */
-  public metrics(): Metrics | undefined {
+  public metrics(): IMetrics {
     if (!this.isActive) {
-      console.warn(
-        "Cannot access the metrics object when the agent is inactive"
-      )
-      return
+      return new NoopMetrics()
     }
 
     return this._metrics

--- a/packages/nodejs/src/interfaces/metrics.ts
+++ b/packages/nodejs/src/interfaces/metrics.ts
@@ -1,14 +1,4 @@
-import { metrics } from "./extension"
-import { Metrics as IMetrics } from "./interfaces/metrics"
-
-import { DataArray, DataMap } from "./internal"
-
-/**
- * The metrics object.
- *
- * @class
- */
-export class Metrics implements IMetrics {
+export interface Metrics {
   /**
    * A gauge is a metric value at a specific time. If you set more
    * than one gauge with the same key, the latest value for that
@@ -19,23 +9,11 @@ export class Metrics implements IMetrics {
    * accounts, etc.). Currently all AppSignal host metrics are stored
    * as gauges.
    */
-  public setGauge(
+  setGauge(
     key: string,
     value: number,
     tags?: { [key: string]: string | number | boolean }
-  ) {
-    if (!key || !value) return this
-
-    metrics.setGauge(
-      key,
-      value,
-      tags && Array.isArray(tags)
-        ? new DataArray(tags)?.ref
-        : new DataMap(tags)?.ref
-    )
-
-    return this
-  }
+  ): this
 
   /**
    * Measurements are used for things like response times. We allow you to
@@ -50,23 +28,11 @@ export class Metrics implements IMetrics {
    * - `P90`, the 90th percentile of the metric value for the point in time.
    * - `P95`, the 95th percentile of the metric value for the point in time.
    */
-  public addDistributionValue(
+  addDistributionValue(
     key: string,
     value: number,
     tags?: { [key: string]: string | number | boolean }
-  ) {
-    if (!key || !value) return this
-
-    metrics.addDistributionValue(
-      key,
-      value,
-      tags && Array.isArray(tags)
-        ? new DataArray(tags)?.ref
-        : new DataMap(tags)?.ref
-    )
-
-    return this
-  }
+  ): this
 
   /**
    * The counter metric type stores a number value for a given time frame. These
@@ -82,21 +48,9 @@ export class Metrics implements IMetrics {
    *
    * When this method is called multiple times, the total/sum of all calls is persisted.
    */
-  public incrementCounter(
+  incrementCounter(
     key: string,
     value: number,
     tags?: { [key: string]: string | number | boolean }
-  ) {
-    if (!key || !value) return this
-
-    metrics.incrementCounter(
-      key,
-      value,
-      tags && Array.isArray(tags)
-        ? new DataArray(tags)?.ref
-        : new DataMap(tags)?.ref
-    )
-
-    return this
-  }
+  ): this
 }

--- a/packages/nodejs/src/noops/index.ts
+++ b/packages/nodejs/src/noops/index.ts
@@ -1,2 +1,3 @@
 export * from "./span"
 export * from "./tracer"
+export * from "./metrics"

--- a/packages/nodejs/src/noops/metrics.ts
+++ b/packages/nodejs/src/noops/metrics.ts
@@ -1,0 +1,27 @@
+import { Metrics } from "../interfaces/metrics"
+
+export class NoopMetrics implements Metrics {
+  public setGauge(
+    key: string,
+    value: number,
+    tags?: { [key: string]: string | number | boolean }
+  ): this {
+    return this
+  }
+
+  public addDistributionValue(
+    key: string,
+    value: number,
+    tags?: { [key: string]: string | number | boolean }
+  ): this {
+    return this
+  }
+
+  public incrementCounter(
+    key: string,
+    value: number,
+    tags?: { [key: string]: string | number | boolean }
+  ): this {
+    return this
+  }
+}


### PR DESCRIPTION
To keep consistent with the `Tracer`, we now return a `NoopMetrics` object if the agent isn't loaded or started. This is a breaking API change.