### PR TITLE
Add minutely probes to metrics object

### DIFF
--- a/packages/nodejs/src/__tests__/probes.test.ts
+++ b/packages/nodejs/src/__tests__/probes.test.ts
@@ -1,0 +1,21 @@
+import { Probes } from "../probes"
+
+describe("Probes", () => {
+  let probes: Probes
+
+  beforeEach(() => {
+    jest.useFakeTimers()
+    probes = new Probes()
+  })
+
+  afterEach(() => {
+    jest.clearAllTimers()
+  })
+
+  it("registers a probe", () => {
+    const fn = jest.fn()
+    probes.register("test_metric", fn)
+    jest.runOnlyPendingTimers()
+    expect(fn).toHaveBeenCalled()
+  })
+})

--- a/packages/nodejs/src/interfaces/metrics.ts
+++ b/packages/nodejs/src/interfaces/metrics.ts
@@ -1,3 +1,5 @@
+import { Probes } from "../probes"
+
 export interface Metrics {
   /**
    * A gauge is a metric value at a specific time. If you set more
@@ -53,4 +55,11 @@ export interface Metrics {
     value: number,
     tags?: { [key: string]: string | number | boolean }
   ): this
+
+  /**
+   * Minutely probes allow the AppSignal module to collect custom metrics
+   * for integrations and app-specific metrics by calling a user-defined function
+   * every minute.
+   */
+  probes(): Probes
 }

--- a/packages/nodejs/src/metrics.ts
+++ b/packages/nodejs/src/metrics.ts
@@ -2,6 +2,7 @@ import { metrics } from "./extension"
 import { Metrics } from "./interfaces/metrics"
 
 import { DataArray, DataMap } from "./internal"
+import { Probes } from "./probes"
 
 /**
  * The metrics object.
@@ -9,6 +10,8 @@ import { DataArray, DataMap } from "./internal"
  * @class
  */
 export class BaseMetrics implements Metrics {
+  private _probes = new Probes()
+
   /**
    * A gauge is a metric value at a specific time. If you set more
    * than one gauge with the same key, the latest value for that
@@ -98,5 +101,14 @@ export class BaseMetrics implements Metrics {
     )
 
     return this
+  }
+
+  /**
+   * Minutely probes allow the AppSignal module to collect custom metrics
+   * for integrations and app-specific metrics by calling a user-defined function
+   * every minute.
+   */
+  public probes(): Probes {
+    return this._probes
   }
 }

--- a/packages/nodejs/src/noops/metrics.ts
+++ b/packages/nodejs/src/noops/metrics.ts
@@ -1,6 +1,9 @@
 import { Metrics } from "../interfaces/metrics"
+import { Probes } from "../probes"
 
 export class NoopMetrics implements Metrics {
+  private _probes = new Probes()
+
   public setGauge(
     key: string,
     value: number,
@@ -23,5 +26,9 @@ export class NoopMetrics implements Metrics {
     tags?: { [key: string]: string | number | boolean }
   ): this {
     return this
+  }
+
+  public probes(): Probes {
+    return this._probes
   }
 }

--- a/packages/nodejs/src/probes.ts
+++ b/packages/nodejs/src/probes.ts
@@ -1,0 +1,41 @@
+import { EventEmitter } from "events"
+
+/**
+ * The Minutely probes object.
+ */
+export class Probes extends EventEmitter {
+  private _timers = new Map<string, NodeJS.Timeout>()
+
+  constructor() {
+    super()
+  }
+
+  /**
+   * Number of probes that are registered.
+   */
+  get count(): number {
+    return this._timers.size
+  }
+
+  /**
+   * Registers a new minutely probe. Using a probe `name` that has already been set
+   * will overwrite the current probe.
+   */
+  public register(name: string, fn: () => void): this {
+    this._timers.set(
+      name,
+      setInterval(() => this.emit(name), 60 * 1000)
+    )
+
+    return this.on(name, fn)
+  }
+
+  /**
+   * Unregisters all probes and clears the timers.
+   */
+  public clear(): this {
+    this._timers.forEach(t => clearInterval(t))
+    this._timers = new Map()
+    return this
+  }
+}


### PR DESCRIPTION
Adds minutely probes. We didn't have a ticket for this one.

The probes object is an instance of `EventEmitter`, that calls the registered function passed to `probes.register(name, fn)` once every minute unless unregistered.