### PR TITLE
Refactor span, accept context via span args

### DIFF
--- a/packages/nodejs/src/__tests__/scope.test.ts
+++ b/packages/nodejs/src/__tests__/scope.test.ts
@@ -40,7 +40,7 @@ describe("ScopeManager", () => {
     })
 
     it("should run the callback (object as target)", done => {
-      const test = new RootSpan("test")
+      const test = new RootSpan({ namespace: "test" })
 
       scopeManager.withContext(test, () => {
         expect(scopeManager.active()).toStrictEqual(test)
@@ -72,8 +72,8 @@ describe("ScopeManager", () => {
     })
 
     it("should finally restore an old scope", done => {
-      const scope1 = new RootSpan("scope1")
-      const scope2 = new RootSpan("scope2")
+      const scope1 = new RootSpan({ namespace: "scope1" })
+      const scope2 = new RootSpan({ namespace: "scope2" })
 
       scopeManager.withContext(scope1, () => {
         expect(scopeManager.active()).toStrictEqual(scope1)
@@ -91,7 +91,7 @@ describe("ScopeManager", () => {
 
   describe(".bindContext()", () => {
     it("Propagates context to bound functions", () => {
-      const test = new RootSpan("test")
+      const test = new RootSpan({ namespace: "test" })
 
       let fn = () => {
         const span = scopeManager.active()

--- a/packages/nodejs/src/__tests__/span.test.ts
+++ b/packages/nodejs/src/__tests__/span.test.ts
@@ -46,12 +46,12 @@ describe("RootSpan", () => {
   })
 
   it("belongs to a given namespace", () => {
-    const ns = "test_namespace"
+    const namespace = "test_namespace"
 
-    span = new RootSpan(ns)
+    span = new RootSpan({ namespace })
     internal = JSON.parse(span.toJSON())
 
-    expect(internal.namespace).toEqual(ns)
+    expect(internal.namespace).toEqual(namespace)
   })
 
   it("sets the name", () => {
@@ -69,7 +69,7 @@ describe("ChildSpan", () => {
   let internal: SpanData
 
   beforeEach(() => {
-    span = new ChildSpan("test_trace_id", "parent_span_id")
+    span = new ChildSpan({ traceId: "test_trace_id", spanId: "parent_span_id" })
     internal = JSON.parse(span.toJSON())
   })
 
@@ -106,7 +106,11 @@ describe("ChildSpan", () => {
   it("sets the name", () => {
     const name = "test_span"
 
-    span = new ChildSpan("test_trace_id", "parent_span_id").setName(name)
+    span = new ChildSpan({
+      traceId: "test_trace_id",
+      spanId: "parent_span_id"
+    }).setName(name)
+
     internal = JSON.parse(span.toJSON())
 
     expect(internal.name).toEqual(name)

--- a/packages/nodejs/src/client.ts
+++ b/packages/nodejs/src/client.ts
@@ -42,8 +42,8 @@ export class Client {
     this._tracer = new BaseTracer()
     this._metrics = new BaseMetrics()
 
-    this.config = new Configuration(options)
     this.agent = new Agent({ active })
+    this.config = new Configuration(options)
     this.instrumentation = new Instrumentation(this.tracer(), this.metrics())
 
     // load plugins

--- a/packages/nodejs/src/interfaces/context.ts
+++ b/packages/nodejs/src/interfaces/context.ts
@@ -1,0 +1,21 @@
+export interface SpanContext {
+  /**
+   * The current ID of the trace.
+   */
+  traceId: string
+
+  /**
+   * The current ID of the Span.
+   */
+  spanId: string
+
+  /**
+   *
+   */
+  traceFlags?: { sampled: boolean }
+
+  /**
+   *
+   */
+  traceState?: { [key: string]: string }
+}

--- a/packages/nodejs/src/interfaces/span.ts
+++ b/packages/nodejs/src/interfaces/span.ts
@@ -1,5 +1,10 @@
 import { HashMap } from "@appsignal/types"
 
+export interface SpanOptions {
+  namespace: string
+  startTime: number
+}
+
 export interface Span {
   /**
    * The current ID of the trace.
@@ -53,8 +58,6 @@ export interface Span {
    * span as the body, which will show the sanitized query in your dashboard.
    */
   setSQL(value: string): this
-
-  setSQL(key: string, value: string): this
 
   /**
    * Completes the current `Span`.

--- a/packages/nodejs/src/interfaces/tracer.ts
+++ b/packages/nodejs/src/interfaces/tracer.ts
@@ -1,20 +1,28 @@
 import { EventEmitter } from "events"
 
-import { Span } from "./span"
+import { Span, SpanOptions } from "./span"
+import { SpanContext } from "./context"
 import { Func } from "../types/utils"
 
 export interface Tracer {
   /**
-   * Creates a new `Span` instance.
+   * Creates a new `Span` instance. If a `Span` is passed as the optional second
+   * argument, then the returned `Span` will be a `ChildSpan`.
    */
-  createSpan(namespace?: string, span?: Span): Span
+  createSpan(options?: Partial<SpanOptions>, span?: Span): Span
+
+  /**
+   * Creates a new `Span` instance. If a `SpanContext` is passed as the optional second
+   * argument, then the returned `Span` will be a `ChildSpan`.
+   */
+  createSpan(options?: Partial<SpanOptions>, context?: SpanContext): Span
 
   /**
    * Returns the current Span.
    *
    * If there is no current Span available, `undefined` is returned.
    */
-  currentSpan(): Span | undefined
+  currentSpan(): Span
 
   /**
    * Executes a given function asynchronously within the context of a given

--- a/packages/nodejs/src/noops/tracer.ts
+++ b/packages/nodejs/src/noops/tracer.ts
@@ -1,16 +1,21 @@
 import { EventEmitter } from "events"
 
 import { NoopSpan } from "./span"
-import { Span } from "../interfaces/span"
+
+import { Span, SpanOptions } from "../interfaces/span"
+import { SpanContext } from "../interfaces/context"
 import { Tracer } from "../interfaces/tracer"
 import { Func } from "../types/utils"
 
 export class NoopTracer implements Tracer {
-  public createSpan(namespace?: string, span?: Span): Span {
+  public createSpan(
+    options?: Partial<SpanOptions>,
+    spanOrContext?: Span | SpanContext
+  ): Span {
     return new NoopSpan()
   }
 
-  public currentSpan(): Span | undefined {
+  public currentSpan(): Span {
     return new NoopSpan()
   }
 

--- a/packages/nodejs/src/scope.ts
+++ b/packages/nodejs/src/scope.ts
@@ -104,7 +104,7 @@ export class ScopeManager {
    */
   public active(): Span | undefined {
     const uid = asyncHooks.executionAsyncId()
-    return this._scopes.get(uid) || undefined
+    return this._scopes.get(uid)
   }
 
   /**
@@ -149,7 +149,7 @@ export class ScopeManager {
 
     // wrap `fn` so that any AsyncResource objects that are created in `fn` will
     // share context with that of the `AsyncResource` with the given ID.
-    const contextWrapper: ContextWrapped<Func<T>> = function(
+    const contextWrapper: ContextWrapped<Func<T>> = function (
       this: {},
       ...args: unknown[]
     ) {
@@ -177,7 +177,7 @@ export class ScopeManager {
     EVENT_EMITTER_METHODS.forEach(method => {
       if (ee[method]) {
         shimmer.wrap(ee, method, (oldFn: Func<any>) => {
-          return function(this: {}, event: string, cb: Func<void>) {
+          return function (this: {}, event: string, cb: Func<void>) {
             return oldFn.call(this, event, that.bindContext(cb))
           }
         })


### PR DESCRIPTION
This is a ⚠️ breaking change.

This PR refactors some of the Span logic to move it closer to the OpenTelemetry behaviour as well as allowing https://github.com/appsignal/appsignal-agent/pull/524 to be implemented.

- Instead of taking a `namespace` argument in the first position, the `Span` now takes a `SpanOptions` object with optional `name` and `startTime` properties.
- `Span`s can now take an optional `SpanContext` as the second parameter,  ready for https://github.com/appsignal/appsignal-agent/issues/531
- `currentSpan()`  now returns a `NoopSpan` instead of `undefined` if no current `Span` is available.
- Remove incorrect implementation of `public setSQL(keyOrValue: string, value?: string)`, this should only be unary.