### PR TITLE
Move postgres integration to core, deprecate @appsignal/pg

### DIFF
--- a/packages/nodejs/src/client.ts
+++ b/packages/nodejs/src/client.ts
@@ -8,6 +8,7 @@ import { NoopTracer, NoopMetrics } from "./noops"
 
 import { Instrumentation } from "./instrument"
 import { httpPlugin, httpsPlugin } from "./instrumentation/http"
+import * as pgPlugin from "./instrumentation/pg"
 import * as redisPlugin from "./instrumentation/redis"
 
 import { AppsignalOptions } from "./types/options"
@@ -49,7 +50,7 @@ export class Client {
     this.instrumentation = new Instrumentation(this.tracer(), this.metrics())
 
     // load plugins
-    const plugins: any[] = [httpPlugin, httpsPlugin, redisPlugin]
+    const plugins: any[] = [httpPlugin, httpsPlugin, redisPlugin, pgPlugin]
     plugins.forEach(p => this.instrument(p))
   }
 

--- a/packages/nodejs/src/instrumentation/pg/index.ts
+++ b/packages/nodejs/src/instrumentation/pg/index.ts
@@ -1,0 +1,79 @@
+import shimmer from "shimmer"
+import pg from "pg"
+import { EventEmitter } from "events"
+import { Tracer } from "../../interfaces/tracer"
+import { Span } from "../../interfaces/span"
+import { Plugin } from "../../interfaces/plugin"
+
+import { patchCallback, patchPromise, patchSubmittable } from "./patches"
+
+// quick alias to expose a type for the entire module
+type PostgresModule = typeof pg
+
+export const PLUGIN_NAME = "pg"
+
+export const instrument = (
+  mod: PostgresModule,
+  tracer: Tracer
+): Plugin<PostgresModule> => ({
+  version: ">= 7.0.0",
+  install(): PostgresModule {
+    shimmer.wrap(mod.Client.prototype, "query", original => {
+      return function wrapPgQuery(this: pg.Client, ...args: any[]) {
+        const rootSpan = tracer.currentSpan()
+
+        if (!rootSpan) {
+          return original.apply(this, args as any)
+        }
+
+        const span = rootSpan.child()
+
+        span.setCategory("sql.postgres").setName("Query")
+
+        let returned: any
+
+        if (args.length >= 1) {
+          const queryObj = args[0]
+
+          // extract query
+          if (typeof queryObj === "object") {
+            if (queryObj.text) {
+              span.setSQL(queryObj.text)
+            }
+          } else if (typeof queryObj === "string") {
+            span.setSQL(queryObj)
+          }
+
+          const callback = args[args.length - 1]
+
+          // handle callback method signature
+          if (typeof callback === "function") {
+            args[args.length - 1] = patchCallback(tracer, span, callback)
+          } else if (typeof args[0] === "object") {
+            // handle callback method signature
+            patchSubmittable(tracer, span, queryObj)
+          }
+
+          returned = original.apply(this, args as any)
+        } else {
+          returned = original.apply(this, args as any)
+        }
+
+        if (returned) {
+          if (returned instanceof EventEmitter) {
+            tracer.wrapEmitter(returned)
+          } else if (typeof returned.then === "function") {
+            returned = patchPromise(span, returned)
+          }
+        }
+
+        return returned
+      }
+    })
+
+    return mod
+  },
+  uninstall(): void {
+    shimmer.unwrap(mod.Client.prototype, "query")
+  }
+})

--- a/packages/nodejs/src/instrumentation/pg/patches/index.ts
+++ b/packages/nodejs/src/instrumentation/pg/patches/index.ts
@@ -1,6 +1,7 @@
 import shimmer from "shimmer"
 import { Submittable } from "pg"
-import { Tracer, Span } from "@appsignal/nodejs"
+import { Tracer } from "../../../interfaces/tracer"
+import { Span } from "../../../interfaces/span"
 
 interface Handlers {
   handleError?: (msg: any) => any

--- a/packages/pg/src/index.ts
+++ b/packages/pg/src/index.ts
@@ -1,9 +1,5 @@
-import shimmer from "shimmer"
 import pg from "pg"
-import { EventEmitter } from "events"
 import { Tracer, Plugin } from "@appsignal/nodejs"
-
-import { patchCallback, patchPromise, patchSubmittable } from "./patches"
 
 // quick alias to expose a type for the entire module
 type PostgresModule = typeof pg
@@ -16,62 +12,14 @@ export const instrument = (
 ): Plugin<PostgresModule> => ({
   version: ">= 7.0.0",
   install(): PostgresModule {
-    shimmer.wrap(mod.Client.prototype, "query", original => {
-      return function wrapPgQuery(this: pg.Client, ...args: any[]) {
-        const rootSpan = tracer.currentSpan()
-
-        if (!rootSpan) {
-          return original.apply(this, args as any)
-        }
-
-        const span = rootSpan.child()
-
-        span.setCategory("sql.postgres").setName("Query")
-
-        let returned: any
-
-        if (args.length >= 1) {
-          const queryObj = args[0]
-
-          // extract query
-          if (typeof queryObj === "object") {
-            if (queryObj.text) {
-              span.setSQL(queryObj.text)
-            }
-          } else if (typeof queryObj === "string") {
-            span.setSQL(queryObj)
-          }
-
-          const callback = args[args.length - 1]
-
-          // handle callback method signature
-          if (typeof callback === "function") {
-            args[args.length - 1] = patchCallback(tracer, span, callback)
-          } else if (typeof args[0] === "object") {
-            // handle callback method signature
-            patchSubmittable(tracer, span, queryObj)
-          }
-
-          returned = original.apply(this, args as any)
-        } else {
-          returned = original.apply(this, args as any)
-        }
-
-        if (returned) {
-          if (returned instanceof EventEmitter) {
-            tracer.wrapEmitter(returned)
-          } else if (typeof returned.then === "function") {
-            returned = patchPromise(span, returned)
-          }
-        }
-
-        return returned
-      }
-    })
+    console.warn(
+      "The @appsignal/pg package is deprecated as the pg package is now automatically instrumented by @appsignal/nodejs. The @appsignal/pg package is now a no-op. Please remove the package from your package.json, and any references to it in your code, to remove this message."
+    )
 
     return mod
   },
   uninstall(): void {
-    shimmer.unwrap(mod.Client.prototype, "query")
+    // this is a no-op
+    return
   }
 })


### PR DESCRIPTION
This change moves the plugin for `pg` into the core Node.js integrations installed with `@appsignal/nodejs`. This means that `pg` will be automatically instrumented when `@appsignal/nodejs` (an additional package is no longer required). This has no user side impact aside from warning the user that they should remove the package from `package.json`.