### PR TITLE
Print token from diagnose endpoint response to console

### DIFF
--- a/packages/nodejs/bin/diagnose
+++ b/packages/nodejs/bin/diagnose
@@ -19,7 +19,9 @@ This diagnose output was sent to AppSignal, contact us at support@appsignal.com 
 `)
 
 if (!process.env["APPSIGNAL_PUSH_API_KEY"]) {
-  throw new Error(`No Push API key found. Set the APPSIGNAL_PUSH_API_KEY environment variable to your Push API key and try again.`)
+  throw new Error(
+    `No Push API key found. Set the APPSIGNAL_PUSH_API_KEY environment variable to your Push API key and try again.`
+  )
 }
 
 const data = tool.generate()
@@ -38,6 +40,12 @@ const opts = {
 
 const req = https.request(opts, res => {
   res.setEncoding("utf8")
+
+  // print token to the console
+  res.on("data", chunk => {
+    const { token } = JSON.parse(chunk.toString())
+    console.log("Your diagnose token is:", token)
+  })
 })
 
 req.on("error", e => {


### PR DESCRIPTION
The documentation for the other integrations mentions that the diagnose token should be printed to the console, so I have added this in this PR.

<img width="433" alt="Screenshot 2020-09-15 at 15 29 39" src="https://user-images.githubusercontent.com/16296989/93216678-4e449b80-f768-11ea-8560-2291cd71d078.png">
