### PR TITLE
Add diagnose URL to console output

### DIFF
--- a/packages/nodejs/bin/diagnose
+++ b/packages/nodejs/bin/diagnose
@@ -45,6 +45,7 @@ const req = https.request(opts, res => {
   res.on("data", chunk => {
     const { token } = JSON.parse(chunk.toString())
     console.log("Your diagnose token is:", token)
+    console.log(`👀 View this report: https://appsignal.com/diagnose/${token}`)
   })
 })
 
@@ -57,4 +58,4 @@ req.write(json)
 req.end()
 
 console.log(data, "\n")
-console.log("✅ Done!")
+console.log("✅ Done!", "\n")


### PR DESCRIPTION
As discussed in the content call today, this adds the diagnose URL to the console output.

<img width="558" alt="Screenshot 2020-09-18 at 16 29 13" src="https://user-images.githubusercontent.com/16296989/93609785-8d732680-f9cc-11ea-8dbb-461674a95c90.png">

cc/ @mmaksimovic @aksie 