### PR TITLE
Add ignoreInstrumentation option

### DIFF
--- a/packages/nodejs/src/types/options.ts
+++ b/packages/nodejs/src/types/options.ts
@@ -15,6 +15,7 @@ export type AppsignalOptions = {
   ignoreActions: string[]
   ignoreErrors: string[]
   ignoreNamespaces: string[]
+  ignoreInstrumentation: string[]
   httpProxy: string
   runningInContainer: boolean
   workingDirPath: string


### PR DESCRIPTION
Closes #60. Adds a `ignoreInstrumentation` config option to ignore an automatic instrumentation. It can be used like this:

```
const { Appsignal } = require("@appsignal/nodejs")

const appsignal = new Appsignal({
  active: true,
  name: "<YOUR APPLICATION NAME>"
  apiKey: "<YOUR API KEY>",
  ignoreInstrumentation: ["http"]
})
```

...which will ignore the `http` instrumentation. The string must match the name of the module as passed to `require()`. This also fixes a bug I noticed where active instrumentation was not added to the `instrumentation.active` array.