### PR TITLE
Use ECMA standard private fields and remove TS private and public field modifiers

### DIFF
--- a/packages/nodejs/src/agent.ts
+++ b/packages/nodejs/src/agent.ts
@@ -6,7 +6,7 @@ import { extension } from "./extension"
  * @class
  */
 export class Agent {
-  public isLoaded = false
+  isLoaded = false
 
   constructor(options?: { active: boolean }) {
     if (options?.active) this.start()

--- a/packages/nodejs/src/client.ts
+++ b/packages/nodejs/src/client.ts
@@ -25,14 +25,14 @@ import { Metrics } from "./interfaces/metrics"
  * @class
  */
 export class Client {
-  public VERSION = VERSION
+  VERSION = VERSION
 
-  public agent: Agent
-  public config: Configuration
-  public instrumentation: Instrumentation
+  config: Configuration
+  agent: Agent
+  instrumentation: Instrumentation
 
-  private _tracer: Tracer
-  private _metrics: Metrics
+  #tracer: Tracer
+  #metrics: Metrics
 
   /**
    * Creates a new instance of the `Appsignal` object
@@ -41,8 +41,8 @@ export class Client {
     // Agent is not started by default
     const { active = false, ignoreInstrumentation } = options
 
-    this._tracer = new BaseTracer()
-    this._metrics = new BaseMetrics()
+    this.#tracer = new BaseTracer()
+    this.#metrics = new BaseMetrics()
 
     this.config = new Configuration(options)
     this.agent = new Agent({ active })
@@ -118,7 +118,7 @@ export class Client {
       return new NoopTracer()
     }
 
-    return this._tracer
+    return this.#tracer
   }
 
   /**
@@ -139,7 +139,7 @@ export class Client {
       return new NoopMetrics()
     }
 
-    return this._metrics
+    return this.#metrics
   }
 
   /**

--- a/packages/nodejs/src/config.ts
+++ b/packages/nodejs/src/config.ts
@@ -13,7 +13,7 @@ import { ENV_TO_KEY_MAPPING, PRIVATE_ENV_MAPPING } from "./config/configmap"
  * @class
  */
 export class Configuration {
-  public data: Partial<AppsignalOptions>
+  data: Partial<AppsignalOptions>
 
   constructor(options: Partial<AppsignalOptions>) {
     writePrivateConstants()

--- a/packages/nodejs/src/instrument.ts
+++ b/packages/nodejs/src/instrument.ts
@@ -13,16 +13,16 @@ type InstrumentedModule = { name: string; hook: Hook }
  * @class
  */
 export class Instrumentation {
-  public active: InstrumentedModule[]
+  active: InstrumentedModule[]
 
-  private _tracer: Tracer
-  private _meter: Metrics
+  #tracer: Tracer
+  #meter: Metrics
 
   constructor(tracer: Tracer, meter: Metrics) {
     this.active = []
 
-    this._tracer = tracer
-    this._meter = meter
+    this.#tracer = tracer
+    this.#meter = meter
   }
 
   /**
@@ -41,7 +41,7 @@ export class Instrumentation {
         : process.versions.node
 
       // init the plugin
-      const plugin = fn(mod, this._tracer, this._meter)
+      const plugin = fn(mod, this.#tracer, this.#meter)
 
       // install if version range matches
       if (semver.satisfies(version, plugin.version)) {

--- a/packages/nodejs/src/metrics.ts
+++ b/packages/nodejs/src/metrics.ts
@@ -10,7 +10,7 @@ import { Probes } from "./probes"
  * @class
  */
 export class BaseMetrics implements Metrics {
-  private _probes = new Probes()
+  #probes = new Probes()
 
   /**
    * A gauge is a metric value at a specific time. If you set more
@@ -91,6 +91,6 @@ export class BaseMetrics implements Metrics {
    * every minute.
    */
   public probes(): Probes {
-    return this._probes
+    return this.#probes
   }
 }

--- a/packages/nodejs/src/noops/metrics.ts
+++ b/packages/nodejs/src/noops/metrics.ts
@@ -2,7 +2,7 @@ import { Metrics } from "../interfaces/metrics"
 import { Probes } from "../probes"
 
 export class NoopMetrics implements Metrics {
-  private _probes = new Probes()
+  #probes = new Probes()
 
   public setGauge(
     key: string,
@@ -29,6 +29,6 @@ export class NoopMetrics implements Metrics {
   }
 
   public probes(): Probes {
-    return this._probes
+    return this.#probes
   }
 }

--- a/packages/nodejs/src/probes.ts
+++ b/packages/nodejs/src/probes.ts
@@ -4,7 +4,7 @@ import { EventEmitter } from "events"
  * The Minutely probes object.
  */
 export class Probes extends EventEmitter {
-  private _timers = new Map<string, NodeJS.Timeout>()
+  #timers = new Map<string, NodeJS.Timeout>()
 
   constructor() {
     super()
@@ -14,7 +14,7 @@ export class Probes extends EventEmitter {
    * Number of probes that are registered.
    */
   get count(): number {
-    return this._timers.size
+    return this.#timers.size
   }
 
   /**
@@ -22,7 +22,7 @@ export class Probes extends EventEmitter {
    * will overwrite the current probe.
    */
   public register(name: string, fn: () => void): this {
-    this._timers.set(
+    this.#timers.set(
       name,
       setInterval(() => this.emit(name), 60 * 1000)
     )
@@ -34,8 +34,8 @@ export class Probes extends EventEmitter {
    * Unregisters all probes and clears the timers.
    */
   public clear(): this {
-    this._timers.forEach(t => clearInterval(t))
-    this._timers = new Map()
+    this.#timers.forEach(t => clearInterval(t))
+    this.#timers = new Map()
     return this
   }
 }

--- a/packages/nodejs/src/tracer.ts
+++ b/packages/nodejs/src/tracer.ts
@@ -15,10 +15,10 @@ import { SpanContext } from "./interfaces/context"
  * @class
  */
 export class BaseTracer implements Tracer {
-  private _scopeManager: ScopeManager
+  #scopeManager: ScopeManager
 
   constructor() {
-    this._scopeManager = new ScopeManager().enable()
+    this.#scopeManager = new ScopeManager().enable()
   }
 
   /**
@@ -53,7 +53,7 @@ export class BaseTracer implements Tracer {
    * If there is no current Span available, `undefined` is returned.
    */
   public currentSpan(): Span {
-    return this._scopeManager.active() || new NoopSpan()
+    return this.#scopeManager.active() || new NoopSpan()
   }
 
   /**
@@ -66,20 +66,20 @@ export class BaseTracer implements Tracer {
    * operations.
    */
   public withSpan<T>(span: Span, fn: (s: Span) => T): T {
-    return this._scopeManager.withContext(span, fn)
+    return this.#scopeManager.withContext(span, fn)
   }
 
   /**
    * Wraps a given function in the current `Span`s scope.
    */
   public wrap<T>(fn: Func<T>): Func<T> {
-    return this._scopeManager.bindContext(fn)
+    return this.#scopeManager.bindContext(fn)
   }
 
   /**
    * Wraps an `EventEmitter` in the current `Span`s scope.
    */
   public wrapEmitter(emitter: EventEmitter): void {
-    return this._scopeManager.emitWithContext(emitter)
+    return this.#scopeManager.emitWithContext(emitter)
   }
 }


### PR DESCRIPTION
Closes #252. 

Removes any usage of TypeScripts `public` and `private` modifiers on class fields and use the ECMA standard notation instead. Note that `protected` is still used in some places as no standardized version exists. All methods remain notated with `public` and `private` modifiers until TypeScript is compatible with the ECMA standard version.