### PR TITLE
Allow span to be closed with optional endTime

### DIFF
--- a/packages/nodejs-ext/ext/appsignal_extension.cpp
+++ b/packages/nodejs-ext/ext/appsignal_extension.cpp
@@ -285,6 +285,21 @@ Napi::Value CloseSpan(const Napi::CallbackInfo &info) {
   return env.Null();
 }
 
+Napi::Value CloseSpanWithTimestamp(const Napi::CallbackInfo &info) {
+  Napi::Env env = info.Env();
+
+  Napi::External<appsignal_span_t> span =
+      info[0].As<Napi::External<appsignal_span_t>>();
+
+  Napi::Number sec = info[1].As<Napi::Number>();
+  Napi::Number nsec = info[2].As<Napi::Number>();
+
+  appsignal_close_span_with_timestamp(span.Data(), (long)sec.DoubleValue(),
+                                      (long)nsec.DoubleValue());
+
+  return env.Null();
+}
+
 Napi::Value GetTraceId(const Napi::CallbackInfo &info) {
   Napi::Env env = info.Env();
 
@@ -591,6 +606,8 @@ Napi::Object CreateSpanObject(Napi::Env env, Napi::Object exports) {
            Napi::Function::New(env, GetSpanId));
   span.Set(Napi::String::New(env, "closeSpan"),
            Napi::Function::New(env, CloseSpan));
+  span.Set(Napi::String::New(env, "closeSpanWithTimestamp"),
+           Napi::Function::New(env, CloseSpanWithTimestamp));
   span.Set(Napi::String::New(env, "addSpanError"),
            Napi::Function::New(env, AddSpanError));
   span.Set(Napi::String::New(env, "setSpanName"),

--- a/packages/nodejs/src/span.ts
+++ b/packages/nodejs/src/span.ts
@@ -145,16 +145,21 @@ export class BaseSpan implements Span {
    * Completes the current `Span`.
    *
    * If an `endTime` is passed as an argument, the `Span` is closed with the
-   * timestamp that you provide.
+   * timestamp that you provide. `endTime` should be a numeric
+   * timestamp in milliseconds since the UNIX epoch.
    */
   public close(endTime?: number): this {
-    if (endTime) {
+    if (endTime && typeof endTime === "number") {
+      const sec = Math.round(endTime / 1000) // seconds
+      const nsec = Math.round(endTime * 1e6) // nanoseconds
+
+      span.closeSpanWithTimestamp(this._ref, sec, nsec)
+
+      return this
+    } else {
+      span.closeSpan(this._ref)
       return this
     }
-
-    span.closeSpan(this._ref)
-
-    return this
   }
 
   /**


### PR DESCRIPTION
This PR allows a span to be closed with optional `endTime`, the same as in https://github.com/appsignal/appsignal-elixir/commit/c02a06bd315bd444fe12274e5ace94803698bde4.