### PR TITLE
Add option to disable calling setSampleData

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1780,6 +1780,30 @@
         }
       }
     },
+    "@jest/create-cache-key-function": {
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/@jest/create-cache-key-function/-/create-cache-key-function-26.6.2.tgz",
+      "integrity": "sha512-LgEuqU1f/7WEIPYqwLPIvvHuc1sB6gMVbT6zWhin3txYUNYK/kGQrC1F2WR4gR34YlI9bBtViTm5z98RqVZAaw==",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^26.6.2"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "26.6.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
+          "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^15.0.0",
+            "chalk": "^4.0.0"
+          }
+        }
+      }
+    },
     "@jest/environment": {
       "version": "26.5.2",
       "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-26.5.2.tgz",
@@ -8930,9 +8954,9 @@
       "dev": true
     },
     "graphql": {
-      "version": "15.3.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.3.0.tgz",
-      "integrity": "sha512-GTCJtzJmkFLWRfFJuoo9RWWa/FfamUHgiFosxi/X1Ani4AVWbeyBenZTNX6dM+7WSbbFfTo/25eh0LLkwHMw2w==",
+      "version": "15.4.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.4.0.tgz",
+      "integrity": "sha512-EB3zgGchcabbsU9cFe1j+yxdzKQKAbGUWRb13DsrsMN1yyfmmIq+2+L5MqVWcDCE4V89R5AyUOi7sMOGxdsYtA==",
       "dev": true
     },
     "growly": {
@@ -11247,12 +11271,12 @@
       }
     },
     "jest-util": {
-      "version": "26.3.0",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.3.0.tgz",
-      "integrity": "sha512-4zpn6bwV0+AMFN0IYhH/wnzIQzRaYVrz1A8sYnRnj4UXDXbOVtWmlaZkO9mipFqZ13okIfN87aDoJWB7VH6hcw==",
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.6.2.tgz",
+      "integrity": "sha512-MDW0fKfsn0OI7MS7Euz6h8HNDXVQ0gaM9uW6RjfDmd1DAFcaxX9OqIakHIqhbnmF08Cf2DLDG+ulq8YQQ0Lp0Q==",
       "dev": true,
       "requires": {
-        "@jest/types": "^26.3.0",
+        "@jest/types": "^26.6.2",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.4",
@@ -11261,9 +11285,9 @@
       },
       "dependencies": {
         "@jest/types": {
-          "version": "26.3.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
-          "integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
+          "version": "26.6.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
+          "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
@@ -11271,25 +11295,6 @@
             "@types/node": "*",
             "@types/yargs": "^15.0.0",
             "chalk": "^4.0.0"
-          }
-        },
-        "@types/istanbul-reports": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
-          "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
-          "dev": true,
-          "requires": {
-            "@types/istanbul-lib-report": "*"
-          }
-        },
-        "chalk": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
           }
         }
       }
@@ -13852,15 +13857,15 @@
       "dev": true
     },
     "pg": {
-      "version": "8.4.1",
-      "resolved": "https://registry.npmjs.org/pg/-/pg-8.4.1.tgz",
-      "integrity": "sha512-NRsH0aGMXmX1z8Dd0iaPCxWUw4ffu+lIAmGm+sTCwuDDWkpEgRCAHZYDwqaNhC5hG5DRMOjSUFasMWhvcmLN1A==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.4.2.tgz",
+      "integrity": "sha512-E9FlUrrc7w3+sbRmL1CSw99vifACzB2TjhMM9J5w9D1LIg+6un0jKkpHS1EQf2CWhKhec2bhrBLVMmUBDbjPRQ==",
       "dev": true,
       "requires": {
         "buffer-writer": "2.0.0",
         "packet-reader": "1.0.0",
         "pg-connection-string": "^2.4.0",
-        "pg-pool": "^3.2.1",
+        "pg-pool": "^3.2.2",
         "pg-protocol": "^1.3.0",
         "pg-types": "^2.1.0",
         "pgpass": "1.x"
@@ -13879,9 +13884,9 @@
       "dev": true
     },
     "pg-pool": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.2.1.tgz",
-      "integrity": "sha512-BQDPWUeKenVrMMDN9opfns/kZo4lxmSWhIqo+cSAF7+lfi9ZclQbr9vfnlNaPr8wYF3UYjm5X0yPAhbcgqNOdA==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.2.2.tgz",
+      "integrity": "sha512-ORJoFxAlmmros8igi608iVEbQNNZlp89diFVx6yV5v+ehmpMY9sK6QgpmgoXbmkNaBAx8cOOZh9g80kJv1ooyA==",
       "dev": true
     },
     "pg-protocol": {
@@ -13904,12 +13909,34 @@
       }
     },
     "pgpass": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.2.tgz",
-      "integrity": "sha1-Knu0G2BltnkH6R2hsHwYR8h3swY=",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.4.tgz",
+      "integrity": "sha512-YmuA56alyBq7M59vxVBfPJrGSozru8QAdoNlWuW3cz8l+UX3cWge0vTvjKhsSHSJpo3Bom8/Mm6hf0TR5GY0+w==",
       "dev": true,
       "requires": {
-        "split": "^1.0.0"
+        "split2": "^3.1.1"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "split2": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
+          "integrity": "sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==",
+          "dev": true,
+          "requires": {
+            "readable-stream": "^3.0.0"
+          }
+        }
       }
     },
     "picomatch": {
@@ -16595,11 +16622,12 @@
       "dev": true
     },
     "ts-jest": {
-      "version": "26.4.1",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-26.4.1.tgz",
-      "integrity": "sha512-F4aFq01aS6mnAAa0DljNmKr/Kk9y4HVZ1m6/rtJ0ED56cuxINGq3Q9eVAh+z5vcYKe5qnTMvv90vE8vUMFxomg==",
+      "version": "26.4.3",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-26.4.3.tgz",
+      "integrity": "sha512-pFDkOKFGY+nL9v5pkhm+BIFpoAuno96ff7GMnIYr/3L6slFOS365SI0fGEVYx2RKGji5M2elxhWjDMPVcOCdSw==",
       "dev": true,
       "requires": {
+        "@jest/create-cache-key-function": "^26.5.0",
         "@types/jest": "26.x",
         "bs-logger": "0.x",
         "buffer-from": "1.x",
@@ -16626,9 +16654,9 @@
           "dev": true
         },
         "yargs-parser": {
-          "version": "20.2.1",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.1.tgz",
-          "integrity": "sha512-yYsjuSkjbLMBp16eaOt7/siKTjNVjMm3SoJnIg3sEh/JsvqVVDyjRKmaJV4cl+lNIgq6QEco2i3gDebJl7/vLA==",
+          "version": "20.2.4",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
+          "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
           "dev": true
         }
       }
@@ -16719,9 +16747,9 @@
       }
     },
     "typescript": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.3.tgz",
-      "integrity": "sha512-tEu6DGxGgRJPb/mVPIZ48e69xCn2yRmCgYmDugAVwmJ6o+0u1RI18eO7E7WBTLYLaEVVOhwQmcdhQHweux/WPg==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.5.tgz",
+      "integrity": "sha512-ywmr/VrTVCmNTJ6iV2LwIrfG1P+lv6luD8sUJs+2eI9NLGigaN+nUQc13iHqisq7bra9lnmUSYqbJvegraBOPQ==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -18,19 +18,19 @@
     "@types/semver": "^7.3.4",
     "@types/shimmer": "^1.0.1",
     "express": "^4.17.1",
-    "graphql": "^15.3.0",
+    "graphql": "^15.4.0",
     "husky": "^4.3.0",
     "jest": "^26.5.3",
     "lerna": "^3.22.1",
     "lint-staged": "^10.4.2",
     "next": "^9.5.5",
     "npm-run-all": "^4.1.5",
-    "pg": "^8.4.1",
+    "pg": "^8.4.2",
     "prettier": "^2.1.2",
     "redis": "^3.0.2",
     "rimraf": "^3.0.2",
-    "ts-jest": "^26.4.1",
-    "typescript": "^4.0.3"
+    "ts-jest": "^26.4.3",
+    "typescript": "^4.0.5"
   },
   "scripts": {
     "build": "lerna run --stream --concurrency 1 --sort build",

--- a/packages/apollo-server/package-lock.json
+++ b/packages/apollo-server/package-lock.json
@@ -122,9 +122,9 @@
       "integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w=="
     },
     "@types/node": {
-      "version": "10.17.37",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.37.tgz",
-      "integrity": "sha512-4c38N7p9k9yqdcANh/WExTahkBgOTmggCyrTvVcbE8ByqO3g8evt/407v/I4X/gdfUkIyZBSQh/Rc3tvuwlVGw=="
+      "version": "10.17.44",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.44.tgz",
+      "integrity": "sha512-vHPAyBX1ffLcy4fQHmDyIUMUb42gHZjPHU66nhvbMzAWJqHnySGZ6STwN3rwrnSd1FHB0DI/RWgGELgKSYRDmw=="
     },
     "abbrev": {
       "version": "1.1.1",
@@ -151,9 +151,9 @@
       "optional": true
     },
     "apollo-reporting-protobuf": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/apollo-reporting-protobuf/-/apollo-reporting-protobuf-0.6.0.tgz",
-      "integrity": "sha512-AFLQIuO0QhkoCF+41Be/B/YU0C33BZ0opfyXorIjM3MNNiEDSyjZqmUozlB3LqgfhT9mn2IR5RSsA+1b4VovDQ==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/apollo-reporting-protobuf/-/apollo-reporting-protobuf-0.6.1.tgz",
+      "integrity": "sha512-qr4DheFP154PGZsd93SSIS9RkqHnR5b6vT+eCloWjy3UIpY+yZ3cVLlttlIjYvOG4xTJ25XEwcHiAExatQo/7g==",
       "requires": {
         "@apollo/protobufjs": "^1.0.3"
       }
@@ -176,19 +176,19 @@
       }
     },
     "apollo-server-plugin-base": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/apollo-server-plugin-base/-/apollo-server-plugin-base-0.10.1.tgz",
-      "integrity": "sha512-XChCBDNyfByWqVXptsjPwrwrCj5cxMmNbchZZi8KXjtJ0hN2C/9BMNlInJd6bVGXvUbkRJYUakfKCfO5dZmwIg==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/apollo-server-plugin-base/-/apollo-server-plugin-base-0.10.2.tgz",
+      "integrity": "sha512-uM5uL1lOxbXdgvt/aEIbgs40fV9xA45Y3Mmh0VtQ/ddqq0MXR5aG92nnf8rM+URarBCUfxKJKaYzJJ/CXAnEdA==",
       "requires": {
-        "apollo-server-types": "^0.6.0"
+        "apollo-server-types": "^0.6.1"
       }
     },
     "apollo-server-types": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/apollo-server-types/-/apollo-server-types-0.6.0.tgz",
-      "integrity": "sha512-usqXaz81bHxD2IZvKEQNnLpSbf2Z/BmobXZAjEefJEQv1ItNn+lJNUmSSEfGejHvHlg2A7WuAJKJWyDWcJrNnA==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/apollo-server-types/-/apollo-server-types-0.6.1.tgz",
+      "integrity": "sha512-IEQ37aYvMLiTUzsySVLOSuvvhxuyYdhI05f3cnH6u2aN1HgGp7vX6bg+U3Ue8wbHfdcifcGIk5UEU+Q+QO6InA==",
       "requires": {
-        "apollo-reporting-protobuf": "^0.6.0",
+        "apollo-reporting-protobuf": "^0.6.1",
         "apollo-server-caching": "^0.5.2",
         "apollo-server-env": "^2.4.5"
       }
@@ -265,6 +265,15 @@
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
+      }
+    },
+    "call-bind": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.0.tgz",
+      "integrity": "sha512-AEXsYIyyDY3MCzbwdhzG3Jx1R0J2wetQyUynn6dYHAO+bg8l1k7jwZtRv4ryryFs7EP+NDlikJlVe59jr0cM2w==",
+      "requires": {
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.0.0"
       }
     },
     "caseless": {
@@ -468,6 +477,16 @@
         "string-width": "^1.0.1",
         "strip-ansi": "^3.0.1",
         "wide-align": "^1.1.0"
+      }
+    },
+    "get-intrinsic": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.0.1.tgz",
+      "integrity": "sha512-ZnWP+AmS1VUaLgTRy47+zKtjTxz+0xMpx3I52i+aalBK1QP19ggLF3Db89KJX7kjfOfP2eoa01qc++GwPgufPg==",
+      "requires": {
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1"
       }
     },
     "getpass": {
@@ -820,35 +839,14 @@
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
     },
     "object.assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.1.tgz",
-      "integrity": "sha512-VT/cxmx5yaoHSOTSyrCygIDFco+RsibY2NM0a4RdEeY/4KgqezwFtK1yr3U67xYhqJSlASm2pKhLVzPj2lr4bA==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+      "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
       "requires": {
+        "call-bind": "^1.0.0",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.18.0-next.0",
         "has-symbols": "^1.0.1",
         "object-keys": "^1.1.1"
-      },
-      "dependencies": {
-        "es-abstract": {
-          "version": "1.18.0-next.1",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
-          "integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
-          "requires": {
-            "es-to-primitive": "^1.2.1",
-            "function-bind": "^1.1.1",
-            "has": "^1.0.3",
-            "has-symbols": "^1.0.1",
-            "is-callable": "^1.2.2",
-            "is-negative-zero": "^2.0.0",
-            "is-regex": "^1.1.1",
-            "object-inspect": "^1.8.0",
-            "object-keys": "^1.1.1",
-            "object.assign": "^4.1.1",
-            "string.prototype.trimend": "^1.0.1",
-            "string.prototype.trimstart": "^1.0.1"
-          }
-        }
       }
     },
     "object.getownpropertydescriptors": {
@@ -1065,21 +1063,63 @@
       }
     },
     "string.prototype.trimend": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.1.tgz",
-      "integrity": "sha512-LRPxFUaTtpqYsTeNKaFOw3R4bxIzWOnbQ837QfBylo8jIxtcbK/A/sMV7Q+OAV/vWo+7s25pOE10KYSjaSO06g==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.2.tgz",
+      "integrity": "sha512-8oAG/hi14Z4nOVP0z6mdiVZ/wqjDtWSLygMigTzAb+7aPEDTleeFf+WrF+alzecxIRkckkJVn+dTlwzJXORATw==",
       "requires": {
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.5"
+        "es-abstract": "^1.18.0-next.1"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.18.0-next.1",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
+          "integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.2.2",
+            "is-negative-zero": "^2.0.0",
+            "is-regex": "^1.1.1",
+            "object-inspect": "^1.8.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.1",
+            "string.prototype.trimend": "^1.0.1",
+            "string.prototype.trimstart": "^1.0.1"
+          }
+        }
       }
     },
     "string.prototype.trimstart": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.1.tgz",
-      "integrity": "sha512-XxZn+QpvrBI1FOcg6dIpxUPgWCPuNXvMD72aaRaUQv1eD4e/Qy8i/hFTe0BUmD60p/QA6bh1avmuPTfNjqVWRw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.2.tgz",
+      "integrity": "sha512-7F6CdBTl5zyu30BJFdzSTlSlLPwODC23Od+iLoVH8X6+3fvDPPuBVVj9iaB1GOsSTSIgVfsfm27R2FGrAPznWg==",
       "requires": {
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.5"
+        "es-abstract": "^1.18.0-next.1"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.18.0-next.1",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
+          "integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.2.2",
+            "is-negative-zero": "^2.0.0",
+            "is-regex": "^1.1.1",
+            "object-inspect": "^1.8.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.1",
+            "string.prototype.trimend": "^1.0.1",
+            "string.prototype.trimstart": "^1.0.1"
+          }
+        }
       }
     },
     "string_decoder": {

--- a/packages/apollo-server/package.json
+++ b/packages/apollo-server/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "dependencies": {
     "@appsignal/nodejs": "^1.0.1",
-    "apollo-server-plugin-base": "^0.10.1",
+    "apollo-server-plugin-base": "^0.10.2",
     "tslib": "^2.0.3"
   },
   "scripts": {

--- a/packages/express/src/middleware/index.ts
+++ b/packages/express/src/middleware/index.ts
@@ -8,11 +8,23 @@ import {
   RequestHandler
 } from "express"
 
+type ExpressMiddlewareOptions = {
+  /**
+   * Used to indicate if we should call span.setSampleData with
+   * ExpressJS parsed params. If you're setting these manually,
+   * pass false to prevent overriding your values.
+   */
+  recordParams?: boolean
+}
+
 /**
  * Returns an Express middleware that can augment the current span
  * with data.
  */
-export function expressMiddleware(appsignal: Appsignal): RequestHandler {
+export function expressMiddleware(
+  appsignal: Appsignal,
+  { recordParams = false }: ExpressMiddlewareOptions = {}
+): RequestHandler {
   return function (req: Request, res: Response, next: NextFunction) {
     const tracer = appsignal.tracer()
     const rootSpan = tracer.currentSpan()
@@ -41,8 +53,10 @@ export function expressMiddleware(appsignal: Appsignal): RequestHandler {
           span.setName(`${method} ${req.route.path}`)
         }
 
-        // set route params (if parsed by express correctly)
-        span.setSampleData("params", { ...params, ...query })
+        if (recordParams) {
+          // set route params (if parsed by express correctly)
+          span.setSampleData("params", { ...params, ...query })
+        }
 
         return res.end.apply(this, arguments as any)
       }

--- a/packages/nodejs-ext/scripts/extension/constants.js
+++ b/packages/nodejs-ext/scripts/extension/constants.js
@@ -1,37 +1,37 @@
-const AGENT_VERSION = "5b16a75"
+const AGENT_VERSION = "881e3b3"
 
 const TRIPLES = {
   "x86_64-darwin": {
-    checksum: "643cb9d7d8ecc6a994fb8c3455784abe4289f2385fd02a596b94c52fbb2f3f94",
-    downloadUrl: "https://appsignal-agent-releases.global.ssl.fastly.net/5b16a75/appsignal-x86_64-darwin-all-static.tar.gz"
+    checksum: "57bf0fed677bf02b445ceca6a92ab97f8b55ea648cd395d3423a98fa05523cbf",
+    downloadUrl: "https://appsignal-agent-releases.global.ssl.fastly.net/881e3b3/appsignal-x86_64-darwin-all-static.tar.gz"
   },
   "universal-darwin": {
-    checksum: "643cb9d7d8ecc6a994fb8c3455784abe4289f2385fd02a596b94c52fbb2f3f94",
-    downloadUrl: "https://appsignal-agent-releases.global.ssl.fastly.net/5b16a75/appsignal-x86_64-darwin-all-static.tar.gz"
+    checksum: "57bf0fed677bf02b445ceca6a92ab97f8b55ea648cd395d3423a98fa05523cbf",
+    downloadUrl: "https://appsignal-agent-releases.global.ssl.fastly.net/881e3b3/appsignal-x86_64-darwin-all-static.tar.gz"
   },
   "i686-linux": {
-    checksum: "f81ca1d2c43862708ed48de6c492fb8a7ae979024663973b6b47d75abb12ef9c",
-    downloadUrl: "https://appsignal-agent-releases.global.ssl.fastly.net/5b16a75/appsignal-i686-linux-all-static.tar.gz"
+    checksum: "fd3fd8eb14e033c914b36fd008775db279fc09499937f1bce4a4a2a6e8bc192c",
+    downloadUrl: "https://appsignal-agent-releases.global.ssl.fastly.net/881e3b3/appsignal-i686-linux-all-static.tar.gz"
   },
   "x86-linux": {
-    checksum: "f81ca1d2c43862708ed48de6c492fb8a7ae979024663973b6b47d75abb12ef9c",
-    downloadUrl: "https://appsignal-agent-releases.global.ssl.fastly.net/5b16a75/appsignal-i686-linux-all-static.tar.gz"
+    checksum: "fd3fd8eb14e033c914b36fd008775db279fc09499937f1bce4a4a2a6e8bc192c",
+    downloadUrl: "https://appsignal-agent-releases.global.ssl.fastly.net/881e3b3/appsignal-i686-linux-all-static.tar.gz"
   },
   "x86_64-linux": {
-    checksum: "b9d43a7c57338c9e6e1aa85a947685ade910c570bd9035b477bc2b28efecf778",
-    downloadUrl: "https://appsignal-agent-releases.global.ssl.fastly.net/5b16a75/appsignal-x86_64-linux-all-static.tar.gz"
+    checksum: "cca80d7b3ab0ba1450618b039f2e5522341e553b3f2852184d04c0f62f1e0ad7",
+    downloadUrl: "https://appsignal-agent-releases.global.ssl.fastly.net/881e3b3/appsignal-x86_64-linux-all-static.tar.gz"
   },
   "x86_64-linux-musl": {
-    checksum: "c1964b137b891c184dfdb5b9cf867a3a849452c4012458973fe9522b5b4432b6",
-    downloadUrl: "https://appsignal-agent-releases.global.ssl.fastly.net/5b16a75/appsignal-x86_64-linux-musl-all-static.tar.gz"
+    checksum: "47a204d30c10ebfdcdff5574ed8401d75ead4c935b504645d7a311731f417b24",
+    downloadUrl: "https://appsignal-agent-releases.global.ssl.fastly.net/881e3b3/appsignal-x86_64-linux-musl-all-static.tar.gz"
   },
   "x86_64-freebsd": {
-    checksum: "5bfd91805896dc7414a69ba0fc69c6121ba9aef60e8199370221595bee975a78",
-    downloadUrl: "https://appsignal-agent-releases.global.ssl.fastly.net/5b16a75/appsignal-x86_64-freebsd-all-static.tar.gz"
+    checksum: "78ccc748ff600072e99211eb21fa161c15f18ba51217a878957559da2cc86201",
+    downloadUrl: "https://appsignal-agent-releases.global.ssl.fastly.net/881e3b3/appsignal-x86_64-freebsd-all-static.tar.gz"
   },
   "amd64-freebsd": {
-    checksum: "5bfd91805896dc7414a69ba0fc69c6121ba9aef60e8199370221595bee975a78",
-    downloadUrl: "https://appsignal-agent-releases.global.ssl.fastly.net/5b16a75/appsignal-x86_64-freebsd-all-static.tar.gz"
+    checksum: "78ccc748ff600072e99211eb21fa161c15f18ba51217a878957559da2cc86201",
+    downloadUrl: "https://appsignal-agent-releases.global.ssl.fastly.net/881e3b3/appsignal-x86_64-freebsd-all-static.tar.gz"
   },
 }
 


### PR DESCRIPTION
Adds an option to `expressMiddleware` to disable calling `setSampleData` and settings `"params"`.

## Context

In our NextJS application, we're using both the NextJS middleware and the ExpressJS middleware for Appsignal. In our app, we're manually calling `span.setSampleData("params", ...)` and this calls gets overriden by the ExpressJS middleware as it does a monkey patch over `res.end`, and in that way its call to `span.setSampleData` always win and we end up with empty Parameters on the Appsignal dashboard.

I tried our code with the library call to `setSampleData` disabled, and then we were able to get our parameters in the dashboard.

Not sure if this extra option is the right solution for the problem we have, but happy to discuss this or other approaches 😄  Thanks in advance!