### PR TITLE
Extract function to set span name out of middleware

### DIFF
--- a/packages/nextjs/src/handler.ts
+++ b/packages/nextjs/src/handler.ts
@@ -2,20 +2,56 @@ import url from "url"
 import { Appsignal } from "@appsignal/nodejs"
 import { ServerResponse, IncomingMessage } from "http"
 
+interface Route {
+  page: string
+  match: (
+    pathname: string | null | undefined
+  ) => false | { [param: string]: any }
+}
+
 interface NextServer {
   router: {
-    dynamicRoutes?: {
-      page: string
-      match: (
-        pathname: string | null | undefined
-      ) => false | { [param: string]: any }
-    }[]
+    dynamicRoutes?: Route[]
   }
   getRequestHandler(): (
     req: IncomingMessage,
     res: ServerResponse,
     ...rest: any[]
   ) => Promise<void>
+}
+
+export function setSpanName(
+  appsignal: Appsignal,
+  req: IncomingMessage,
+  routes: Route[] = []
+) {
+  const span = appsignal.tracer().currentSpan()
+  const { pathname } = url.parse(req.url || "/", true)
+
+  if (span) {
+    const matched = routes.filter(el => el.match(pathname))[0]
+
+    // passing { debug: true } to the `Appsignal` constructor will log
+    // data about the current route to the console. don't rely on this
+    // working in future!
+    if (appsignal.config.debug) {
+      console.log("[APPSIGNAL]: Next.js debug data", {
+        routes,
+        matched,
+        pathname
+      })
+    }
+
+    if (matched) {
+      // matched to a dynamic route
+      span.setName(`${req.method} ${matched.page}`)
+    } else if (!matched && pathname === "/") {
+      // the root
+      span.setName(`${req.method} ${pathname}`)
+    } else {
+      span.setName(`${req.method} [unknown route]`)
+    }
+  }
 }
 
 /**
@@ -29,35 +65,7 @@ export function getRequestHandler<T extends NextServer>(
   const handler = app.getRequestHandler()
 
   return function (req: IncomingMessage, res: ServerResponse, ...rest: any[]) {
-    const span = appsignal.tracer().currentSpan()
-    const { pathname } = url.parse(req.url || "/", true)
-
-    if (span) {
-      const routes = app.router.dynamicRoutes || []
-      const matched = routes.filter(el => el.match(pathname))[0]
-
-      // passing { debug: true } to the `Appsignal` constructor will log
-      // data about the current route to the console. don't rely on this
-      // working in future!
-      if (appsignal.config.debug) {
-        console.log("[APPSIGNAL]: Next.js debug data", {
-          routes,
-          matched,
-          pathname
-        })
-      }
-
-      if (matched) {
-        // matched to a dynamic route
-        span.setName(`${req.method} ${matched.page}`)
-      } else if (!matched && pathname === "/") {
-        // the root
-        span.setName(`${req.method} ${pathname}`)
-      } else {
-        span.setName(`${req.method} [unknown route]`)
-      }
-    }
-
+    setSpanName(appsignal, req, app.router.dynamicRoutes)
     return handler(req, res, ...rest)
   }
 }


### PR DESCRIPTION
Extracts the logic of setting the span name to a separate function, and exports it for library consumers.

## Context

We have a NextJS application, and we faced 2 challenges when integrating Appsignal for monitoring.

First, we use a third party library for defining routes: https://github.com/vonschau/next-routes-with-locale, we use this to internationalize routes, and once we integrated Appsignal for performance monitoring, all requests were labeled as:
```
${METHOD} [unknown route]
```

After some digging around, we found out that in our case `app.router.dynamicRoutes` was an empty array, and this is most likely as we use the library I mentioned, so we had the routes in our app, but just in a different object, so in our case reading from `app.router.dynamicRoutes` won't work.

Second, we could not use the NextJS middleware (`getRequestHandler`) as `next-routes-with-locale` also relies on calling the request handler from NextJS: https://github.com/vonschau/next-routes-with-locale/blob/56ada8d2b71fb63f74fc5b8e0a07e911f09f39fa/src/index.js#L131-L150, so this made this middleware (and the other one too), quite hard to compose together. Ideally for us, this wouldn't call the NextJS request handler, but I don't know if there's any specific reason why it does.

To solve both of these, we extracted the logic to set the span name into a separate function, and this function takes the `routes` as a parameter, this way we can use this function inside a middleware in our app and get the expected result.

Again, I don't know if this is the best solution, but happy to discuss more approaches! and if more context is needed pleast let me know, thanks in advance!

