### PR TITLE
Fixes for Next.js routes not ignored by HTTP integration

### DIFF
--- a/packages/nodejs/src/instrumentation/http/lifecycle/incoming.ts
+++ b/packages/nodejs/src/instrumentation/http/lifecycle/incoming.ts
@@ -14,9 +14,9 @@ import { Tracer } from "../../../interfaces/tracer"
 // submit a pull request if you have any potential candidates for this array!
 const DEFAULT_IGNORED_URLS = [
   // common static asset paths (with any query string)
-  /\.(css|js|jpg|jpeg|gif|png|svg|webp|json|ico|webmanifest)((\?|\&)([^=]+)\=([^&]+))*$/i,
-  // next.js hot reloading
-  /(\/_next\/webpack-hmr)/i,
+  /\.(css|js|jpg|jpeg|gif|png|svg|webp|json|ico|webmanifest|jsx|less|swf|eot|ttf|otf|woff|woff2)((\?|\&)([^=]+)\=([^&]+))*$/i,
+  // next.js related routes
+  /(\/_next)/i,
   // gatsby hot reloading
   /(\/__webpack_hmr)/i,
   // next.js integration web vitals endpoint


### PR DESCRIPTION
Modifies the regex check for Next.js routes to have a broader scope. Also ignores more types of static assets found in testing, and ignores the outgoing requests to Next.js Telemetry.

Fixes #317. 