### PR TITLE
Add engine-strict=true config to prevent installs on old Node

### DIFF
--- a/packages/nodejs-ext/.npmrc
+++ b/packages/nodejs-ext/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/packages/nodejs/.npmrc
+++ b/packages/nodejs/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true


### PR DESCRIPTION
We were not locking the Node.js engine version correctly - while the install fails correctly on `node < 10` when installed with `yarn`, `npm` doesn't behave in the same way without this config option in `.npmrc`. 

Fixes #311.