### PR TITLE
Allow spans to be created with a startTime

### DIFF
--- a/packages/nodejs/src/__tests__/span.test.ts
+++ b/packages/nodejs/src/__tests__/span.test.ts
@@ -1,12 +1,13 @@
 import { ChildSpan, RootSpan } from "../span"
 
 type SpanData = {
-  name: string
-  namespace: string
-  parent_span_id: string
-  span_id: string
-  start_time: number
-  trace_id: string
+  closed: boolean
+  name?: string
+  namespace?: string
+  parent_span_id?: string
+  span_id?: string
+  start_time?: number
+  trace_id?: string
 }
 
 describe("RootSpan", () => {
@@ -20,6 +21,16 @@ describe("RootSpan", () => {
 
   it("creates a RootSpan", () => {
     expect(span).toBeInstanceOf(RootSpan)
+    expect(internal.closed).toBeFalsy()
+  })
+
+  it("creates a RootSpan with a timestamp", () => {
+    const startTime = 1607022684531
+
+    span = new RootSpan({ startTime })
+    internal = JSON.parse(span.toJSON())
+
+    expect(internal.start_time).toEqual(1607022685)
   })
 
   it("exposes a spanId", () => {
@@ -31,6 +42,14 @@ describe("RootSpan", () => {
   })
 
   it("exposes a traceId", () => {
+    const { traceId } = span
+
+    expect(traceId).toBeDefined()
+    expect(internal.trace_id).toBeDefined()
+    expect(traceId).toEqual(internal.trace_id)
+  })
+
+  it("exposes a start time", () => {
     const { traceId } = span
 
     expect(traceId).toBeDefined()
@@ -62,6 +81,13 @@ describe("RootSpan", () => {
 
     expect(internal.name).toEqual(name)
   })
+
+  it("closes a span", () => {
+    span = new RootSpan().close()
+    internal = JSON.parse(span.toJSON())
+
+    expect(internal.closed).toBeTruthy()
+  })
 })
 
 describe("ChildSpan", () => {
@@ -78,6 +104,20 @@ describe("ChildSpan", () => {
 
     expect(internal.trace_id).toEqual("test_trace_id")
     expect(internal.parent_span_id).toEqual("parent_span_id")
+    expect(internal.closed).toBeFalsy()
+  })
+
+  it("creates a RootSpan with a timestamp", () => {
+    const startTime = 1607022684531
+
+    span = new ChildSpan(
+      { traceId: "test_trace_id", spanId: "parent_span_id" },
+      { startTime }
+    )
+
+    internal = JSON.parse(span.toJSON())
+
+    expect(internal.start_time).toEqual(1607022685)
   })
 
   it("exposes a spanId", () => {
@@ -89,6 +129,14 @@ describe("ChildSpan", () => {
   })
 
   it("exposes a traceId", () => {
+    const { traceId } = span
+
+    expect(traceId).toBeDefined()
+    expect(internal.trace_id).toBeDefined()
+    expect(traceId).toEqual(internal.trace_id)
+  })
+
+  it("exposes a start time", () => {
     const { traceId } = span
 
     expect(traceId).toBeDefined()
@@ -114,5 +162,16 @@ describe("ChildSpan", () => {
     internal = JSON.parse(span.toJSON())
 
     expect(internal.name).toEqual(name)
+  })
+
+  it("closes a span", () => {
+    span = new ChildSpan({
+      traceId: "test_trace_id",
+      spanId: "parent_span_id"
+    }).close()
+
+    internal = JSON.parse(span.toJSON())
+
+    expect(internal.closed).toBeTruthy()
   })
 })

--- a/packages/nodejs/src/span.ts
+++ b/packages/nodejs/src/span.ts
@@ -170,7 +170,16 @@ export class BaseSpan implements NodeSpan {
    * Returns a JSON string representing the internal Span in the agent.
    */
   public toJSON(): string {
-    return span.spanToJSON(this._ref)
+    const json = span.spanToJSON(this._ref)
+
+    // if this is true, then the span has been garbage collected
+    // @TODO: i feel that this could have better ergonomics on the agent
+    // side. come up with something better here later.
+    if (json.trim() === "") {
+      return JSON.stringify({ closed: true })
+    }
+
+    return json
   }
 }
 

--- a/packages/nodejs/src/tracer.ts
+++ b/packages/nodejs/src/tracer.ts
@@ -51,7 +51,7 @@ export class BaseTracer implements Tracer {
     if (!spanOrContext) {
       return new RootSpan(options)
     } else {
-      return new ChildSpan(spanOrContext)
+      return new ChildSpan(spanOrContext, options)
     }
   }
 

--- a/packages/nodejs/src/utils.ts
+++ b/packages/nodejs/src/utils.ts
@@ -14,3 +14,16 @@ export function getPackageVerson(basedir: string): string {
     return "0.0.0"
   }
 }
+
+/**
+ * Given a valid POSIX `timestamp`, return an object containing a
+ * representation if that timestamps in seconds and nanoseconds.
+ *
+ * @function
+ */
+export function getAgentTimestamps(timestamp: number) {
+  return {
+    sec: Math.round(timestamp / 1000), // seconds
+    nsec: Math.round(timestamp * 1e6) // nanoseconds
+  }
+}


### PR DESCRIPTION
Related to https://github.com/appsignal/appsignal-agent/pull/524, this adds the ability for `RootSpan` and `ChildSpan` to receive a `startTime`. Also patches some undesirable behaviour caused by the agent returning an empty string with a predefined byte length from the extension.