### PR TITLE
Make log path config consistent with other integrations

### DIFF
--- a/packages/nodejs/src/__tests__/config.test.ts
+++ b/packages/nodejs/src/__tests__/config.test.ts
@@ -34,4 +34,31 @@ describe("Configuration", () => {
     config = new Configuration({ name, apiKey })
     expect(process.env["_APPSIGNAL_ACTIVE"]).toBeTruthy()
   })
+
+  it("uses a default log file path", () => {
+    expect(process.env["_APPSIGNAL_LOG_FILE_PATH"]).toEqual("/tmp/appsignal.log")
+  })
+
+  describe("Overriden log path with file specified", () => {
+    beforeEach(() => {
+      process.env["APPSIGNAL_LOG_PATH"] = "/other_path/appsignal.log"
+      config = new Configuration({ name, apiKey })
+    })
+
+    it("uses the overwritten path", () => {
+      // Test backwards compatibility with previous behaviour
+      expect(process.env["_APPSIGNAL_LOG_FILE_PATH"]).toEqual("/other_path/appsignal.log")
+    })
+  })
+
+  describe("Overriden log path", () => {
+    beforeEach(() => {
+      process.env["APPSIGNAL_LOG_PATH"] = "/other_path"
+      config = new Configuration({ name, apiKey })
+    })
+
+    it("uses the overwritten path", () => {
+      expect(process.env["_APPSIGNAL_LOG_FILE_PATH"]).toEqual("/other_path/appsignal.log")
+    })
+  })
 })

--- a/packages/nodejs/src/config.ts
+++ b/packages/nodejs/src/config.ts
@@ -21,7 +21,7 @@ export class Configuration {
     this.data = {
       debug: false,
       log: "file",
-      logPath: "/tmp/appsignal.log",
+      logPath: "/tmp",
       caFilePath: path.join(__dirname, "../cert/cacert.pem"),
       endpoint: "https://push.appsignal.com",
       environment: process.env.NODE_ENV || "development",
@@ -78,6 +78,12 @@ export class Configuration {
    * @private
    */
   private _write(config: { [key: string]: any }) {
+    // First write log file path based on log path
+    if (config["logPath"].endsWith("appsignal.log")) {
+      config["logFilePath"] = config["logPath"]
+    } else {
+      config["logFilePath"] = path.join(config["logPath"], "appsignal.log")
+    }
     // write to a "private" environment variable if it exists in the
     // config structure
     Object.entries(PRIVATE_ENV_MAPPING).forEach(([k, v]) => {

--- a/packages/nodejs/src/config/configmap.ts
+++ b/packages/nodejs/src/config/configmap.ts
@@ -35,7 +35,7 @@ export const PRIVATE_ENV_MAPPING: { [key: string]: string } = {
   _APPSIGNAL_DEBUG_LOGGING: "debug",
   _APPSIGNAL_TRANSACTION_DEBUG_MODE: "debug",
   _APPSIGNAL_LOG: "log",
-  _APPSIGNAL_LOG_FILE_PATH: "logPath",
+  _APPSIGNAL_LOG_FILE_PATH: "logFilePath",
   _APPSIGNAL_PUSH_API_ENDPOINT: "endpoint",
   _APPSIGNAL_PUSH_API_KEY: "apiKey",
   _APPSIGNAL_APP_NAME: "name",


### PR DESCRIPTION
Other AppSignal integrations expect a path in the log path config option. Do that here as well in a backwards compatible way.