### PR TITLE
Don't break diagnose when agent isn't loaded

### DIFF
--- a/packages/nodejs/src/agent.ts
+++ b/packages/nodejs/src/agent.ts
@@ -1,4 +1,4 @@
-import { extension } from "./extension"
+import {extension} from "./extension"
 
 /**
  * The public interface for the extension.
@@ -8,7 +8,7 @@ import { extension } from "./extension"
 export class Agent {
   isLoaded = false
 
-  constructor(options?: { active: boolean }) {
+  constructor(options?: {active: boolean}) {
     if (options?.active) this.start()
   }
 
@@ -48,7 +48,11 @@ export class Agent {
     return this.isLoaded
   }
 
-  public diagnose(): string {
-    return JSON.parse(extension.diagnoseRaw())
+  public diagnose(): object {
+    if (this.isLoaded) {
+      return JSON.parse(extension.diagnoseRaw())
+    } else {
+      return {}
+    }
   }
 }


### PR DESCRIPTION
Before:

    /usr/src/app/node_modules/@appsignal/nodejs/dist/agent.js:46
    return JSON.parse(extension_1.extension.diagnoseRaw());
    ^
    TypeError: extension_1.extension.diagnoseRaw is not a function
    at Agent.diagnose (/usr/src/app/node_modules/@appsignal/nodejs/dist/agent.js:46:49)
    at DiagnoseTool.generate (/usr/src/app/node_modules/@appsignal/nodejs/dist/diagnose.js:28:65)
    at Object.<anonymous> (/usr/src/app/node_modules/@appsignal/nodejs/bin/diagnose:38:19)
    at Module._compile (internal/modules/cjs/loader.js:1076:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1097:10)
    at Module.load (internal/modules/cjs/loader.js:941:32)
    at Function.Module._load (internal/modules/cjs/loader.js:782:14)
    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:72:12)
    at internal/main/run_main_module.js:17:47
    error Command failed with exit code 1.
    info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.

This was caused by `diagnoseRaw` being called on the extension object.
The extension-based functions aren't loaded when the extension isn't,
which causes the diagnose report to break.

Instead, we'd like to send the report even if the extension isn't loaded
by keeping the extension part of the report empty. This patch checks if
the extension is loaded beofre calling the `diagnoseRaw` on it, or
returns an empty object otherwise.

Closes https://github.com/appsignal/support/issues/112.

PS: There's no test for this, as there's not currently a setup for unloading
the extension and runnign the diagnose command. I can work on getting
the test suite to run locally and setting that up before merging this,
if that's something we'd like to spend more time on before merging this.