### PR TITLE
Report the install status as unknown in diagnose

### DIFF
--- a/packages/nodejs-ext/scripts/extension.js
+++ b/packages/nodejs-ext/scripts/extension.js
@@ -140,7 +140,7 @@ function getMetadataForTarget({
         downloadUrl: metadata.downloadUrl
       })
 
-      report.result.status = "success"
+      report.result.status = "unknown"
 
       return dumpReport(report).then(() => {
         process.exit(0)


### PR DESCRIPTION
I was confused by an issue reporting the extension was installed
correctly but it wasn't starting on app boot.

The diagnose report always reports the install status as "success" when
the download has succeeded. The status field is for the installation,
and not just the download status.

Write the status as "unknown" when the download has succeeded, because
we don't know if the installation that happens after that has succeeded
or not.

This is part of issue https://github.com/appsignal/appsignal-nodejs/issues/371

This change does not fix that issue, but will communicate better that
the diagnose doesn't know the install status.