### PR TITLE
Fix musl target and override reporting

### DIFF
--- a/packages/nodejs-ext/scripts/extension.js
+++ b/packages/nodejs-ext/scripts/extension.js
@@ -78,13 +78,11 @@ function dumpReport(report) {
 
 function getMetadataForTarget({
   architecture,
-  target,
-  musl_override: muslOverride
+  target
 }) {
   const triple = [
     architecture === "x64" ? "x86_64" : "i686",
-    `-${target}`,
-    muslOverride ? "-musl" : ""
+    `-${target}`
   ]
 
   return TRIPLES[triple.join("")]

--- a/packages/nodejs-ext/scripts/report.js
+++ b/packages/nodejs-ext/scripts/report.js
@@ -20,14 +20,29 @@ function createReport() {
   }
 }
 
+function muslOverride() {
+  return process.env["APPSIGNAL_BUILD_FOR_MUSL"] === "true"
+}
+
+function agentTarget() {
+  if (muslOverride()) {
+    return "linux-musl"
+  }
+
+  const target = [process.platform];
+  if (/linux/.test(target[0]) && hasMusl()) {
+    target.push("-musl")
+  }
+  return target.join("")
+}
+
 function createBuildReport({ isLocalBuild = false }) {
   return {
     time: new Date().toISOString(),
     package_path: path.join(__dirname, "/../ext/"),
     architecture: process.arch,
-    target: process.platform,
-    musl_override:
-      process.env["APPSIGNAL_BUILD_FOR_MUSL"] === "true" || hasMusl(),
+    target: agentTarget(),
+    musl_override: muslOverride(),
     library_type: "static",
     dependencies: {},
     flags: {},


### PR DESCRIPTION
The musl_override value in the diagnose reports if the user has manually
chosen the linux-musl build of the agent and extension, by specifying
`APPSIGNAL_BUILD_FOR_MUSL=true` as the environment variable. (Also
accepts the `1` value on other integrations, see
appsignal/integration-guide#26 .)

In this Node.js integration it currently is set to true if the host
system is detected as a musl system, not just when the user specifies
the `APPSIGNAL_BUILD_FOR_MUSL` environment variable.

This change fixes that, and moves the `-musl` suffix to the `target`
key, which is used to determine which file to download. The `-musl`
suffix should be part of the `target` key value, like it's done in other
integrations.

Fixes https://github.com/appsignal/appsignal-nodejs/issues/370

I've not implemented the fallback for musl builds on old libc versions
like is part of the other integrations, as that's outside of the scope
of this change.