### PR TITLE
Handle all non-dynamic paths as static routes

### DIFF
--- a/packages/nextjs/src/handler.ts
+++ b/packages/nextjs/src/handler.ts
@@ -61,11 +61,8 @@ export function getRequestHandler<T extends NextServer>(
       if (matched) {
         // matched to a dynamic route
         span.setName(`${req.method} ${matched.page}`)
-      } else if (!matched && pathname === "/") {
-        // the root
-        span.setName(`${req.method} ${pathname}`)
       } else {
-        span.setName(`${req.method} [unknown route]`)
+        span.setName(`${req.method} ${pathname}`)
       }
     }
 

--- a/packages/nextjs/test/example/pages/blog/index.js
+++ b/packages/nextjs/test/example/pages/blog/index.js
@@ -1,0 +1,5 @@
+import Link from "next/link"
+
+export default function BlogIndexPage() {
+  return <h1>Blog</h1>
+}

--- a/packages/nextjs/test/example/pages/post/[id].js
+++ b/packages/nextjs/test/example/pages/post/[id].js
@@ -1,0 +1,10 @@
+import { useRouter } from "next/router"
+
+const Post = () => {
+  const router = useRouter()
+  const { id } = router.query
+
+  return <h1>Post: {id}</h1>
+}
+
+export default Post

--- a/packages/nextjs/test/integration_spec.rb
+++ b/packages/nextjs/test/integration_spec.rb
@@ -61,4 +61,21 @@ RSpec.describe "Next.js" do
       expect(/Set name 'GET \/blog' for span '#{$1}'/.match(log)).to be_truthy()
     end
   end
+
+  describe "/post/1" do
+    before do
+      @result = Net::HTTP.get(URI('http://localhost:3000/post/1'))
+    end
+
+    it "renders the post page" do
+      expect(@result).to match(/Post: /)
+    end
+
+    it "sets the root span's name" do
+      log = File.read(@log_path)
+
+      expect(/Start root span '(\w+)' in 'web'/.match(log)).to be_truthy()
+      expect(/Set name 'GET \/post\/\[id\]' for span '#{$1}'/.match(log)).to be_truthy()
+    end
+  end
 end

--- a/packages/nextjs/test/integration_spec.rb
+++ b/packages/nextjs/test/integration_spec.rb
@@ -20,25 +20,45 @@ RSpec.describe "Next.js" do
         break if line =~ /Ready on/
       end
     end
-
   end
 
   after(:all) do
     Process.kill 3, @pid
   end
 
-  before do
-    uri = URI('http://localhost:3000/')
-    @result = Net::HTTP.get(uri)
+  after do
+    File.delete(@log_path)
   end
 
-  it "renders the index page" do
-    expect(@result).to match(/Welcome to .+Next\.js!/)
+  describe "/" do
+    before do
+      @result = Net::HTTP.get(URI('http://localhost:3000/'))
+    end
+
+    it "renders the index page" do
+      expect(@result).to match(/Welcome to .+Next\.js!/)
+    end
+
+    it "sets the root span's name" do
+      log = File.read(@log_path)
+      expect(/Start root span '(\w+)' in 'web'/.match(log)).to be_truthy()
+      expect(/Set name 'GET \/' for span '#{$1}'/.match(log)).to be_truthy()
+    end
   end
 
-  it "sets the root span's name" do
-    log = File.read(@log_path)
-    expect(/Start root span '(\w+)' in 'web'/.match(log)).to be_truthy()
-    expect(/Set name 'GET \/' for span '#{$1}'/.match(log)).to be_truthy()
+  describe "/blog" do
+    before do
+      @result = Net::HTTP.get(URI('http://localhost:3000/blog'))
+    end
+
+    it "renders the index page" do
+      expect(@result).to match(/Blog/)
+    end
+
+    it "sets the root span's name" do
+      log = File.read(@log_path)
+      expect(/Start root span '(\w+)' in 'web'/.match(log)).to be_truthy()
+      expect(/Set name 'GET \/blog' for span '#{$1}'/.match(log)).to be_truthy()
+    end
   end
 end


### PR DESCRIPTION
In previous versions, we only used the full path name as in the sample
name if it matched "/". This patch removes that constraint, leaving two
types of routes:

1. Dyanmic routes, matched from the dynamicRoutes
2. Static routes, including everything else

This is based on the assumption that all non-dynamic routes are in fact
static. I haven't found any examples where this might fail, but I'm open
to suggestions on that.

Closes #337.