### PR TITLE
Wrap filepath in quotes in tar command

### DIFF
--- a/packages/nodejs-ext/scripts/extension.js
+++ b/packages/nodejs-ext/scripts/extension.js
@@ -42,7 +42,7 @@ function download(url, outputPath) {
 
 function extract(filepath) {
   return new Promise((resolve, reject) => {
-    childProcess.exec(`tar -C ext/ -xzf ${filepath}`, err => {
+    childProcess.exec(`tar -C ext/ -xzf "${filepath}"`, err => {
       return !err ? resolve() : reject(err)
     })
   })


### PR DESCRIPTION
Wrap the file path in the tar command in quotes to make sure we support paths with spaces.

Closes https://github.com/appsignal/support/issues/124.