### PR TITLE
Add --[no-]send-report options to diagnose

### DIFF
--- a/packages/nodejs/.changesets/send-report-and-no-send-report-options.md
+++ b/packages/nodejs/.changesets/send-report-and-no-send-report-options.md
@@ -1,0 +1,8 @@
+---
+bump: "patch"
+---
+
+Replace the `--no-report` option--which turned sending the diagnose report
+to AppSignal's servers off--with `--send-report` and `--no-send-report`.
+
+By default, the report is not sent if you don't pass `--send-report`.

--- a/packages/nodejs/bin/diagnose
+++ b/packages/nodejs/bin/diagnose
@@ -11,9 +11,9 @@ const { DiagnoseTool } = require("../dist/diagnose")
 // enable diagnose mode
 process.env["_APPSIGNAL_DIAGNOSE"] = "true"
 
-// providing --no-report at runtime stops the report from bieng sent
+// providing --send-report sends the report. --no-send-report stops the report from bieng sent
 // it can also be passed by @appsignal/cli
-const shouldSendReport = !process.argv.includes("--no-report")
+const shouldSendReport = process.argv.includes("--send-report") && !process.argv.includes("--no-send-report")
 
 const tool = new DiagnoseTool({})
 

--- a/packages/nodejs/bin/diagnose
+++ b/packages/nodejs/bin/diagnose
@@ -11,7 +11,7 @@ const { DiagnoseTool } = require("../dist/diagnose")
 // enable diagnose mode
 process.env["_APPSIGNAL_DIAGNOSE"] = "true"
 
-// providing --send-report sends the report. --no-send-report stops the report from bieng sent
+// providing --send-report sends the report. --no-send-report stops the report from being sent
 // it can also be passed by @appsignal/cli
 const shouldSendReport = process.argv.includes("--send-report") && !process.argv.includes("--no-send-report")
 


### PR DESCRIPTION
Replace the `--no-report` option--which turned sending the diagnose report
to AppSignal's servers off--with `--send-report` and `--no-send-report`.

By default, the report is not sent if you don't pass `--send-report`.

Part of https://github.com/appsignal/appsignal-nodejs/issues/375.