### PR TITLE
Update mono to 0.2.0

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -36,7 +36,7 @@ blocks:
               values: ["10", "11", "12", "13", "14"]
           commands:
             - mono build
-            - (cd packages/nodejs-ext && npm run build:ext)
+            - mono run npm run build:ext --package @appsignal/nodejs-ext
             - cache store packages-$SEMAPHORE_GIT_SHA-$SEMAPHORE_GIT_BRANCH-v$NODE_VERSION packages
   - name: "Tests"
     dependencies: ["Install and Build"]

--- a/script/setup
+++ b/script/setup
@@ -4,7 +4,7 @@ set -eu
 
 # Change version number to a release/tag available on the mono repo to update it
 # https://github.com/appsignal/mono/releases
-MONO_VERSION="v0.1.2-alpha.2"
+MONO_VERSION="v0.2.0"
 
 MONO_PATH="$HOME/mono"
 


### PR DESCRIPTION
Update mono so we can use the `--package` selector and run the
`build:ext` script through mono. This way we use a consistent interface.

[skip review]