### PR TITLE
Make APPSIGNAL_BUILD_FOR_MUSL behavior consistent

### DIFF
--- a/packages/nodejs-ext/.changesets/musl-build-flag.md
+++ b/packages/nodejs-ext/.changesets/musl-build-flag.md
@@ -1,0 +1,7 @@
+---
+bump: "patch"
+---
+
+Update `APPSIGNAL_BUILD_FOR_MUSL` build flag to also listen to the value `1`,
+as is documented. Usage: `APPSIGNAL_BUILD_FOR_MUSL=1` and then run the
+`npm/yarn install` command.

--- a/packages/nodejs-ext/jest.config.js
+++ b/packages/nodejs-ext/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  resetMocks: true,
+  resetModules: true
+}

--- a/packages/nodejs-ext/package.json
+++ b/packages/nodejs-ext/package.json
@@ -15,7 +15,8 @@
     "build:watch": "tsc -p tsconfig.json -w --preserveWatchOutput",
     "clean": "rimraf dist coverage",
     "link:npm": "npm link",
-    "link:yarn": "yarn link"
+    "link:yarn": "yarn link",
+    "test": "jest"
   },
   "os": [
     "linux",

--- a/packages/nodejs-ext/scripts/report.js
+++ b/packages/nodejs-ext/scripts/report.js
@@ -21,7 +21,8 @@ function createReport() {
 }
 
 function muslOverride() {
-  return process.env["APPSIGNAL_BUILD_FOR_MUSL"] === "true"
+  const musl = process.env["APPSIGNAL_BUILD_FOR_MUSL"]
+  return musl === "true" || musl === "1"
 }
 
 function agentTarget() {
@@ -29,7 +30,7 @@ function agentTarget() {
     return "linux-musl"
   }
 
-  const target = [process.platform];
+  const target = [process.platform]
   if (/linux/.test(target[0]) && hasMusl()) {
     target.push("-musl")
   }

--- a/packages/nodejs-ext/scripts/report.test.js
+++ b/packages/nodejs-ext/scripts/report.test.js
@@ -1,0 +1,107 @@
+const originalProcess = process
+const originalProcessEnv = process.env
+const mockHelpers = { hasMusl: jest.fn() }
+
+jest.doMock("./extension/helpers", () => mockHelpers)
+
+const { createBuildReport } = require("./report")
+
+describe("muslOverride", () => {
+  beforeEach(() => {
+    // Make a copy of the process object so that it doesn't modify the original
+    // objects.
+    global.process = {
+      ...originalProcess,
+      env: { ...originalProcessEnv }
+    }
+
+    // Set defaults
+    setHasMusl(false)
+  })
+
+  afterEach(() => {
+    global.process = originalProcess
+  })
+
+  function setPlatform(platform) {
+    global.process.platform = platform
+  }
+
+  function setEnv(key, value) {
+    global.process.env[key] = value
+  }
+
+  function setHasMusl(value) {
+    mockHelpers.hasMusl.mockReturnValue(value)
+  }
+
+  describe("with linux platform", () => {
+    test("returns linux platform", () => {
+      setPlatform("linux")
+      setHasMusl(false)
+
+      expect(createBuildReport({})).toMatchObject({
+        target: "linux",
+        musl_override: false
+      })
+    })
+
+    describe("when on musl system", () => {
+      test("returns linux-musl platform with musl_override === false", () => {
+        setPlatform("linux")
+        expect(process.env.APPSIGNAL_BUILD_FOR_MUSL).toBeUndefined()
+        setHasMusl(true)
+
+        expect(createBuildReport({})).toMatchObject({
+          target: "linux-musl",
+          musl_override: false
+        })
+      })
+    })
+  })
+
+  describe("with darwin platform", () => {
+    test("returns darwin platform", () => {
+      setPlatform("darwin")
+
+      expect(createBuildReport({})).toMatchObject({
+        target: "darwin",
+        musl_override: false
+      })
+    })
+  })
+
+  describe("with APPSIGNAL_BUILD_FOR_MUSL empty", () => {
+    test("returns linux-musl platform with musl_override === false", () => {
+      setPlatform("linux")
+      setEnv("APPSIGNAL_BUILD_FOR_MUSL", "")
+
+      expect(createBuildReport({})).toMatchObject({
+        target: "linux",
+        musl_override: false
+      })
+    })
+  })
+
+  describe("with APPSIGNAL_BUILD_FOR_MUSL=1", () => {
+    test("returns linux-musl platform with musl_override === true", () => {
+      setEnv("APPSIGNAL_BUILD_FOR_MUSL", "1")
+
+      expect(createBuildReport({})).toMatchObject({
+        target: "linux-musl",
+        musl_override: true
+      })
+    })
+  })
+
+  describe("with APPSIGNAL_BUILD_FOR_MUSL=true", () => {
+    test("returns linux-musl platform with musl_override === true", () => {
+      setEnv("APPSIGNAL_BUILD_FOR_MUSL", "true")
+
+      expect(createBuildReport({})).toMatchObject({
+        target: "linux-musl",
+        musl_override: true
+      })
+    })
+  })
+})


### PR DESCRIPTION
Other integrations listen to both the `true` and `1` value. We only
documented the `1` value in our docs here:
https://docs.appsignal.com/support/operating-systems.html#musl-build-override

This means that users may try to use the `1` value but it doesn't work
for them. This makes the `1` value work now.

As decided upon in: https://github.com/appsignal/integration-guide/pull/26

I also added a Jest testing setup. Configure it to reset all mocks and
modules between tests so that state from mocks don't leak between tests.

I mocked some calls to the Node.js `process` global because I needed to
test the results for different platforms and environment variables.

Fixes #368