### PR TITLE
Add Linux ARM flag to enable experimental build

### DIFF
--- a/packages/nodejs-ext/.changesets/linux-arm-build.md
+++ b/packages/nodejs-ext/.changesets/linux-arm-build.md
@@ -1,0 +1,5 @@
+---
+bump: "patch"
+---
+
+Add Linux ARM 64-bit experimental build, available behind a feature flag. To test this set the `APPSIGNAL_BUILD_FOR_LINUX_ARM` flag before compiling your apps: `export APPSIGNAL_BUILD_FOR_LINUX_ARM=1 <command>`. Please be aware this is an experimental build. Please report any issue you may encounter at our [support email](mailto:support@appsignal.com).

--- a/packages/nodejs-ext/scripts/extension.js
+++ b/packages/nodejs-ext/scripts/extension.js
@@ -76,14 +76,30 @@ function dumpReport(report) {
   })
 }
 
-function getMetadataForTarget({
-  architecture,
-  target
-}) {
-  const triple = [
-    architecture === "x64" ? "x86_64" : "i686",
-    `-${target}`
-  ]
+function mapArchitecture(architecture) {
+  switch (architecture) {
+    case "x64":
+      return "x86_64"
+      break
+    case "x86":
+      return "i686"
+      break
+    case "arm64":
+      return "aarch64"
+      break
+  }
+
+  console.error(
+    `AppSignal currently does not know about your system architecture 
+    (${architecture}). Please let us know at support@appsignal.com, we aim to 
+    support everything our customers run.`
+  )
+
+  return process.exit(1)
+}
+
+function getMetadataForTarget({ architecture, target }) {
+  const triple = [mapArchitecture(architecture), `-${target}`]
 
   return TRIPLES[triple.join("")]
 }

--- a/packages/nodejs-ext/scripts/extension/constants.js
+++ b/packages/nodejs-ext/scripts/extension/constants.js
@@ -1,38 +1,60 @@
-const AGENT_VERSION = "d08ae6c"
+const AGENT_VERSION = "9f282f3"
 
 const TRIPLES = {
   "x86_64-darwin": {
-    checksum: "09a6ab79a1888b0d5101f099c1441477192243e431a2f099137a88dc13bf841e",
-    downloadUrl: "https://appsignal-agent-releases.global.ssl.fastly.net/d08ae6c/appsignal-x86_64-darwin-all-static.tar.gz"
+    checksum:
+      "c279d061ac04b53c8e2ea21b7714d4d54964495124ddc7e794ba998366f9c195",
+    downloadUrl:
+      "https://appsignal-agent-releases.global.ssl.fastly.net/9f282f3/appsignal-x86_64-darwin-all-static.tar.gz"
   },
   "universal-darwin": {
-    checksum: "09a6ab79a1888b0d5101f099c1441477192243e431a2f099137a88dc13bf841e",
-    downloadUrl: "https://appsignal-agent-releases.global.ssl.fastly.net/d08ae6c/appsignal-x86_64-darwin-all-static.tar.gz"
+    checksum:
+      "c279d061ac04b53c8e2ea21b7714d4d54964495124ddc7e794ba998366f9c195",
+    downloadUrl:
+      "https://appsignal-agent-releases.global.ssl.fastly.net/9f282f3/appsignal-x86_64-darwin-all-static.tar.gz"
+  },
+  "aarch64-linux": {
+    checksum:
+      "3054b6e3bcab8c8959d4e87eb6fd9fc7a5821e0986c8e733154c2b76251c9e70",
+    downloadUrl:
+      "https://appsignal-agent-releases.global.ssl.fastly.net/9f282f3/appsignal-aarch64-linux-all-static.tar.gz"
   },
   "i686-linux": {
-    checksum: "976a43a8679bd69fc58b0f2dd2a15e9dc28ff27b5bd971a9c33cb75ee7f5f2d3",
-    downloadUrl: "https://appsignal-agent-releases.global.ssl.fastly.net/d08ae6c/appsignal-i686-linux-all-static.tar.gz"
+    checksum:
+      "30554989a59632cdaf8fdf5d15024b866d32930e91c080425955842e8078952b",
+    downloadUrl:
+      "https://appsignal-agent-releases.global.ssl.fastly.net/9f282f3/appsignal-i686-linux-all-static.tar.gz"
   },
   "x86-linux": {
-    checksum: "976a43a8679bd69fc58b0f2dd2a15e9dc28ff27b5bd971a9c33cb75ee7f5f2d3",
-    downloadUrl: "https://appsignal-agent-releases.global.ssl.fastly.net/d08ae6c/appsignal-i686-linux-all-static.tar.gz"
+    checksum:
+      "30554989a59632cdaf8fdf5d15024b866d32930e91c080425955842e8078952b",
+    downloadUrl:
+      "https://appsignal-agent-releases.global.ssl.fastly.net/9f282f3/appsignal-i686-linux-all-static.tar.gz"
   },
   "x86_64-linux": {
-    checksum: "f5ddf0914c285849a5f765ee15d7ea6a7c5ab415aa949fb0a521edd82516caa7",
-    downloadUrl: "https://appsignal-agent-releases.global.ssl.fastly.net/d08ae6c/appsignal-x86_64-linux-all-static.tar.gz"
+    checksum:
+      "f11fa7ec493c3668e965ef4cff077d44fe55101197a5eeaf50ccacf7314eba2b",
+    downloadUrl:
+      "https://appsignal-agent-releases.global.ssl.fastly.net/9f282f3/appsignal-x86_64-linux-all-static.tar.gz"
   },
   "x86_64-linux-musl": {
-    checksum: "c00fdf7f24ef459314eb9294c645df1517c1062498897abfc71b092f0fd26eb6",
-    downloadUrl: "https://appsignal-agent-releases.global.ssl.fastly.net/d08ae6c/appsignal-x86_64-linux-musl-all-static.tar.gz"
+    checksum:
+      "0dae02e77e244275b69bb8332e79bdcb0e0fa3b6b6f84744780ce0baffa9784f",
+    downloadUrl:
+      "https://appsignal-agent-releases.global.ssl.fastly.net/9f282f3/appsignal-x86_64-linux-musl-all-static.tar.gz"
   },
   "x86_64-freebsd": {
-    checksum: "cd6b80873e94a6f79a62bda6ca0058d97f4fccef4b07f5abde198d8df582de0d",
-    downloadUrl: "https://appsignal-agent-releases.global.ssl.fastly.net/d08ae6c/appsignal-x86_64-freebsd-all-static.tar.gz"
+    checksum:
+      "d9146a04bbbb85dccf22c84cacfa924ee8b7e2ff8ed79402aba14ac4333e440f",
+    downloadUrl:
+      "https://appsignal-agent-releases.global.ssl.fastly.net/9f282f3/appsignal-x86_64-freebsd-all-static.tar.gz"
   },
   "amd64-freebsd": {
-    checksum: "cd6b80873e94a6f79a62bda6ca0058d97f4fccef4b07f5abde198d8df582de0d",
-    downloadUrl: "https://appsignal-agent-releases.global.ssl.fastly.net/d08ae6c/appsignal-x86_64-freebsd-all-static.tar.gz"
-  },
+    checksum:
+      "d9146a04bbbb85dccf22c84cacfa924ee8b7e2ff8ed79402aba14ac4333e440f",
+    downloadUrl:
+      "https://appsignal-agent-releases.global.ssl.fastly.net/9f282f3/appsignal-x86_64-freebsd-all-static.tar.gz"
+  }
 }
 
 module.exports = { AGENT_VERSION, TRIPLES }

--- a/packages/nodejs-ext/scripts/extension/helpers.js
+++ b/packages/nodejs-ext/scripts/extension/helpers.js
@@ -24,7 +24,7 @@ function hasLocalBuild() {
  */
 function hasSupportedArchitecture(arch) {
   // 'x32' and 'x64' supported
-  return arch === "x32" || arch === "x64"
+  return arch === "x32" || arch === "x64" || arch === "arm64"
 }
 
 /**

--- a/packages/nodejs-ext/scripts/report.js
+++ b/packages/nodejs-ext/scripts/report.js
@@ -25,7 +25,15 @@ function muslOverride() {
   return musl === "true" || musl === "1"
 }
 
+function linuxArmOverride() {
+  const arm = process.env["APPSIGNAL_BUILD_FOR_LINUX_ARM"]
+  return arm === "true" || arm === "1"
+}
+
 function agentTarget() {
+  if (linuxArmOverride()) {
+    return "linux"
+  }
   if (muslOverride()) {
     return "linux-musl"
   }
@@ -37,13 +45,21 @@ function agentTarget() {
   return target.join("")
 }
 
+function agentArchitecture() {
+  if (linuxArmOverride()) {
+    return "arm64"
+  }
+  return process.arch
+}
+
 function createBuildReport({ isLocalBuild = false }) {
   return {
     time: new Date().toISOString(),
     package_path: path.join(__dirname, "/../ext/"),
-    architecture: process.arch,
+    architecture: agentArchitecture(),
     target: agentTarget(),
     musl_override: muslOverride(),
+    linux_arm_override: linuxArmOverride(),
     library_type: "static",
     dependencies: {},
     flags: {},

--- a/packages/nodejs-ext/scripts/report.test.js
+++ b/packages/nodejs-ext/scripts/report.test.js
@@ -104,4 +104,41 @@ describe("muslOverride", () => {
       })
     })
   })
+
+  describe("with APPSIGNAL_BUILD_FOR_LINUX_ARM empty", () => {
+    test("returns linux-musl platform with musl_override === false", () => {
+      setPlatform("linux")
+      setEnv("APPSIGNAL_BUILD_FOR_LINUX_ARM", "")
+
+      expect(createBuildReport({})).toMatchObject({
+        architecture: "x64",
+        target: "linux",
+        linux_arm_override: false
+      })
+    })
+  })
+
+  describe("with APPSIGNAL_BUILD_FOR_LINUX_ARM=1", () => {
+    test("returns linux-musl platform with musl_override === true", () => {
+      setEnv("APPSIGNAL_BUILD_FOR_LINUX_ARM", "1")
+
+      expect(createBuildReport({})).toMatchObject({
+        architecture: "arm64",
+        target: "linux",
+        linux_arm_override: true
+      })
+    })
+  })
+
+  describe("with APPSIGNAL_BUILD_FOR_LINUX_ARM=true", () => {
+    test("returns linux-musl platform with musl_override === true", () => {
+      setEnv("APPSIGNAL_BUILD_FOR_LINUX_ARM", "true")
+
+      expect(createBuildReport({})).toMatchObject({
+        architecture: "arm64",
+        target: "linux",
+        linux_arm_override: true
+      })
+    })
+  })
 })


### PR DESCRIPTION
Users can enable the Linux ARM build with the
`APPSIGNAL_BUILD_FOR_LINUX_ARM` environment variable during
installation. This build is by default behind a flag because it requires
more testing. People may expect it just works because it gets chosen
automatically if we don't put it behind a flag. Now we have an
opportunity to warn them beforehand.