### PR TITLE
Return the full log path in the diagnose report

### DIFF
--- a/packages/nodejs/.changesets/fix-diagnose-log-paths.md
+++ b/packages/nodejs/.changesets/fix-diagnose-log-paths.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+---
+
+Fix the log path reported when running the diagnose command to include the
+filename.

--- a/packages/nodejs/src/__tests__/diagnose.test.ts
+++ b/packages/nodejs/src/__tests__/diagnose.test.ts
@@ -36,4 +36,21 @@ describe("DiagnoseTool", () => {
       "/tmp/appsignal.log"
     )
   })
+
+  describe("when to log path is configured as a full path", () => {
+    beforeEach(() => {
+      process.env["APPSIGNAL_LOG_PATH"] = "/path/to/appsignal.log"
+      tool = new DiagnoseTool({})
+    })
+
+    it("returns the log_dir_path", () => {
+      expect(tool.generate().paths.log_dir_path.path).toEqual("/path/to")
+    })
+
+    it("returns the appsignal.log path", () => {
+      expect(tool.generate().paths["appsignal.log"].path).toEqual(
+        "/path/to/appsignal.log"
+      )
+    })
+  })
 })

--- a/packages/nodejs/src/__tests__/diagnose.test.ts
+++ b/packages/nodejs/src/__tests__/diagnose.test.ts
@@ -26,4 +26,14 @@ describe("DiagnoseTool", () => {
 
     expect(output.process.uid).toEqual(process.getuid())
   })
+
+  it("returns the log_dir_path", () => {
+    expect(tool.generate().paths.log_dir_path.path).toEqual("/tmp")
+  })
+
+  it("returns the appsignal.log path", () => {
+    expect(tool.generate().paths["appsignal.log"].path).toEqual(
+      "/tmp/appsignal.log"
+    )
+  })
 })

--- a/packages/nodejs/src/diagnose.ts
+++ b/packages/nodejs/src/diagnose.ts
@@ -93,7 +93,8 @@ export class DiagnoseTool {
 
     // we want to fall over if this value isn't present
     // (it should be)
-    const logPath = this.#config.data.logPath!
+    const logDirPath = this.#config.data.logPath!
+    const logPath = logDirPath + "/appsignal.log"
 
     // add any paths we want to check to this object!
     const files = {
@@ -101,7 +102,7 @@ export class DiagnoseTool {
         path: process.cwd()
       },
       log_dir_path: {
-        path: logPath.replace("/appsignal.log", "")
+        path: logDirPath
       },
       "appsignal.log": {
         path: logPath,

--- a/packages/nodejs/src/diagnose.ts
+++ b/packages/nodejs/src/diagnose.ts
@@ -93,8 +93,7 @@ export class DiagnoseTool {
 
     // we want to fall over if this value isn't present
     // (it should be)
-    const logDirPath = this.#config.data.logPath!
-    const logPath = this.#config.data.logFilePath!
+    const logFilePath = <string>this.#config.data.logFilePath!
 
     // add any paths we want to check to this object!
     const files = {
@@ -102,11 +101,11 @@ export class DiagnoseTool {
         path: process.cwd()
       },
       log_dir_path: {
-        path: logDirPath
+        path: this.#config.data.logPath!
       },
       "appsignal.log": {
-        path: logPath,
-        content: safeReadFromPath(logPath).split("\n")
+        path: logFilePath,
+        content: safeReadFromPath(logFilePath).split("\n")
       }
     }
 

--- a/packages/nodejs/src/diagnose.ts
+++ b/packages/nodejs/src/diagnose.ts
@@ -94,7 +94,7 @@ export class DiagnoseTool {
     // we want to fall over if this value isn't present
     // (it should be)
     const logDirPath = this.#config.data.logPath!
-    const logPath = logDirPath + "/appsignal.log"
+    const logPath = this.#config.data.logFilePath!
 
     // add any paths we want to check to this object!
     const files = {

--- a/packages/nodejs/src/diagnose.ts
+++ b/packages/nodejs/src/diagnose.ts
@@ -101,7 +101,7 @@ export class DiagnoseTool {
         path: process.cwd()
       },
       log_dir_path: {
-        path: this.#config.data.logPath!
+        path: this.#config.data.logPath!.replace("/appsignal.log", "")
       },
       "appsignal.log": {
         path: logFilePath,


### PR DESCRIPTION
Currently, the diagnose command expects the logPath to include the
filename for the `appsignal.log` file. To get the `log_dir_path`, the
filename is stripped off. The `LogPath` is then used to return the full
path to the file.

In reality, it should be the other way around. The `LogPath` does not
include the filename, so it can be used as the log_dir_path in the
diagnose. Then, to get the full path to the `appsignal.log` file, this
patch appends the filename to the log path.