### PR TITLE
Test against Node.js 15

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -37,6 +37,58 @@ blocks:
         value: '15'
       commands:
       - rake build_matrix:semaphore:validate
+- name: Node.js 15 - Build
+  dependencies:
+  - Validation
+  task:
+    env_vars:
+    - name: NODE_VERSION
+      value: '15'
+    prologue:
+      commands:
+      - cache restore
+      - mono bootstrap --ci
+      - cache store
+    jobs:
+    - name: Build
+      commands:
+      - mono build
+      - mono run --package @appsignal/nodejs-ext -- npm run build:ext
+      - cache store $_PACKAGES_CACHE-packages-$SEMAPHORE_GIT_SHA-v$NODE_VERSION packages
+- name: Node.js 15 - Tests
+  dependencies:
+  - Node.js 15 - Build
+  task:
+    env_vars:
+    - name: NODE_VERSION
+      value: '15'
+    prologue:
+      commands:
+      - cache restore
+      - cache restore $_PACKAGES_CACHE-packages-$SEMAPHORE_GIT_SHA-v$NODE_VERSION
+      - mono bootstrap --ci
+    jobs:
+    - name: "@appsignal/nodejs - nodejs"
+      commands:
+      - mono test --package=@appsignal/nodejs
+    - name: "@appsignal/nodejs-ext - nodejs-ext"
+      commands:
+      - mono test --package=@appsignal/nodejs-ext
+    - name: "@appsignal/nextjs - next.js@latest - integrations"
+      commands:
+      - npm install next@latest react@latest react-dom@latest --save-dev
+      - BUNDLE_GEMFILE=packages/nextjs/test/Gemfile bundle install
+      - BUNDLE_GEMFILE=packages/nextjs/test/Gemfile bundle exec rspec packages/nextjs/test
+    - name: "@appsignal/nextjs - next.js@11.0.1 - integrations"
+      commands:
+      - npm install next@11.0.1 react@17.0.2 react-dom@17.0.2 --save-dev
+      - BUNDLE_GEMFILE=packages/nextjs/test/Gemfile bundle install
+      - BUNDLE_GEMFILE=packages/nextjs/test/Gemfile bundle exec rspec packages/nextjs/test
+    - name: "@appsignal/nextjs - next.js@10.2.3 - integrations"
+      commands:
+      - npm install next@10.2.3 react@16.14.0 react-dom@16.14.0 --save-dev
+      - BUNDLE_GEMFILE=packages/nextjs/test/Gemfile bundle install
+      - BUNDLE_GEMFILE=packages/nextjs/test/Gemfile bundle exec rspec packages/nextjs/test
 - name: Node.js 14 - Build
   dependencies:
   - Validation

--- a/build_matrix.yml
+++ b/build_matrix.yml
@@ -38,6 +38,7 @@ semaphore: # Default `.semaphore/semaphore.yml` contents
 
 matrix:
   nodejs:
+    - nodejs: "15"
     - nodejs: "14"
     - nodejs: "13"
     - nodejs: "12"

--- a/script/setup
+++ b/script/setup
@@ -4,7 +4,7 @@ set -eu
 
 # Change version number to a release/tag available on the mono repo to update it
 # https://github.com/appsignal/mono/releases
-MONO_VERSION="v0.5.6"
+MONO_VERSION="v0.5.7"
 
 MONO_PATH="$HOME/mono"
 


### PR DESCRIPTION
Add Node.js 15 to the build matrix so that we run all tests on Node.js
15 as well.

Bump mono to 0.5.7 so that it install a higher npm version that's
required to fix the issue on older npm versions about it not finding the
nodejs package workspace so that it install a higher npm version that's
required to fix the issue on older npm versions about it not finding the
appsignal-nodejs package workspace.

The error previously on builds for Node.js 15 with older the npm 7
package:

```
$ mono build
...
npm ERR! No workspaces found:
npm ERR!   --workspace=@appsignal/nodejs
```

Part of https://github.com/appsignal/appsignal-nodejs/issues/389
[skip review]