### PR TITLE
Add Node.js 16 build

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -37,6 +37,60 @@ blocks:
         value: '15'
       commands:
       - rake build_matrix:semaphore:validate
+- name: Node.js 16 - Build
+  dependencies:
+  - Validation
+  task:
+    env_vars:
+    - name: NODE_VERSION
+      value: '16'
+    prologue:
+      commands:
+      - sem-version c 8
+      - cache restore
+      - mono bootstrap --ci
+      - cache store
+    jobs:
+    - name: Build
+      commands:
+      - mono build
+      - mono run --package @appsignal/nodejs-ext -- npm run build:ext
+      - cache store $_PACKAGES_CACHE-packages-$SEMAPHORE_GIT_SHA-v$NODE_VERSION packages
+- name: Node.js 16 - Tests
+  dependencies:
+  - Node.js 16 - Build
+  task:
+    env_vars:
+    - name: NODE_VERSION
+      value: '16'
+    prologue:
+      commands:
+      - sem-version c 8
+      - cache restore
+      - cache restore $_PACKAGES_CACHE-packages-$SEMAPHORE_GIT_SHA-v$NODE_VERSION
+      - mono bootstrap --ci
+    jobs:
+    - name: "@appsignal/nodejs - nodejs"
+      commands:
+      - mono test --package=@appsignal/nodejs
+    - name: "@appsignal/nodejs-ext - nodejs-ext"
+      commands:
+      - mono test --package=@appsignal/nodejs-ext
+    - name: "@appsignal/nextjs - next.js@latest - integrations"
+      commands:
+      - npm install next@latest react@latest react-dom@latest --save-dev
+      - BUNDLE_GEMFILE=packages/nextjs/test/Gemfile bundle install
+      - BUNDLE_GEMFILE=packages/nextjs/test/Gemfile bundle exec rspec packages/nextjs/test
+    - name: "@appsignal/nextjs - next.js@11.0.1 - integrations"
+      commands:
+      - npm install next@11.0.1 react@17.0.2 react-dom@17.0.2 --save-dev
+      - BUNDLE_GEMFILE=packages/nextjs/test/Gemfile bundle install
+      - BUNDLE_GEMFILE=packages/nextjs/test/Gemfile bundle exec rspec packages/nextjs/test
+    - name: "@appsignal/nextjs - next.js@10.2.3 - integrations"
+      commands:
+      - npm install next@10.2.3 react@16.14.0 react-dom@16.14.0 --save-dev
+      - BUNDLE_GEMFILE=packages/nextjs/test/Gemfile bundle install
+      - BUNDLE_GEMFILE=packages/nextjs/test/Gemfile bundle exec rspec packages/nextjs/test
 - name: Node.js 15 - Build
   dependencies:
   - Validation

--- a/Rakefile
+++ b/Rakefile
@@ -9,6 +9,7 @@ namespace :build_matrix do
       builds = []
       matrix["nodejs"].each do |nodejs|
         nodejs_version = nodejs["nodejs"]
+        setup = nodejs.fetch("setup", [])
 
         build_block_name = "Node.js #{nodejs_version} - Build"
         build_block = build_semaphore_task(
@@ -17,7 +18,7 @@ namespace :build_matrix do
           "task" => {
             "env_vars" => ["name" => "NODE_VERSION", "value" => nodejs_version],
             "prologue" => {
-              "commands" => [
+              "commands" => setup + [
                 "cache restore",
                 "mono bootstrap --ci",
                 "cache store"
@@ -84,7 +85,7 @@ namespace :build_matrix do
             "task" => {
               "env_vars" => ["name" => "NODE_VERSION", "value" => nodejs_version],
               "prologue" => {
-                "commands" => [
+                "commands" => setup + [
                   "cache restore",
                   "cache restore $_PACKAGES_CACHE-packages-$SEMAPHORE_GIT_SHA-v$NODE_VERSION",
                   "mono bootstrap --ci"

--- a/build_matrix.yml
+++ b/build_matrix.yml
@@ -38,6 +38,12 @@ semaphore: # Default `.semaphore/semaphore.yml` contents
 
 matrix:
   nodejs:
+    - nodejs: "16"
+      setup:
+        # Configure the host to use GCC 8.3 for Node.js 16. This is the minimal
+        # required version for Node.js 16, and the extension won't compile
+        # without it.
+        - sem-version c 8
     - nodejs: "15"
     - nodejs: "14"
     - nodejs: "13"


### PR DESCRIPTION
Add Node.js 16 to the build to test against the latest Node.js version
available.

## Extension installation issus

With the default config the Node.js 16 build would not install the
AppSignal extension successfully, failing the build step.

The error it would output:

```
g++: error: unrecognized command line option ‘-std=gnu++14’
make: *** [Release/obj.target/extension/ext/appsignal_extension.o] Error 1
build error
stack Error: `make` failed with exit code: 2
stack     at ChildProcess.onExit (/home/semaphore/appsignal-nodejs/node_modules/node-gyp/lib/build.js:194:23)
stack     at ChildProcess.emit (node:events:394:28)
stack     at Process.ChildProcess._handle.onexit (node:internal/child_process:290:12)
System Linux 4.15.0-147-generic
command "/home/semaphore/.nvm/versions/node/v16.4.0/bin/node" "/home/semaphore/appsignal-nodejs/node_modules/.bin/node-gyp" "rebuild"
```

The issue originated from the `node-gyp build` step. It failed on an
unrecognized option `-std=gnu++14`. This is caused by Node.js 16
requiring GCC 8.3 at the minimum, and the Semaphore environment being
configured to GCC 4.8 by default.

> (SEMVER-MAJOR) doc: update minimum supported GCC to 8.3 (Michaël Zasso) #37871

Source, the Node.js 16 release notes:
https://nodejs.org/en/blog/release/v16.0.0/

## Configuring the GCC version

To fix this extension installation issue, configure the GCC version to
the installed GCC 8. Semaphore allows builds to switch to another
version of the installed GCC by switching the C language with the
`sem-version c 8` command. Several versions of C are installed according
to the Semaphore docs.

Source: https://docs.semaphoreci.com/programming-languages/c/

## Setup set for the build matrix

Add an additional `setup` key to the build matrix for Node.js versions
that need it. These extra steps are added to the prologue of the tasks
for that Node.js version. In the case of Node.js 16 it's used to GCC 8
to use to fix this issue.

---

[skip review]