### PR TITLE
Fix extension installation reporting

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -56,6 +56,8 @@ blocks:
       - mono build
       - mono run --package @appsignal/nodejs-ext -- npm run build:ext
       - cache store $_PACKAGES_CACHE-packages-$SEMAPHORE_GIT_SHA-v$NODE_VERSION packages
+      - cache store $_PACKAGES_CACHE-install-report-$SEMAPHORE_GIT_SHA-v$NODE_VERSION
+        /tmp/appsignal-install-report.json
 - name: Node.js 16 - Tests
   dependencies:
   - Node.js 16 - Build
@@ -68,6 +70,7 @@ blocks:
       - sem-version c 8
       - cache restore
       - cache restore $_PACKAGES_CACHE-packages-$SEMAPHORE_GIT_SHA-v$NODE_VERSION
+      - cache restore $_PACKAGES_CACHE-install-report-$SEMAPHORE_GIT_SHA-v$NODE_VERSION
       - mono bootstrap --ci
     jobs:
     - name: "@appsignal/nodejs - nodejs"
@@ -76,6 +79,7 @@ blocks:
     - name: "@appsignal/nodejs-ext - nodejs-ext"
       commands:
       - mono test --package=@appsignal/nodejs-ext
+      - mono run --package @appsignal/nodejs-ext -- npm run test:failure
     - name: "@appsignal/nextjs - next.js@latest - integrations"
       commands:
       - npm install next@latest react@latest react-dom@latest --save-dev
@@ -109,6 +113,8 @@ blocks:
       - mono build
       - mono run --package @appsignal/nodejs-ext -- npm run build:ext
       - cache store $_PACKAGES_CACHE-packages-$SEMAPHORE_GIT_SHA-v$NODE_VERSION packages
+      - cache store $_PACKAGES_CACHE-install-report-$SEMAPHORE_GIT_SHA-v$NODE_VERSION
+        /tmp/appsignal-install-report.json
 - name: Node.js 15 - Tests
   dependencies:
   - Node.js 15 - Build
@@ -120,6 +126,7 @@ blocks:
       commands:
       - cache restore
       - cache restore $_PACKAGES_CACHE-packages-$SEMAPHORE_GIT_SHA-v$NODE_VERSION
+      - cache restore $_PACKAGES_CACHE-install-report-$SEMAPHORE_GIT_SHA-v$NODE_VERSION
       - mono bootstrap --ci
     jobs:
     - name: "@appsignal/nodejs - nodejs"
@@ -128,6 +135,7 @@ blocks:
     - name: "@appsignal/nodejs-ext - nodejs-ext"
       commands:
       - mono test --package=@appsignal/nodejs-ext
+      - mono run --package @appsignal/nodejs-ext -- npm run test:failure
     - name: "@appsignal/nextjs - next.js@latest - integrations"
       commands:
       - npm install next@latest react@latest react-dom@latest --save-dev
@@ -161,6 +169,8 @@ blocks:
       - mono build
       - mono run --package @appsignal/nodejs-ext -- npm run build:ext
       - cache store $_PACKAGES_CACHE-packages-$SEMAPHORE_GIT_SHA-v$NODE_VERSION packages
+      - cache store $_PACKAGES_CACHE-install-report-$SEMAPHORE_GIT_SHA-v$NODE_VERSION
+        /tmp/appsignal-install-report.json
 - name: Node.js 14 - Tests
   dependencies:
   - Node.js 14 - Build
@@ -172,6 +182,7 @@ blocks:
       commands:
       - cache restore
       - cache restore $_PACKAGES_CACHE-packages-$SEMAPHORE_GIT_SHA-v$NODE_VERSION
+      - cache restore $_PACKAGES_CACHE-install-report-$SEMAPHORE_GIT_SHA-v$NODE_VERSION
       - mono bootstrap --ci
     jobs:
     - name: "@appsignal/nodejs - nodejs"
@@ -180,6 +191,7 @@ blocks:
     - name: "@appsignal/nodejs-ext - nodejs-ext"
       commands:
       - mono test --package=@appsignal/nodejs-ext
+      - mono run --package @appsignal/nodejs-ext -- npm run test:failure
     - name: "@appsignal/nextjs - next.js@latest - integrations"
       commands:
       - npm install next@latest react@latest react-dom@latest --save-dev
@@ -213,6 +225,8 @@ blocks:
       - mono build
       - mono run --package @appsignal/nodejs-ext -- npm run build:ext
       - cache store $_PACKAGES_CACHE-packages-$SEMAPHORE_GIT_SHA-v$NODE_VERSION packages
+      - cache store $_PACKAGES_CACHE-install-report-$SEMAPHORE_GIT_SHA-v$NODE_VERSION
+        /tmp/appsignal-install-report.json
 - name: Node.js 13 - Tests
   dependencies:
   - Node.js 13 - Build
@@ -224,6 +238,7 @@ blocks:
       commands:
       - cache restore
       - cache restore $_PACKAGES_CACHE-packages-$SEMAPHORE_GIT_SHA-v$NODE_VERSION
+      - cache restore $_PACKAGES_CACHE-install-report-$SEMAPHORE_GIT_SHA-v$NODE_VERSION
       - mono bootstrap --ci
     jobs:
     - name: "@appsignal/nodejs - nodejs"
@@ -232,6 +247,7 @@ blocks:
     - name: "@appsignal/nodejs-ext - nodejs-ext"
       commands:
       - mono test --package=@appsignal/nodejs-ext
+      - mono run --package @appsignal/nodejs-ext -- npm run test:failure
     - name: "@appsignal/nextjs - next.js@latest - integrations"
       commands:
       - npm install next@latest react@latest react-dom@latest --save-dev
@@ -265,6 +281,8 @@ blocks:
       - mono build
       - mono run --package @appsignal/nodejs-ext -- npm run build:ext
       - cache store $_PACKAGES_CACHE-packages-$SEMAPHORE_GIT_SHA-v$NODE_VERSION packages
+      - cache store $_PACKAGES_CACHE-install-report-$SEMAPHORE_GIT_SHA-v$NODE_VERSION
+        /tmp/appsignal-install-report.json
 - name: Node.js 12 - Tests
   dependencies:
   - Node.js 12 - Build
@@ -276,6 +294,7 @@ blocks:
       commands:
       - cache restore
       - cache restore $_PACKAGES_CACHE-packages-$SEMAPHORE_GIT_SHA-v$NODE_VERSION
+      - cache restore $_PACKAGES_CACHE-install-report-$SEMAPHORE_GIT_SHA-v$NODE_VERSION
       - mono bootstrap --ci
     jobs:
     - name: "@appsignal/nodejs - nodejs"
@@ -284,6 +303,7 @@ blocks:
     - name: "@appsignal/nodejs-ext - nodejs-ext"
       commands:
       - mono test --package=@appsignal/nodejs-ext
+      - mono run --package @appsignal/nodejs-ext -- npm run test:failure
     - name: "@appsignal/nextjs - next.js@latest - integrations"
       commands:
       - npm install next@latest react@latest react-dom@latest --save-dev
@@ -317,6 +337,8 @@ blocks:
       - mono build
       - mono run --package @appsignal/nodejs-ext -- npm run build:ext
       - cache store $_PACKAGES_CACHE-packages-$SEMAPHORE_GIT_SHA-v$NODE_VERSION packages
+      - cache store $_PACKAGES_CACHE-install-report-$SEMAPHORE_GIT_SHA-v$NODE_VERSION
+        /tmp/appsignal-install-report.json
 - name: Node.js 11 - Tests
   dependencies:
   - Node.js 11 - Build
@@ -328,6 +350,7 @@ blocks:
       commands:
       - cache restore
       - cache restore $_PACKAGES_CACHE-packages-$SEMAPHORE_GIT_SHA-v$NODE_VERSION
+      - cache restore $_PACKAGES_CACHE-install-report-$SEMAPHORE_GIT_SHA-v$NODE_VERSION
       - mono bootstrap --ci
     jobs:
     - name: "@appsignal/nodejs - nodejs"
@@ -336,6 +359,7 @@ blocks:
     - name: "@appsignal/nodejs-ext - nodejs-ext"
       commands:
       - mono test --package=@appsignal/nodejs-ext
+      - mono run --package @appsignal/nodejs-ext -- npm run test:failure
     - name: "@appsignal/nextjs - next.js@latest - integrations"
       commands:
       - npm install next@latest react@latest react-dom@latest --save-dev
@@ -369,6 +393,8 @@ blocks:
       - mono build
       - mono run --package @appsignal/nodejs-ext -- npm run build:ext
       - cache store $_PACKAGES_CACHE-packages-$SEMAPHORE_GIT_SHA-v$NODE_VERSION packages
+      - cache store $_PACKAGES_CACHE-install-report-$SEMAPHORE_GIT_SHA-v$NODE_VERSION
+        /tmp/appsignal-install-report.json
 - name: Node.js 10 - Tests
   dependencies:
   - Node.js 10 - Build
@@ -380,6 +406,7 @@ blocks:
       commands:
       - cache restore
       - cache restore $_PACKAGES_CACHE-packages-$SEMAPHORE_GIT_SHA-v$NODE_VERSION
+      - cache restore $_PACKAGES_CACHE-install-report-$SEMAPHORE_GIT_SHA-v$NODE_VERSION
       - mono bootstrap --ci
     jobs:
     - name: "@appsignal/nodejs - nodejs"
@@ -388,6 +415,7 @@ blocks:
     - name: "@appsignal/nodejs-ext - nodejs-ext"
       commands:
       - mono test --package=@appsignal/nodejs-ext
+      - mono run --package @appsignal/nodejs-ext -- npm run test:failure
     - name: "@appsignal/nextjs - next.js@latest - integrations"
       commands:
       - npm install next@latest react@latest react-dom@latest --save-dev

--- a/Rakefile
+++ b/Rakefile
@@ -30,7 +30,8 @@ namespace :build_matrix do
                 "commands" => [
                   "mono build",
                   "mono run --package @appsignal/nodejs-ext -- npm run build:ext",
-                  "cache store $_PACKAGES_CACHE-packages-$SEMAPHORE_GIT_SHA-v$NODE_VERSION packages"
+                  "cache store $_PACKAGES_CACHE-packages-$SEMAPHORE_GIT_SHA-v$NODE_VERSION packages",
+                  "cache store $_PACKAGES_CACHE-install-report-$SEMAPHORE_GIT_SHA-v$NODE_VERSION /tmp/appsignal-install-report.json"
                 ]
               )
             ]
@@ -59,10 +60,10 @@ namespace :build_matrix do
               # that we don't forget to run those new tests.
               primary_jobs << build_semaphore_job(
                 "name" => "#{package["package"]} - #{variation_name}",
-                "commands" => [
+                "commands" => ([
                   update_package_version_command,
                   "mono test --package=#{package["package"]}"
-                ].compact
+                ] + package.fetch("extra_commands", [])).compact
               )
             end
 
@@ -88,6 +89,7 @@ namespace :build_matrix do
                 "commands" => setup + [
                   "cache restore",
                   "cache restore $_PACKAGES_CACHE-packages-$SEMAPHORE_GIT_SHA-v$NODE_VERSION",
+                  "cache restore $_PACKAGES_CACHE-install-report-$SEMAPHORE_GIT_SHA-v$NODE_VERSION",
                   "mono bootstrap --ci"
                 ]
               },

--- a/build_matrix.yml
+++ b/build_matrix.yml
@@ -59,6 +59,8 @@ matrix:
       path: "packages/nodejs-ext"
       variations:
         - name: "nodejs-ext"
+      extra_commands:
+        - mono run --package @appsignal/nodejs-ext -- npm run test:failure
     # Library integrations
     - package: "@appsignal/apollo-server"
       path: "packages/apollo-server"

--- a/packages/nodejs-ext/.changesets/fix-installation-report.md
+++ b/packages/nodejs-ext/.changesets/fix-installation-report.md
@@ -1,0 +1,5 @@
+---
+bump: "patch"
+---
+
+Fix installation report result. The installation report would report always "unknown" previously, now it will accurately report success and failure results. This will help the AppSignal team debug issues when the report is sent along with the diagnose report.

--- a/packages/nodejs-ext/package.json
+++ b/packages/nodejs-ext/package.json
@@ -9,14 +9,16 @@
     "node-gyp": "^7.1.2"
   },
   "scripts": {
-    "install": "node scripts/extension.js && node-gyp rebuild",
+    "install": "node scripts/extension.js",
     "build": "tsc -p tsconfig.json",
     "build:ext": "node-gyp rebuild",
     "build:watch": "tsc -p tsconfig.json -w --preserveWatchOutput",
     "clean": "rimraf dist coverage && rimraf ext/appsignal-agent ext/libappsignal.a ext/appsignal.* ext/*.tar.gz",
     "link:npm": "npm link",
     "link:yarn": "yarn link",
-    "test": "jest"
+    "test": "jest --filter=./test/filter.js",
+    "pretest:failure": "npm run clean",
+    "test:failure": "_TEST_APPSIGNAL_EXTENSION_FAILURE=true npm run install; _TEST_APPSIGNAL_EXTENSION_FAILURE=true jest --filter=./test/filter.js"
   },
   "os": [
     "linux",

--- a/packages/nodejs-ext/scripts/extension.failure.test.js
+++ b/packages/nodejs-ext/scripts/extension.failure.test.js
@@ -1,0 +1,34 @@
+const fs = require("fs")
+const path = require("path")
+
+function hasExtensionFailure() {
+  if (process.env._TEST_APPSIGNAL_EXTENSION_FAILURE !== "true") {
+    console.log(
+      `Skipping failure tests, because _TEST_APPSIGNAL_EXTENSION_FAILURE is not set to "true".`
+    )
+    return true
+  }
+}
+
+describe("Extension install failure", () => {
+  test("writes error result to diagnose installation report", () => {
+    if (hasExtensionFailure()) {
+      return
+    }
+
+    const report = readReport()
+    expect(report["result"]).toMatchObject({
+      status: "error",
+      error: "AppSignal internal test failure",
+      backtrace: expect.any(Array)
+    })
+  })
+})
+
+function readReport() {
+  const contents = fs.readFileSync(
+    path.resolve("/tmp/appsignal-install-report.json"),
+    "utf-8"
+  )
+  return JSON.parse(contents)
+}

--- a/packages/nodejs-ext/scripts/extension.test.js
+++ b/packages/nodejs-ext/scripts/extension.test.js
@@ -1,0 +1,19 @@
+const fs = require("fs")
+const path = require("path")
+
+describe("Extension install failure", () => {
+  test("writes success result to diagnose installation report", () => {
+    const report = readReport()
+    expect(report["result"]).toEqual({
+      status: "success"
+    })
+  })
+})
+
+function readReport() {
+  const contents = fs.readFileSync(
+    path.resolve("/tmp/appsignal-install-report.json"),
+    "utf-8"
+  )
+  return JSON.parse(contents)
+}

--- a/packages/nodejs-ext/test/filter.js
+++ b/packages/nodejs-ext/test/filter.js
@@ -1,0 +1,25 @@
+"use strict"
+
+const testExtensionFailure =
+  process.env._TEST_APPSIGNAL_EXTENSION_FAILURE === "true"
+// This function is run by using the --filter option for Jest. It will filter
+// out tests that should not be run in certain situations, like testing the
+// scenario when the extension failed.
+module.exports = function (tests) {
+  return {
+    filtered: tests
+      .filter(t => {
+        const match = t.indexOf(".failure")
+        if (testExtensionFailure) {
+          // Select tests with `.failure` in the path if we're testing the
+          // failure state.
+          return match > -1
+        } else {
+          // Skip the tests with `.failure` in the path if we're testing the
+          // success state.
+          return match == -1
+        }
+      })
+      .map(test => ({ test }))
+  }
+}


### PR DESCRIPTION
When the extension installed we never stored if it installed correctly
or not. Originally it would always report it as a "success" status. In a
previous commit cb08b7a16c4f81239724a1f71ac99371015b568e, PR #373, I
changed the report status to "unknown", because after the `extension.js`
script was run the `node-gyp rebuild` command was run through the
`package.json` `install` script. After the node-gyp command was run it
would not return to the extension.js script and we couldn't check the
exit status of that command.

Instead of running the node-gyp command after the `extension.js` script,
run the node-gyp command from the `extension.js` script so we can listen
to the exit status and report the installation as a success or "error"
when it encounters an error.

This should fix #371, the issue describing the scenario above, the
install report not accurately describing the installation status.

I am not sure why the originally implementation was chosen. The original
implementation was present since the initial commit of the project.
There may be a problem with this new implementation that I am unaware of
now, because I'm no Node.js expert. But we call out to other commands
like `tar` from the `extension.js` script as well, so I figure it will
be fine.

## CI build update

I've added tests for the extension build failure scenario, and the
success scenario. For this I needed to have Jest run certain specs only
some of the time, based on the `_TEST_APPSIGNAL_EXTENSION_FAILURE`
environment variable (same as in the Ruby gem CI setup). This is done
with the `--filter` option (which links to a file with a filter
function), which is configured through the `package.json` test scripts.

Since these new tests are only for the `nodejs-ext` package I found it
unnecessary to spin up a new job for it, and instead add it as
`extra_commands` to the package's test commands.

Before the failure state is tested, the extension installation is
cleaned up, so it doesn't think it has installed correctly.

Because we install the extension in the "Build" task, and it's not
present in the project dir, but instead the `/tmp` dir on the system,
I've also copied the report location from the "Build" task to the job
that tests this report. Otherwise it would fail on a missing file, or
we'd need to install the extension again. Hopefully we can find a better
location for the install report location in issue #372.