### PR TITLE
Add Git linter to build

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -23,7 +23,8 @@ global_job_config:
   prologue:
     commands:
     - checkout
-    - sem-version node $NODE_VERSION
+    - '[ -n "$NODE_VERSION" ] && sem-version node $NODE_VERSION || echo Skipping Node.js
+      install'
     - script/setup
     - source ~/.bashrc
 blocks:
@@ -32,11 +33,19 @@ blocks:
   task:
     jobs:
     - name: Validate CI setup
-      env_vars:
-      - name: NODE_VERSION
-        value: '15'
       commands:
       - rake build_matrix:semaphore:validate
+- name: Linters
+  dependencies: []
+  task:
+    jobs:
+    - name: Git Lint (Lintje)
+      env_vars:
+      - name: LINTJE_VERSION
+        value: 0.2.0
+      commands:
+      - script/install_lintje
+      - "$HOME/bin/lintje $SEMAPHORE_GIT_COMMIT_RANGE"
 - name: Node.js 16 - Build
   dependencies:
   - Validation

--- a/build_matrix.yml
+++ b/build_matrix.yml
@@ -19,7 +19,7 @@ semaphore: # Default `.semaphore/semaphore.yml` contents
     prologue:
       commands:
         - checkout
-        - sem-version node $NODE_VERSION
+        - "[ -n \"$NODE_VERSION\" ] && sem-version node $NODE_VERSION || echo Skipping Node.js install"
 
         # Mono setup
         - script/setup
@@ -30,11 +30,19 @@ semaphore: # Default `.semaphore/semaphore.yml` contents
       task:
         jobs:
         - name: Validate CI setup
-          env_vars:
-            - name: "NODE_VERSION"
-              value: "15"
           commands:
             - rake build_matrix:semaphore:validate
+    - name: Linters
+      dependencies: []
+      task:
+        jobs:
+        - name: Git Lint (Lintje)
+          env_vars:
+            - name: "LINTJE_VERSION"
+              value: "0.2.0"
+          commands:
+            - script/install_lintje
+            - $HOME/bin/lintje $SEMAPHORE_GIT_COMMIT_RANGE
 
 matrix:
   nodejs:

--- a/script/install_lintje
+++ b/script/install_lintje
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -eu
+
+mkdir -p $HOME/bin
+cache_key=v1-lintje-$LINTJE_VERSION
+cache restore $cache_key
+
+# File exists and is executable
+if [ -x "$HOME/bin/lintje" ]; then
+  echo "Restored Lintje $LINTJE_VERSION from cache"
+else
+  echo "Downloading Lintje $LINTJE_VERSION"
+  curl -L \
+    https://github.com/tombruijn/lintje/releases/download/v$LINTJE_VERSION/x86_64-unknown-linux-gnu.tar.gz | \
+    tar -xz --directory $HOME/bin
+  cache store $cache_key $HOME/bin/lintje
+fi


### PR DESCRIPTION
Enforce a Git standard by adding a linter to the build.
Lintje can be found at: https://github.com/tombruijn/lintje/

Whenever a commit is found that doesn't match the Git standards enforced
by Lintje it will fail this job and in turn the build. Fix the issues
highlighted by Lintje and (force) push your changes (on feature/PR
branches. Don't force push base branches).
Lintje will check all pushed commits in a PR or pushed branch using the
`SEMAPHORE_GIT_COMMIT_RANGE` env variable.

Disclaimer: I am the author of Lintje. Lintje is a personal project.
This addition was discussed with Jeff before making this change.

I added a skip Node.js version install if-statement, because there's no
need to install Node.js for some jobs like the Git linter and when we
validate the build setup. We can save some seconds in the build by
skipping this installation step.