### PR TITLE
Write install report to a unique path for install

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -57,7 +57,7 @@ blocks:
       - mono run --package @appsignal/nodejs-ext -- npm run build:ext
       - cache store $_PACKAGES_CACHE-packages-$SEMAPHORE_GIT_SHA-v$NODE_VERSION packages
       - cache store $_PACKAGES_CACHE-install-report-$SEMAPHORE_GIT_SHA-v$NODE_VERSION
-        /tmp/appsignal-install-report.json
+        /tmp/appsignal-*-install.report
 - name: Node.js 16 - Tests
   dependencies:
   - Node.js 16 - Build
@@ -119,7 +119,7 @@ blocks:
       - mono run --package @appsignal/nodejs-ext -- npm run build:ext
       - cache store $_PACKAGES_CACHE-packages-$SEMAPHORE_GIT_SHA-v$NODE_VERSION packages
       - cache store $_PACKAGES_CACHE-install-report-$SEMAPHORE_GIT_SHA-v$NODE_VERSION
-        /tmp/appsignal-install-report.json
+        /tmp/appsignal-*-install.report
 - name: Node.js 15 - Tests
   dependencies:
   - Node.js 15 - Build
@@ -180,7 +180,7 @@ blocks:
       - mono run --package @appsignal/nodejs-ext -- npm run build:ext
       - cache store $_PACKAGES_CACHE-packages-$SEMAPHORE_GIT_SHA-v$NODE_VERSION packages
       - cache store $_PACKAGES_CACHE-install-report-$SEMAPHORE_GIT_SHA-v$NODE_VERSION
-        /tmp/appsignal-install-report.json
+        /tmp/appsignal-*-install.report
 - name: Node.js 14 - Tests
   dependencies:
   - Node.js 14 - Build
@@ -241,7 +241,7 @@ blocks:
       - mono run --package @appsignal/nodejs-ext -- npm run build:ext
       - cache store $_PACKAGES_CACHE-packages-$SEMAPHORE_GIT_SHA-v$NODE_VERSION packages
       - cache store $_PACKAGES_CACHE-install-report-$SEMAPHORE_GIT_SHA-v$NODE_VERSION
-        /tmp/appsignal-install-report.json
+        /tmp/appsignal-*-install.report
 - name: Node.js 13 - Tests
   dependencies:
   - Node.js 13 - Build
@@ -302,7 +302,7 @@ blocks:
       - mono run --package @appsignal/nodejs-ext -- npm run build:ext
       - cache store $_PACKAGES_CACHE-packages-$SEMAPHORE_GIT_SHA-v$NODE_VERSION packages
       - cache store $_PACKAGES_CACHE-install-report-$SEMAPHORE_GIT_SHA-v$NODE_VERSION
-        /tmp/appsignal-install-report.json
+        /tmp/appsignal-*-install.report
 - name: Node.js 12 - Tests
   dependencies:
   - Node.js 12 - Build
@@ -363,7 +363,7 @@ blocks:
       - mono run --package @appsignal/nodejs-ext -- npm run build:ext
       - cache store $_PACKAGES_CACHE-packages-$SEMAPHORE_GIT_SHA-v$NODE_VERSION packages
       - cache store $_PACKAGES_CACHE-install-report-$SEMAPHORE_GIT_SHA-v$NODE_VERSION
-        /tmp/appsignal-install-report.json
+        /tmp/appsignal-*-install.report
 - name: Node.js 11 - Tests
   dependencies:
   - Node.js 11 - Build
@@ -424,7 +424,7 @@ blocks:
       - mono run --package @appsignal/nodejs-ext -- npm run build:ext
       - cache store $_PACKAGES_CACHE-packages-$SEMAPHORE_GIT_SHA-v$NODE_VERSION packages
       - cache store $_PACKAGES_CACHE-install-report-$SEMAPHORE_GIT_SHA-v$NODE_VERSION
-        /tmp/appsignal-install-report.json
+        /tmp/appsignal-*-install.report
 - name: Node.js 10 - Tests
   dependencies:
   - Node.js 10 - Build

--- a/Rakefile
+++ b/Rakefile
@@ -31,7 +31,7 @@ namespace :build_matrix do
                   "mono build",
                   "mono run --package @appsignal/nodejs-ext -- npm run build:ext",
                   "cache store $_PACKAGES_CACHE-packages-$SEMAPHORE_GIT_SHA-v$NODE_VERSION packages",
-                  "cache store $_PACKAGES_CACHE-install-report-$SEMAPHORE_GIT_SHA-v$NODE_VERSION /tmp/appsignal-install-report.json"
+                  "cache store $_PACKAGES_CACHE-install-report-$SEMAPHORE_GIT_SHA-v$NODE_VERSION /tmp/appsignal-*-install.report"
                 ]
               )
             ]

--- a/packages/nodejs-ext/scripts/extension.failure.test.js
+++ b/packages/nodejs-ext/scripts/extension.failure.test.js
@@ -1,5 +1,6 @@
 const fs = require("fs")
 const path = require("path")
+const { reportPath } = require("./report")
 
 function hasExtensionFailure() {
   if (process.env._TEST_APPSIGNAL_EXTENSION_FAILURE !== "true") {
@@ -26,9 +27,6 @@ describe("Extension install failure", () => {
 })
 
 function readReport() {
-  const contents = fs.readFileSync(
-    path.resolve("/tmp/appsignal-install-report.json"),
-    "utf-8"
-  )
+  const contents = fs.readFileSync(reportPath(), "utf-8")
   return JSON.parse(contents)
 }

--- a/packages/nodejs-ext/scripts/extension.js
+++ b/packages/nodejs-ext/scripts/extension.js
@@ -17,7 +17,8 @@ const {
 const {
   createReport,
   createBuildReport,
-  createDownloadReport
+  createDownloadReport,
+  reportPath
 } = require("./report")
 
 const EXT_PATH = path.join(__dirname, "/../ext/")
@@ -72,13 +73,9 @@ function verify(filepath, checksum) {
 
 function dumpReport(report) {
   return new Promise(resolve => {
-    fs.writeFile(
-      "/tmp/appsignal-install-report.json",
-      JSON.stringify(report, null, 2),
-      () => {
-        return resolve()
-      }
-    )
+    fs.writeFile(reportPath(), JSON.stringify(report, null, 2), () => {
+      return resolve()
+    })
   })
 }
 
@@ -96,8 +93,8 @@ function mapArchitecture(architecture) {
   }
 
   console.error(
-    `AppSignal currently does not know about your system architecture 
-    (${architecture}). Please let us know at support@appsignal.com, we aim to 
+    `AppSignal currently does not know about your system architecture
+    (${architecture}). Please let us know at support@appsignal.com, we aim to
     support everything our customers run.`
   )
 
@@ -132,8 +129,8 @@ function install() {
 
   if (!hasSupportedArchitecture(process.arch)) {
     console.error(
-      `AppSignal currently does not support your system architecture 
-        (${process.platform} ${process.arch}). Please let us know at 
+      `AppSignal currently does not support your system architecture
+        (${process.platform} ${process.arch}). Please let us know at
         support@appsignal.com, we aim to support everything our customers run.`
     )
 
@@ -142,8 +139,8 @@ function install() {
 
   if (!hasSupportedOs(process.platform)) {
     console.error(
-      `AppSignal currently does not support your operating system (${process.platform}). 
-      Please let us know at support@appsignal.com, we aim to support everything 
+      `AppSignal currently does not support your operating system (${process.platform}).
+      Please let us know at support@appsignal.com, we aim to support everything
       our customers run.`
     )
 

--- a/packages/nodejs-ext/scripts/extension.test.js
+++ b/packages/nodejs-ext/scripts/extension.test.js
@@ -1,5 +1,6 @@
 const fs = require("fs")
 const path = require("path")
+const { reportPath } = require("./report")
 
 describe("Extension install failure", () => {
   test("writes success result to diagnose installation report", () => {
@@ -11,9 +12,6 @@ describe("Extension install failure", () => {
 })
 
 function readReport() {
-  const contents = fs.readFileSync(
-    path.resolve("/tmp/appsignal-install-report.json"),
-    "utf-8"
-  )
+  const contents = fs.readFileSync(reportPath(), "utf-8")
   return JSON.parse(contents)
 }

--- a/packages/nodejs-ext/scripts/report.js
+++ b/packages/nodejs-ext/scripts/report.js
@@ -1,3 +1,4 @@
+const crypto = require("crypto")
 const path = require("path")
 
 const { AGENT_VERSION } = require("./extension/constants")
@@ -76,8 +77,21 @@ function createDownloadReport({ verified = false, downloadUrl: download_url }) {
   }
 }
 
+// This implementation should match the `packages/nodejs/src/diagnose.ts`
+// implementation to generate the same path.
+function reportPath() {
+  // Navigate up to the app dir. Move up the scripts dir, package dir,
+  // @appsignal dir and node_modules dir.
+  const appPath = path.join(__dirname, "../../../../")
+  const hash = crypto.createHash("sha256")
+  hash.update(appPath)
+  const reportPathDigest = hash.digest("hex")
+  return path.join(`/tmp/appsignal-${reportPathDigest}-install.report`)
+}
+
 module.exports = {
   createReport,
   createBuildReport,
-  createDownloadReport
+  createDownloadReport,
+  reportPath
 }


### PR DESCRIPTION
The installation report was written to
`/tmp/appsignal-install-report.json`, which can be easily overwritten by
other installations of the AppSignal nodejs-ext package in other apps.

To avoid reports being overwritten, and only the last report being
available, write the install report to a path unique to the app install.

This change generates a digest for the app's location that's used by the
`extension.js` script to write to and the `diagnose.ts` tool to read
from. This path should match as long as the app hasn't been moved after
installation. If it doesn't match the diagnose report won't be able to
find the installation report.

I've implemented the `reportPath` function twice, in both packages,
because they can't share code as the nodejs-ext package may not have
installed correctly and been removed. The implementation of these two
functions need to be kept in sync in order to generate the same path
digest.

## Alternatives

It's not possible currently to write the install report in the
`nodejs-ext` package itself, like the `ext/` dir where we also download
the extension and agent files. If the package fails to install
its directory is removed after the `npm install` process, so we need to
store it somewhere outside of the package directory.

An alternative solution would be to not exit the install process with an
error status code. This way the extension package directory isn't
removed, but we've decided not to do that for now while discussing
issue #372, as it could have impact on the compilation process we're not
foreseeing.

Closes #372