### PR TITLE
Fix diagnose report logging 10 appsignal.log lines

### DIFF
--- a/packages/nodejs/src/cli/diagnose.ts
+++ b/packages/nodejs/src/cli/diagnose.ts
@@ -145,8 +145,10 @@ export class Diagnose {
     console.log(
       `    Path: ${this.format_value(data["paths"]["appsignal.log"]["path"])}`
     )
-    console.log(`    Contents \(last 9 lines\):`)
+    console.log(`    Contents \(last 10 lines\):`)
     console.log(contents.slice(contents.length - 10).join("\n"))
+
+    this.print_newline()
 
     console.log(`Diagnostics report`)
     console.log(`  Do you want to send this diagnostics report to AppSignal?`)

--- a/packages/nodejs/src/diagnose.ts
+++ b/packages/nodejs/src/diagnose.ts
@@ -103,7 +103,7 @@ export class DiagnoseTool {
       },
       "appsignal.log": {
         path: logFilePath,
-        content: safeReadFromPath(logFilePath).split("\n")
+        content: safeReadFromPath(logFilePath).trimEnd().split("\n")
       }
     }
 


### PR DESCRIPTION
When the appsignal.log file is read and split into an array of lines,
the last line of the log, which is always empty, is also considered a
line to be printed.

This is because when a String is split on a line break, it will return
that last empty line as a empty String.

```
$ node
> "foo\nbar\nbaz\n".split("\n")
[ 'foo', 'bar', 'baz', '' ]
```

Since it's empty it shows no useful information and
breaks the formatting, so trim the read data to not include that last
empty line.

Depends on https://github.com/appsignal/diagnose_tests/pull/3