### PR TITLE
Only send 2 MiB of log data in diagnose report

### DIFF
--- a/packages/nodejs/.changesets/limit-appsignal-log-file-size-in-diagnose-report.md
+++ b/packages/nodejs/.changesets/limit-appsignal-log-file-size-in-diagnose-report.md
@@ -1,0 +1,5 @@
+---
+bump: "patch"
+---
+
+Limit the `appsignal.log` file size in diagnose report. It will only send the last 2MiB of the file. This prevents the diagnose report from sending too much data that it gets rejected by the server.


### PR DESCRIPTION
Don't send too much log file data. We previously decided upon 2 MiB of
data for the appsignal.log in the Ruby gem, so apply that in the Node.js
integration too.

I wrote the reading of this data in a sync way, with `Sync` functions
from the `fs` module. I could not get it to work with promises and async
without rewriting the entire script to be async, which seemed like a lot
of work for this change.

This sync approach is less safe I think, because we need to close the
open file manually. To make it more safe I've added the file closing to
the `finally` statement that triggers in the try-block regardless if an
error occurs in the try-block. The finally-block is like an ensure-block
in Ruby.

Closes #413