### PR TITLE
Build matrix tests check

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -145,6 +145,11 @@ def build_semaphore_job(job_hash)
 end
 
 def package_has_tests?(package)
-  Dir.exist?(File.join(package, "src/__tests__")) ||
-    Dir.glob(File.join(package, "**/*.test.*s")).any?
+  test_dir = File.join(package, "src/__tests__")
+  # Has a dedicated test dir and it contains files
+  if Dir.exist?(test_dir) && Dir.glob(File.join(test_dir, "**", "*.*s")).any?
+    return true
+  end
+
+  Dir.glob(File.join(package, "**/*.test.*s")).any?
 end


### PR DESCRIPTION
## Print skipped package tests in build matrix

This way we can see when package tests are omitted from the
`.semaphore.yml` file. I don't expect anyone to review the many line
changes in that file all the time. Now you can see what happens in the
command output.

Make it so that it only logs every package once, and not for every
combination of Node.js version as well.

## Skip package Node.js tests when there are no files

Do not only check if the `__tests__` directory exist, but check if it's
empty or not. When it exists and is empty, ignore it and do not consider
the package to have tests.


[skip review]
