### PR TITLE
Fix middleware path detection for Express

### DIFF
--- a/packages/express/src/middleware/index.ts
+++ b/packages/express/src/middleware/index.ts
@@ -38,7 +38,9 @@ export function expressMiddleware(appsignal: NodeClient): RequestHandler {
         // if there is no error passed to `next()`, the span name will
         // be updated to match the current path
         if (req.route?.path) {
-          span.setName(`${method} ${req.route.path}`)
+          // Prepend the namespace for middlewares
+          const baseUrl = req.baseUrl || ""
+          span.setName(`${method} ${baseUrl}${req.route.path}`)
         }
 
         // defeated the type checker here because i'm pretty sure the error

--- a/packages/express/test/example/admin.js
+++ b/packages/express/test/example/admin.js
@@ -1,0 +1,7 @@
+const app = require("express").Router()
+
+app.get("/dashboard", function (req, res) {
+  res.send("Dashboard for admin")
+})
+
+module.exports = app

--- a/packages/express/test/example/index.js
+++ b/packages/express/test/example/index.js
@@ -11,8 +11,14 @@ const { expressMiddleware } = require("@appsignal/express")
 const app = express()
 const port = 3000
 
+app.use(expressMiddleware(appsignal))
+
 app.get("/", (req, res) => {
   res.send("Hello World!")
+})
+
+app.get("/dashboard", (req, res) => {
+  res.send("Dashboard for user")
 })
 
 app.listen(port, () => {

--- a/packages/express/test/example/index.js
+++ b/packages/express/test/example/index.js
@@ -13,6 +13,9 @@ const port = 3000
 
 app.use(expressMiddleware(appsignal))
 
+const adminRoutes = require("./admin")
+app.use("/admin", adminRoutes)
+
 app.get("/", (req, res) => {
   res.send("Hello World!")
 })

--- a/packages/express/test/integration_spec.rb
+++ b/packages/express/test/integration_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe "Express.js" do
 
   describe "/" do
     before do
-      @result = Net::HTTP.get(URI('http://localhost:3000/'))
+      @result = Net::HTTP.get(URI('http://localhost:3000/?foo=bar'))
     end
 
     it "renders the index page" do

--- a/packages/express/test/integration_spec.rb
+++ b/packages/express/test/integration_spec.rb
@@ -45,4 +45,20 @@ RSpec.describe "Express.js" do
       expect(/Set name 'GET \/' for span '#{$1}'/.match(log)).to be_truthy()
     end
   end
+
+  describe "/dashboard" do
+    before do
+      @result = Net::HTTP.get(URI('http://localhost:3000/dashboard?foo=bar'))
+    end
+
+    it "renders the page" do
+      expect(@result).to match("Dashboard for user")
+    end
+
+    it "renders the dashboard page" do
+      log = File.read(@log_path)
+      expect(/Start root span '(\w+)' in 'web'/.match(log)).to be_truthy()
+      expect(/Set name 'GET \/dashboard' for span '#{$1}'/.match(log)).to be_truthy()
+    end
+  end
 end

--- a/packages/express/test/integration_spec.rb
+++ b/packages/express/test/integration_spec.rb
@@ -61,4 +61,20 @@ RSpec.describe "Express.js" do
       expect(/Set name 'GET \/dashboard' for span '#{$1}'/.match(log)).to be_truthy()
     end
   end
+
+  describe "/admin/dashboard" do
+    before do
+      @result = Net::HTTP.get(URI('http://localhost:3000/admin/dashboard?foo=bar'))
+    end
+
+    it "renders the page" do
+      expect(@result).to include("Dashboard for admin")
+    end
+
+    it "sets the root span's name" do
+      log = File.read(@log_path)
+      expect(/Start root span '(\w+)' in 'web'/.match(log)).to be_truthy()
+      expect(/Set name 'GET \/admin\/dashboard' for span '#{$1}'/.match(log)).to be_truthy()
+    end
+  end
 end


### PR DESCRIPTION
Based on #419

## Fix middleware path detection for Express

The action name set for routes defined in a middleware did not account
for the path they were mounted on. Instead they would only report the
paths as defined in the routes on the middleware.

If mounted like this:

```
const adminRoutes = require("./admin")
app.use("/admin", adminRoutes)
```

The path `/admin` would not be included in the action name.

Use the `baseUrl` to prepend the mounted path on the action name.

Fixes appsignal/support#125

## Test non-root path in Express tests

Do not only test the root path, but test another path that can exist in
the app. This is how I found out that the AppSignal middleware that was
required was not actually used in the test app.

Without the middleware it would set the action name to:
`GET [unknown route]`


## Add query params to test URLS

This will help test what part of the request URL we fetch and set as the
action name. These query params should not be included in the action
name on the span.

