### PR TITLE
Refactor integrations tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,4 @@ build/
 # Agent archives
 packages/nodejs-ext/ext/*.tar.gz
 
+packages/*/test/spec/examples.txt

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -97,43 +97,35 @@ blocks:
     - name: "@appsignal/express - express@latest - integrations"
       commands:
       - npm install express@latest --save-dev
-      - BUNDLE_GEMFILE=packages/express/test/Gemfile bundle install
-      - BUNDLE_GEMFILE=packages/express/test/Gemfile bundle exec rspec packages/express/test
+      - script/test_package_integration express
     - name: "@appsignal/express - express@4.17.1 - integrations"
       commands:
       - npm install express@4.17.1 --save-dev
-      - BUNDLE_GEMFILE=packages/express/test/Gemfile bundle install
-      - BUNDLE_GEMFILE=packages/express/test/Gemfile bundle exec rspec packages/express/test
+      - script/test_package_integration express
     - name: "@appsignal/koa - koa@latest - integrations"
       commands:
       - npm install koa@latest --save-dev
-      - BUNDLE_GEMFILE=packages/koa/test/Gemfile bundle install
-      - BUNDLE_GEMFILE=packages/koa/test/Gemfile bundle exec rspec packages/koa/test
+      - script/test_package_integration koa
     - name: "@appsignal/koa - koa@2.13.1 - integrations"
       commands:
       - npm install koa@2.13.1 --save-dev
-      - BUNDLE_GEMFILE=packages/koa/test/Gemfile bundle install
-      - BUNDLE_GEMFILE=packages/koa/test/Gemfile bundle exec rspec packages/koa/test
+      - script/test_package_integration koa
     - name: "@appsignal/koa - koa@2.12.1 - integrations"
       commands:
       - npm install koa@2.12.1 --save-dev
-      - BUNDLE_GEMFILE=packages/koa/test/Gemfile bundle install
-      - BUNDLE_GEMFILE=packages/koa/test/Gemfile bundle exec rspec packages/koa/test
+      - script/test_package_integration koa
     - name: "@appsignal/nextjs - next.js@latest - integrations"
       commands:
       - npm install next@latest react@latest react-dom@latest --save-dev
-      - BUNDLE_GEMFILE=packages/nextjs/test/Gemfile bundle install
-      - BUNDLE_GEMFILE=packages/nextjs/test/Gemfile bundle exec rspec packages/nextjs/test
+      - script/test_package_integration nextjs
     - name: "@appsignal/nextjs - next.js@11.0.1 - integrations"
       commands:
       - npm install next@11.0.1 react@17.0.2 react-dom@17.0.2 --save-dev
-      - BUNDLE_GEMFILE=packages/nextjs/test/Gemfile bundle install
-      - BUNDLE_GEMFILE=packages/nextjs/test/Gemfile bundle exec rspec packages/nextjs/test
+      - script/test_package_integration nextjs
     - name: "@appsignal/nextjs - next.js@10.2.3 - integrations"
       commands:
       - npm install next@10.2.3 react@16.14.0 react-dom@16.14.0 --save-dev
-      - BUNDLE_GEMFILE=packages/nextjs/test/Gemfile bundle install
-      - BUNDLE_GEMFILE=packages/nextjs/test/Gemfile bundle exec rspec packages/nextjs/test
+      - script/test_package_integration nextjs
 - name: Node.js 15 - Build
   dependencies:
   - Validation
@@ -183,43 +175,35 @@ blocks:
     - name: "@appsignal/express - express@latest - integrations"
       commands:
       - npm install express@latest --save-dev
-      - BUNDLE_GEMFILE=packages/express/test/Gemfile bundle install
-      - BUNDLE_GEMFILE=packages/express/test/Gemfile bundle exec rspec packages/express/test
+      - script/test_package_integration express
     - name: "@appsignal/express - express@4.17.1 - integrations"
       commands:
       - npm install express@4.17.1 --save-dev
-      - BUNDLE_GEMFILE=packages/express/test/Gemfile bundle install
-      - BUNDLE_GEMFILE=packages/express/test/Gemfile bundle exec rspec packages/express/test
+      - script/test_package_integration express
     - name: "@appsignal/koa - koa@latest - integrations"
       commands:
       - npm install koa@latest --save-dev
-      - BUNDLE_GEMFILE=packages/koa/test/Gemfile bundle install
-      - BUNDLE_GEMFILE=packages/koa/test/Gemfile bundle exec rspec packages/koa/test
+      - script/test_package_integration koa
     - name: "@appsignal/koa - koa@2.13.1 - integrations"
       commands:
       - npm install koa@2.13.1 --save-dev
-      - BUNDLE_GEMFILE=packages/koa/test/Gemfile bundle install
-      - BUNDLE_GEMFILE=packages/koa/test/Gemfile bundle exec rspec packages/koa/test
+      - script/test_package_integration koa
     - name: "@appsignal/koa - koa@2.12.1 - integrations"
       commands:
       - npm install koa@2.12.1 --save-dev
-      - BUNDLE_GEMFILE=packages/koa/test/Gemfile bundle install
-      - BUNDLE_GEMFILE=packages/koa/test/Gemfile bundle exec rspec packages/koa/test
+      - script/test_package_integration koa
     - name: "@appsignal/nextjs - next.js@latest - integrations"
       commands:
       - npm install next@latest react@latest react-dom@latest --save-dev
-      - BUNDLE_GEMFILE=packages/nextjs/test/Gemfile bundle install
-      - BUNDLE_GEMFILE=packages/nextjs/test/Gemfile bundle exec rspec packages/nextjs/test
+      - script/test_package_integration nextjs
     - name: "@appsignal/nextjs - next.js@11.0.1 - integrations"
       commands:
       - npm install next@11.0.1 react@17.0.2 react-dom@17.0.2 --save-dev
-      - BUNDLE_GEMFILE=packages/nextjs/test/Gemfile bundle install
-      - BUNDLE_GEMFILE=packages/nextjs/test/Gemfile bundle exec rspec packages/nextjs/test
+      - script/test_package_integration nextjs
     - name: "@appsignal/nextjs - next.js@10.2.3 - integrations"
       commands:
       - npm install next@10.2.3 react@16.14.0 react-dom@16.14.0 --save-dev
-      - BUNDLE_GEMFILE=packages/nextjs/test/Gemfile bundle install
-      - BUNDLE_GEMFILE=packages/nextjs/test/Gemfile bundle exec rspec packages/nextjs/test
+      - script/test_package_integration nextjs
 - name: Node.js 14 - Build
   dependencies:
   - Validation
@@ -269,43 +253,35 @@ blocks:
     - name: "@appsignal/express - express@latest - integrations"
       commands:
       - npm install express@latest --save-dev
-      - BUNDLE_GEMFILE=packages/express/test/Gemfile bundle install
-      - BUNDLE_GEMFILE=packages/express/test/Gemfile bundle exec rspec packages/express/test
+      - script/test_package_integration express
     - name: "@appsignal/express - express@4.17.1 - integrations"
       commands:
       - npm install express@4.17.1 --save-dev
-      - BUNDLE_GEMFILE=packages/express/test/Gemfile bundle install
-      - BUNDLE_GEMFILE=packages/express/test/Gemfile bundle exec rspec packages/express/test
+      - script/test_package_integration express
     - name: "@appsignal/koa - koa@latest - integrations"
       commands:
       - npm install koa@latest --save-dev
-      - BUNDLE_GEMFILE=packages/koa/test/Gemfile bundle install
-      - BUNDLE_GEMFILE=packages/koa/test/Gemfile bundle exec rspec packages/koa/test
+      - script/test_package_integration koa
     - name: "@appsignal/koa - koa@2.13.1 - integrations"
       commands:
       - npm install koa@2.13.1 --save-dev
-      - BUNDLE_GEMFILE=packages/koa/test/Gemfile bundle install
-      - BUNDLE_GEMFILE=packages/koa/test/Gemfile bundle exec rspec packages/koa/test
+      - script/test_package_integration koa
     - name: "@appsignal/koa - koa@2.12.1 - integrations"
       commands:
       - npm install koa@2.12.1 --save-dev
-      - BUNDLE_GEMFILE=packages/koa/test/Gemfile bundle install
-      - BUNDLE_GEMFILE=packages/koa/test/Gemfile bundle exec rspec packages/koa/test
+      - script/test_package_integration koa
     - name: "@appsignal/nextjs - next.js@latest - integrations"
       commands:
       - npm install next@latest react@latest react-dom@latest --save-dev
-      - BUNDLE_GEMFILE=packages/nextjs/test/Gemfile bundle install
-      - BUNDLE_GEMFILE=packages/nextjs/test/Gemfile bundle exec rspec packages/nextjs/test
+      - script/test_package_integration nextjs
     - name: "@appsignal/nextjs - next.js@11.0.1 - integrations"
       commands:
       - npm install next@11.0.1 react@17.0.2 react-dom@17.0.2 --save-dev
-      - BUNDLE_GEMFILE=packages/nextjs/test/Gemfile bundle install
-      - BUNDLE_GEMFILE=packages/nextjs/test/Gemfile bundle exec rspec packages/nextjs/test
+      - script/test_package_integration nextjs
     - name: "@appsignal/nextjs - next.js@10.2.3 - integrations"
       commands:
       - npm install next@10.2.3 react@16.14.0 react-dom@16.14.0 --save-dev
-      - BUNDLE_GEMFILE=packages/nextjs/test/Gemfile bundle install
-      - BUNDLE_GEMFILE=packages/nextjs/test/Gemfile bundle exec rspec packages/nextjs/test
+      - script/test_package_integration nextjs
 - name: Node.js 13 - Build
   dependencies:
   - Validation
@@ -355,43 +331,35 @@ blocks:
     - name: "@appsignal/express - express@latest - integrations"
       commands:
       - npm install express@latest --save-dev
-      - BUNDLE_GEMFILE=packages/express/test/Gemfile bundle install
-      - BUNDLE_GEMFILE=packages/express/test/Gemfile bundle exec rspec packages/express/test
+      - script/test_package_integration express
     - name: "@appsignal/express - express@4.17.1 - integrations"
       commands:
       - npm install express@4.17.1 --save-dev
-      - BUNDLE_GEMFILE=packages/express/test/Gemfile bundle install
-      - BUNDLE_GEMFILE=packages/express/test/Gemfile bundle exec rspec packages/express/test
+      - script/test_package_integration express
     - name: "@appsignal/koa - koa@latest - integrations"
       commands:
       - npm install koa@latest --save-dev
-      - BUNDLE_GEMFILE=packages/koa/test/Gemfile bundle install
-      - BUNDLE_GEMFILE=packages/koa/test/Gemfile bundle exec rspec packages/koa/test
+      - script/test_package_integration koa
     - name: "@appsignal/koa - koa@2.13.1 - integrations"
       commands:
       - npm install koa@2.13.1 --save-dev
-      - BUNDLE_GEMFILE=packages/koa/test/Gemfile bundle install
-      - BUNDLE_GEMFILE=packages/koa/test/Gemfile bundle exec rspec packages/koa/test
+      - script/test_package_integration koa
     - name: "@appsignal/koa - koa@2.12.1 - integrations"
       commands:
       - npm install koa@2.12.1 --save-dev
-      - BUNDLE_GEMFILE=packages/koa/test/Gemfile bundle install
-      - BUNDLE_GEMFILE=packages/koa/test/Gemfile bundle exec rspec packages/koa/test
+      - script/test_package_integration koa
     - name: "@appsignal/nextjs - next.js@latest - integrations"
       commands:
       - npm install next@latest react@latest react-dom@latest --save-dev
-      - BUNDLE_GEMFILE=packages/nextjs/test/Gemfile bundle install
-      - BUNDLE_GEMFILE=packages/nextjs/test/Gemfile bundle exec rspec packages/nextjs/test
+      - script/test_package_integration nextjs
     - name: "@appsignal/nextjs - next.js@11.0.1 - integrations"
       commands:
       - npm install next@11.0.1 react@17.0.2 react-dom@17.0.2 --save-dev
-      - BUNDLE_GEMFILE=packages/nextjs/test/Gemfile bundle install
-      - BUNDLE_GEMFILE=packages/nextjs/test/Gemfile bundle exec rspec packages/nextjs/test
+      - script/test_package_integration nextjs
     - name: "@appsignal/nextjs - next.js@10.2.3 - integrations"
       commands:
       - npm install next@10.2.3 react@16.14.0 react-dom@16.14.0 --save-dev
-      - BUNDLE_GEMFILE=packages/nextjs/test/Gemfile bundle install
-      - BUNDLE_GEMFILE=packages/nextjs/test/Gemfile bundle exec rspec packages/nextjs/test
+      - script/test_package_integration nextjs
 - name: Node.js 12 - Build
   dependencies:
   - Validation
@@ -441,43 +409,35 @@ blocks:
     - name: "@appsignal/express - express@latest - integrations"
       commands:
       - npm install express@latest --save-dev
-      - BUNDLE_GEMFILE=packages/express/test/Gemfile bundle install
-      - BUNDLE_GEMFILE=packages/express/test/Gemfile bundle exec rspec packages/express/test
+      - script/test_package_integration express
     - name: "@appsignal/express - express@4.17.1 - integrations"
       commands:
       - npm install express@4.17.1 --save-dev
-      - BUNDLE_GEMFILE=packages/express/test/Gemfile bundle install
-      - BUNDLE_GEMFILE=packages/express/test/Gemfile bundle exec rspec packages/express/test
+      - script/test_package_integration express
     - name: "@appsignal/koa - koa@latest - integrations"
       commands:
       - npm install koa@latest --save-dev
-      - BUNDLE_GEMFILE=packages/koa/test/Gemfile bundle install
-      - BUNDLE_GEMFILE=packages/koa/test/Gemfile bundle exec rspec packages/koa/test
+      - script/test_package_integration koa
     - name: "@appsignal/koa - koa@2.13.1 - integrations"
       commands:
       - npm install koa@2.13.1 --save-dev
-      - BUNDLE_GEMFILE=packages/koa/test/Gemfile bundle install
-      - BUNDLE_GEMFILE=packages/koa/test/Gemfile bundle exec rspec packages/koa/test
+      - script/test_package_integration koa
     - name: "@appsignal/koa - koa@2.12.1 - integrations"
       commands:
       - npm install koa@2.12.1 --save-dev
-      - BUNDLE_GEMFILE=packages/koa/test/Gemfile bundle install
-      - BUNDLE_GEMFILE=packages/koa/test/Gemfile bundle exec rspec packages/koa/test
+      - script/test_package_integration koa
     - name: "@appsignal/nextjs - next.js@latest - integrations"
       commands:
       - npm install next@latest react@latest react-dom@latest --save-dev
-      - BUNDLE_GEMFILE=packages/nextjs/test/Gemfile bundle install
-      - BUNDLE_GEMFILE=packages/nextjs/test/Gemfile bundle exec rspec packages/nextjs/test
+      - script/test_package_integration nextjs
     - name: "@appsignal/nextjs - next.js@11.0.1 - integrations"
       commands:
       - npm install next@11.0.1 react@17.0.2 react-dom@17.0.2 --save-dev
-      - BUNDLE_GEMFILE=packages/nextjs/test/Gemfile bundle install
-      - BUNDLE_GEMFILE=packages/nextjs/test/Gemfile bundle exec rspec packages/nextjs/test
+      - script/test_package_integration nextjs
     - name: "@appsignal/nextjs - next.js@10.2.3 - integrations"
       commands:
       - npm install next@10.2.3 react@16.14.0 react-dom@16.14.0 --save-dev
-      - BUNDLE_GEMFILE=packages/nextjs/test/Gemfile bundle install
-      - BUNDLE_GEMFILE=packages/nextjs/test/Gemfile bundle exec rspec packages/nextjs/test
+      - script/test_package_integration nextjs
 - name: Node.js 11 - Build
   dependencies:
   - Validation
@@ -527,43 +487,35 @@ blocks:
     - name: "@appsignal/express - express@latest - integrations"
       commands:
       - npm install express@latest --save-dev
-      - BUNDLE_GEMFILE=packages/express/test/Gemfile bundle install
-      - BUNDLE_GEMFILE=packages/express/test/Gemfile bundle exec rspec packages/express/test
+      - script/test_package_integration express
     - name: "@appsignal/express - express@4.17.1 - integrations"
       commands:
       - npm install express@4.17.1 --save-dev
-      - BUNDLE_GEMFILE=packages/express/test/Gemfile bundle install
-      - BUNDLE_GEMFILE=packages/express/test/Gemfile bundle exec rspec packages/express/test
+      - script/test_package_integration express
     - name: "@appsignal/koa - koa@latest - integrations"
       commands:
       - npm install koa@latest --save-dev
-      - BUNDLE_GEMFILE=packages/koa/test/Gemfile bundle install
-      - BUNDLE_GEMFILE=packages/koa/test/Gemfile bundle exec rspec packages/koa/test
+      - script/test_package_integration koa
     - name: "@appsignal/koa - koa@2.13.1 - integrations"
       commands:
       - npm install koa@2.13.1 --save-dev
-      - BUNDLE_GEMFILE=packages/koa/test/Gemfile bundle install
-      - BUNDLE_GEMFILE=packages/koa/test/Gemfile bundle exec rspec packages/koa/test
+      - script/test_package_integration koa
     - name: "@appsignal/koa - koa@2.12.1 - integrations"
       commands:
       - npm install koa@2.12.1 --save-dev
-      - BUNDLE_GEMFILE=packages/koa/test/Gemfile bundle install
-      - BUNDLE_GEMFILE=packages/koa/test/Gemfile bundle exec rspec packages/koa/test
+      - script/test_package_integration koa
     - name: "@appsignal/nextjs - next.js@latest - integrations"
       commands:
       - npm install next@latest react@latest react-dom@latest --save-dev
-      - BUNDLE_GEMFILE=packages/nextjs/test/Gemfile bundle install
-      - BUNDLE_GEMFILE=packages/nextjs/test/Gemfile bundle exec rspec packages/nextjs/test
+      - script/test_package_integration nextjs
     - name: "@appsignal/nextjs - next.js@11.0.1 - integrations"
       commands:
       - npm install next@11.0.1 react@17.0.2 react-dom@17.0.2 --save-dev
-      - BUNDLE_GEMFILE=packages/nextjs/test/Gemfile bundle install
-      - BUNDLE_GEMFILE=packages/nextjs/test/Gemfile bundle exec rspec packages/nextjs/test
+      - script/test_package_integration nextjs
     - name: "@appsignal/nextjs - next.js@10.2.3 - integrations"
       commands:
       - npm install next@10.2.3 react@16.14.0 react-dom@16.14.0 --save-dev
-      - BUNDLE_GEMFILE=packages/nextjs/test/Gemfile bundle install
-      - BUNDLE_GEMFILE=packages/nextjs/test/Gemfile bundle exec rspec packages/nextjs/test
+      - script/test_package_integration nextjs
 - name: Node.js 10 - Build
   dependencies:
   - Validation
@@ -613,40 +565,32 @@ blocks:
     - name: "@appsignal/express - express@latest - integrations"
       commands:
       - npm install express@latest --save-dev
-      - BUNDLE_GEMFILE=packages/express/test/Gemfile bundle install
-      - BUNDLE_GEMFILE=packages/express/test/Gemfile bundle exec rspec packages/express/test
+      - script/test_package_integration express
     - name: "@appsignal/express - express@4.17.1 - integrations"
       commands:
       - npm install express@4.17.1 --save-dev
-      - BUNDLE_GEMFILE=packages/express/test/Gemfile bundle install
-      - BUNDLE_GEMFILE=packages/express/test/Gemfile bundle exec rspec packages/express/test
+      - script/test_package_integration express
     - name: "@appsignal/koa - koa@latest - integrations"
       commands:
       - npm install koa@latest --save-dev
-      - BUNDLE_GEMFILE=packages/koa/test/Gemfile bundle install
-      - BUNDLE_GEMFILE=packages/koa/test/Gemfile bundle exec rspec packages/koa/test
+      - script/test_package_integration koa
     - name: "@appsignal/koa - koa@2.13.1 - integrations"
       commands:
       - npm install koa@2.13.1 --save-dev
-      - BUNDLE_GEMFILE=packages/koa/test/Gemfile bundle install
-      - BUNDLE_GEMFILE=packages/koa/test/Gemfile bundle exec rspec packages/koa/test
+      - script/test_package_integration koa
     - name: "@appsignal/koa - koa@2.12.1 - integrations"
       commands:
       - npm install koa@2.12.1 --save-dev
-      - BUNDLE_GEMFILE=packages/koa/test/Gemfile bundle install
-      - BUNDLE_GEMFILE=packages/koa/test/Gemfile bundle exec rspec packages/koa/test
+      - script/test_package_integration koa
     - name: "@appsignal/nextjs - next.js@latest - integrations"
       commands:
       - npm install next@latest react@latest react-dom@latest --save-dev
-      - BUNDLE_GEMFILE=packages/nextjs/test/Gemfile bundle install
-      - BUNDLE_GEMFILE=packages/nextjs/test/Gemfile bundle exec rspec packages/nextjs/test
+      - script/test_package_integration nextjs
     - name: "@appsignal/nextjs - next.js@11.0.1 - integrations"
       commands:
       - npm install next@11.0.1 react@17.0.2 react-dom@17.0.2 --save-dev
-      - BUNDLE_GEMFILE=packages/nextjs/test/Gemfile bundle install
-      - BUNDLE_GEMFILE=packages/nextjs/test/Gemfile bundle exec rspec packages/nextjs/test
+      - script/test_package_integration nextjs
     - name: "@appsignal/nextjs - next.js@10.2.3 - integrations"
       commands:
       - npm install next@10.2.3 react@16.14.0 react-dom@16.14.0 --save-dev
-      - BUNDLE_GEMFILE=packages/nextjs/test/Gemfile bundle install
-      - BUNDLE_GEMFILE=packages/nextjs/test/Gemfile bundle exec rspec packages/nextjs/test
+      - script/test_package_integration nextjs

--- a/build_matrix.yml
+++ b/build_matrix.yml
@@ -101,8 +101,7 @@ matrix:
             express: "4.17.1"
       extra_tests:
         integrations:
-          - BUNDLE_GEMFILE=packages/express/test/Gemfile bundle install
-          - BUNDLE_GEMFILE=packages/express/test/Gemfile bundle exec rspec packages/express/test
+          - script/test_package_integration express
     - package: "@appsignal/koa"
       path: "packages/koa"
       variations:
@@ -117,8 +116,7 @@ matrix:
             koa: "2.12.1"
       extra_tests:
         integrations:
-          - BUNDLE_GEMFILE=packages/koa/test/Gemfile bundle install
-          - BUNDLE_GEMFILE=packages/koa/test/Gemfile bundle exec rspec packages/koa/test
+          - script/test_package_integration koa
     - package: "@appsignal/nextjs"
       path: "packages/nextjs"
       variations:
@@ -139,5 +137,4 @@ matrix:
             react-dom: "16.14.0"
       extra_tests:
         integrations:
-          - BUNDLE_GEMFILE=packages/nextjs/test/Gemfile bundle install
-          - BUNDLE_GEMFILE=packages/nextjs/test/Gemfile bundle exec rspec packages/nextjs/test
+          - script/test_package_integration nextjs

--- a/packages/express/test/.rspec
+++ b/packages/express/test/.rspec
@@ -1,0 +1,2 @@
+--warnings
+--require spec_helper

--- a/packages/express/test/example/index.js
+++ b/packages/express/test/example/index.js
@@ -9,7 +9,7 @@ const appsignal = new Appsignal({
 const express = require("express")
 const { expressMiddleware } = require("@appsignal/express")
 const app = express()
-const port = 3000
+const port = 4010
 
 app.use(expressMiddleware(appsignal))
 

--- a/packages/express/test/spec/integration_spec.rb
+++ b/packages/express/test/spec/integration_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe "Express.js" do
 
   describe "/" do
     before do
-      @result = Net::HTTP.get(URI('http://localhost:3000/?foo=bar'))
+      @result = Net::HTTP.get(URI('http://localhost:4010/?foo=bar'))
     end
 
     it "renders the index page" do
@@ -48,7 +48,7 @@ RSpec.describe "Express.js" do
 
   describe "/dashboard" do
     before do
-      @result = Net::HTTP.get(URI('http://localhost:3000/dashboard?foo=bar'))
+      @result = Net::HTTP.get(URI('http://localhost:4010/dashboard?foo=bar'))
     end
 
     it "renders the page" do
@@ -64,7 +64,7 @@ RSpec.describe "Express.js" do
 
   describe "/admin/dashboard" do
     before do
-      @result = Net::HTTP.get(URI('http://localhost:3000/admin/dashboard?foo=bar'))
+      @result = Net::HTTP.get(URI('http://localhost:4010/admin/dashboard?foo=bar'))
     end
 
     it "renders the page" do

--- a/packages/express/test/spec/spec_helper.rb
+++ b/packages/express/test/spec/spec_helper.rb
@@ -1,0 +1,10 @@
+RSpec.configure do |config|
+  config.example_status_persistence_file_path = "spec/examples.txt"
+  config.fail_if_no_examples = true
+  config.mock_with :rspec do |mocks|
+    mocks.syntax = :expect
+  end
+  config.expect_with :rspec do |expectations|
+    expectations.syntax = :expect
+  end
+end

--- a/packages/koa/test/.rspec
+++ b/packages/koa/test/.rspec
@@ -1,0 +1,2 @@
+--warnings
+--require spec_helper

--- a/packages/koa/test/Gemfile.lock
+++ b/packages/koa/test/Gemfile.lock
@@ -1,0 +1,32 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    coderay (1.1.3)
+    diff-lcs (1.4.4)
+    method_source (1.0.0)
+    pry (0.14.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    rspec (3.10.0)
+      rspec-core (~> 3.10.0)
+      rspec-expectations (~> 3.10.0)
+      rspec-mocks (~> 3.10.0)
+    rspec-core (3.10.1)
+      rspec-support (~> 3.10.0)
+    rspec-expectations (3.10.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.10.0)
+    rspec-mocks (3.10.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.10.0)
+    rspec-support (3.10.2)
+
+PLATFORMS
+  x86_64-darwin-20
+
+DEPENDENCIES
+  pry
+  rspec
+
+BUNDLED WITH
+   2.2.17

--- a/packages/koa/test/example/index.js
+++ b/packages/koa/test/example/index.js
@@ -9,10 +9,11 @@ const appsignal = new Appsignal({
 appsignal.instrument(require("@appsignal/koa"))
 const Koa = require("koa")
 const app = new Koa()
+const port = 4010
 
 app.use(async ctx => {
   ctx.body = "Hello World!"
 })
 
-app.listen(3000)
-console.log("Example app listening at http://localhost:3000")
+app.listen(port)
+console.log(`Example app listening at http://localhost:${port}`)

--- a/packages/koa/test/spec/integration_spec.rb
+++ b/packages/koa/test/spec/integration_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'Express.js' do
     @log_path = File.join(tmpdir, 'appsignal.log')
     command = "APPSIGNAL_LOG_PATH='#{tmpdir}' APPSIGNAL_DEBUG='true' APPSIGNAL_TRANSACTION_DEBUG_MODE='true' node index.js"
 
-    Dir.chdir File.join(__dir__, 'example')
+    Dir.chdir File.expand_path("../example", __dir__)
 
     puts command
     read, write = IO.pipe

--- a/packages/koa/test/spec/integration_spec.rb
+++ b/packages/koa/test/spec/integration_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe 'Express.js' do
 
   describe '/' do
     before do
-      @result = Net::HTTP.get(URI('http://localhost:3000/'))
+      @result = Net::HTTP.get(URI('http://localhost:4010/'))
     end
 
     it 'renders the index page' do

--- a/packages/koa/test/spec/spec_helper.rb
+++ b/packages/koa/test/spec/spec_helper.rb
@@ -1,0 +1,10 @@
+RSpec.configure do |config|
+  config.example_status_persistence_file_path = "spec/examples.txt"
+  config.fail_if_no_examples = true
+  config.mock_with :rspec do |mocks|
+    mocks.syntax = :expect
+  end
+  config.expect_with :rspec do |expectations|
+    expectations.syntax = :expect
+  end
+end

--- a/packages/nextjs/test/.rspec
+++ b/packages/nextjs/test/.rspec
@@ -1,0 +1,2 @@
+--warnings
+--require spec_helper

--- a/packages/nextjs/test/example/server.js
+++ b/packages/nextjs/test/example/server.js
@@ -14,7 +14,7 @@ const url = require("url")
 const next = require("next")
 const { createServer } = require("http")
 
-const PORT = parseInt(process.env.PORT, 10) || 3000
+const PORT = parseInt(process.env.PORT, 10) || 4010
 
 const dev = process.env.NODE_ENV !== "production"
 const app = next({ dev })

--- a/packages/nextjs/test/spec/integration_spec.rb
+++ b/packages/nextjs/test/spec/integration_spec.rb
@@ -2,13 +2,13 @@ require 'net/http'
 require 'tempfile'
 require 'timeout'
 
-RSpec.describe "Express.js" do
+RSpec.describe "Next.js" do
   before(:all) do
     tmpdir = Dir.mktmpdir
     @log_path = File.join(tmpdir, "appsignal.log")
-    command = "APPSIGNAL_LOG_PATH='#{tmpdir}' APPSIGNAL_DEBUG='true' APPSIGNAL_TRANSACTION_DEBUG_MODE='true' node index.js"
+    command = "APPSIGNAL_LOG_PATH='#{tmpdir}' APPSIGNAL_DEBUG='true' APPSIGNAL_TRANSACTION_DEBUG_MODE='true' node server.js"
 
-    Dir.chdir File.join(__dir__, 'example')
+    Dir.chdir File.expand_path("../example", __dir__)
 
     puts command
     read, write = IO.pipe
@@ -17,7 +17,7 @@ RSpec.describe "Express.js" do
     Timeout::timeout(15) do
       read.each do |line|
         puts line
-        break if line =~ /Example app listening at/
+        break if line =~ /Ready on/
       end
     end
   end
@@ -32,11 +32,11 @@ RSpec.describe "Express.js" do
 
   describe "/" do
     before do
-      @result = Net::HTTP.get(URI('http://localhost:3000/?foo=bar'))
+      @result = Net::HTTP.get(URI('http://localhost:3000/'))
     end
 
     it "renders the index page" do
-      expect(@result).to match(/Hello World!/)
+      expect(@result).to match(/Welcome to .+Next\.js!/)
     end
 
     it "sets the root span's name" do
@@ -46,35 +46,36 @@ RSpec.describe "Express.js" do
     end
   end
 
-  describe "/dashboard" do
+  describe "/blog" do
     before do
-      @result = Net::HTTP.get(URI('http://localhost:3000/dashboard?foo=bar'))
+      @result = Net::HTTP.get(URI('http://localhost:3000/blog'))
     end
 
-    it "renders the page" do
-      expect(@result).to match("Dashboard for user")
-    end
-
-    it "renders the dashboard page" do
-      log = File.read(@log_path)
-      expect(/Start root span '(\w+)' in 'web'/.match(log)).to be_truthy()
-      expect(/Set name 'GET \/dashboard' for span '#{$1}'/.match(log)).to be_truthy()
-    end
-  end
-
-  describe "/admin/dashboard" do
-    before do
-      @result = Net::HTTP.get(URI('http://localhost:3000/admin/dashboard?foo=bar'))
-    end
-
-    it "renders the page" do
-      expect(@result).to include("Dashboard for admin")
+    it "renders the index page" do
+      expect(@result).to match(/Blog/)
     end
 
     it "sets the root span's name" do
       log = File.read(@log_path)
       expect(/Start root span '(\w+)' in 'web'/.match(log)).to be_truthy()
-      expect(/Set name 'GET \/admin\/dashboard' for span '#{$1}'/.match(log)).to be_truthy()
+      expect(/Set name 'GET \/blog' for span '#{$1}'/.match(log)).to be_truthy()
+    end
+  end
+
+  describe "/post/1" do
+    before do
+      @result = Net::HTTP.get(URI('http://localhost:3000/post/1'))
+    end
+
+    it "renders the post page" do
+      expect(@result).to match(/Post: /)
+    end
+
+    it "sets the root span's name" do
+      log = File.read(@log_path)
+
+      expect(/Start root span '(\w+)' in 'web'/.match(log)).to be_truthy()
+      expect(/Set name 'GET \/post\/\[id\]' for span '#{$1}'/.match(log)).to be_truthy()
     end
   end
 end

--- a/packages/nextjs/test/spec/integration_spec.rb
+++ b/packages/nextjs/test/spec/integration_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe "Next.js" do
 
   describe "/" do
     before do
-      @result = Net::HTTP.get(URI('http://localhost:3000/'))
+      @result = Net::HTTP.get(URI('http://localhost:4010/'))
     end
 
     it "renders the index page" do
@@ -48,7 +48,7 @@ RSpec.describe "Next.js" do
 
   describe "/blog" do
     before do
-      @result = Net::HTTP.get(URI('http://localhost:3000/blog'))
+      @result = Net::HTTP.get(URI('http://localhost:4010/blog'))
     end
 
     it "renders the index page" do
@@ -64,7 +64,7 @@ RSpec.describe "Next.js" do
 
   describe "/post/1" do
     before do
-      @result = Net::HTTP.get(URI('http://localhost:3000/post/1'))
+      @result = Net::HTTP.get(URI('http://localhost:4010/post/1'))
     end
 
     it "renders the post page" do

--- a/packages/nextjs/test/spec/spec_helper.rb
+++ b/packages/nextjs/test/spec/spec_helper.rb
@@ -1,0 +1,10 @@
+RSpec.configure do |config|
+  config.example_status_persistence_file_path = "spec/examples.txt"
+  config.fail_if_no_examples = true
+  config.mock_with :rspec do |mocks|
+    mocks.syntax = :expect
+  end
+  config.expect_with :rspec do |expectations|
+    expectations.syntax = :expect
+  end
+end

--- a/script/test_package_integration
+++ b/script/test_package_integration
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -eu
+
+package=$1
+
+if [ "$package" == "" ]; then
+  echo "No package specified!"
+  echo "Usage: test_package_integration <package dir>"
+  echo "Example: test_package_integration koa"
+  exit 1
+fi
+
+package_path="packages/$package/test"
+
+if [ ! -d $package_path ]; then
+  echo "No test directory for package $package in $package_path"
+  echo "Please check if the directory exists in the packages/ directory"
+  exit 1
+fi
+
+cd $package_path
+bundle check || bundle install
+bundle exec rspec


### PR DESCRIPTION
Note: some builds for commits have failed on randomly failing diagnose integration tests 🤷‍♂️ I did not want to restart them a lot to get a green build. It is something we need to take a better look at, they should be more stable.

## Commit missing Gemfile.lock file for koa tests

I think this was not included in the original implementation, but it's
best to commit it so that the CI doesn't need to resolve the versions
every time and everyone uses the same versions locally.

## Add RSpec spec helper

Add an RSpec spec helper where we can configure RSpec in and add some
setup that applies to the entire test suite at a later time.

## Move spec files to spec/ directory

This way we don't need to manually specify the path to the test files
when running RSpec.

RSpec will automatically detect test files in the `spec/` directory, but
not the root of the test directory in which the Ruby project exists.

## Add helper script to run integration tests

I've added a convenience helper script to run the integration tests more
easily. Call the script with the package directory as an executable and
it will run the integration tests. No need to set environment variables
and remember/copy-paste the command.

I've also updated the commands for the CI build to use this script as
well.

### Alternative implementation

Rather than set the `BUNDLE_GEMFILE` env variable and specify the path
to run the tests, navigate to the directory with the test suite and run
the test suite from that context. This requires less configuration of
the bundle gemfile and path in which the tests are present.

Instead of always running `bundle install`, first run `bundle check` if
it's really necessary. This will print less output per test run.

## Use port 4010 for integration test apps

Port 3000 is a commonly used port in Ruby apps, which may conflict if
such an app is already running on the local machine.

Change the test port to 4010 instead, a port I think should be
available. We use 4001 already for the test-setups repo.

