### PR TITLE
Refactor integration tests to reuse helpers

### DIFF
--- a/packages/express/test/spec/spec_helper.rb
+++ b/packages/express/test/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+require_relative "../../../../test/support/app_runner"
+
 RSpec.configure do |config|
   config.example_status_persistence_file_path = "spec/examples.txt"
   config.fail_if_no_examples = true

--- a/packages/koa/test/spec/integration_spec.rb
+++ b/packages/koa/test/spec/integration_spec.rb
@@ -1,34 +1,15 @@
-require 'net/http'
-require 'tempfile'
-require 'timeout'
+require "net/http"
 
-RSpec.describe 'Express.js' do
-  before(:all) do
-    tmpdir = Dir.mktmpdir
-    @log_path = File.join(tmpdir, 'appsignal.log')
-    command = "APPSIGNAL_LOG_PATH='#{tmpdir}' APPSIGNAL_DEBUG='true' APPSIGNAL_TRANSACTION_DEBUG_MODE='true' node index.js"
+EXAMPLE_APP_DIR = File.expand_path(File.join("..", "example"), __dir__)
 
-    Dir.chdir File.expand_path("../example", __dir__)
-
-    puts command
-    read, write = IO.pipe
-    @pid = spawn(command, out: write)
-
-    Timeout.timeout(15) do
-      read.each do |line|
-        puts line
-        break if line =~ /Example app listening at/
-      end
-    end
+RSpec.describe "Koa" do
+  before(:context) do
+    @app = AppRunner.new("node index.js", EXAMPLE_APP_DIR)
+    @app.run
+    @app.wait_for_start!("Example app listening at")
   end
-
-  after(:all) do
-    Process.kill 3, @pid
-  end
-
-  after do
-    File.delete(@log_path)
-  end
+  after(:context) { @app.stop }
+  after { @app.cleanup }
 
   describe '/' do
     before do
@@ -40,9 +21,9 @@ RSpec.describe 'Express.js' do
     end
 
     it "sets the root span's name" do
-      log = File.read(@log_path)
-      expect(/Start root span '(\w+)' in 'web'/.match(log)).to be_truthy
-      expect(%r{Set name 'GET /' for span '#{Regexp.last_match(1)}'}.match(log)).to be_truthy
+      log = @app.logs
+      expect(/Start root span '(\w+)' in 'web'/.match(log)).to be_truthy, log
+      expect(%r{Set name 'GET /' for span '#{Regexp.last_match(1)}'}.match(log)).to be_truthy, log
     end
   end
 end

--- a/packages/koa/test/spec/spec_helper.rb
+++ b/packages/koa/test/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+require_relative "../../../../test/support/app_runner"
+
 RSpec.configure do |config|
   config.example_status_persistence_file_path = "spec/examples.txt"
   config.fail_if_no_examples = true

--- a/packages/nextjs/test/example/server.js
+++ b/packages/nextjs/test/example/server.js
@@ -32,6 +32,6 @@ app.prepare().then(() => {
     handle(req, res, parsedUrl)
   }).listen(PORT, err => {
     if (err) throw err
-    console.log(`> Ready on http://localhost:${PORT}`)
+    console.log(`Example app listening at http://localhost:${PORT}`)
   })
 })

--- a/packages/nextjs/test/spec/spec_helper.rb
+++ b/packages/nextjs/test/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+require_relative "../../../../test/support/app_runner"
+
 RSpec.configure do |config|
   config.example_status_persistence_file_path = "spec/examples.txt"
   config.fail_if_no_examples = true

--- a/test/support/app_runner.rb
+++ b/test/support/app_runner.rb
@@ -1,0 +1,100 @@
+require "timeout"
+require "tempfile"
+
+class AppRunner
+  class AppError < StandardError; end
+  class WaitForStartTimeoutError < Timeout::Error; end
+  class StopTimeoutError < Timeout::Error; end
+
+  def initialize(command, dir)
+    @command = command
+    @dir = dir
+    @output_lines = []
+    @output_mutex = Mutex.new
+  end
+
+  # Start the example app
+  def run
+    tmpdir = Dir.mktmpdir
+    @log_path = File.join(tmpdir, "appsignal.log")
+    env = {
+      "APPSIGNAL_LOG_PATH" => tmpdir,
+      "APPSIGNAL_DEBUG" => "true",
+      "APPSIGNAL_TRANSACTION_DEBUG_MODE" => "true"
+    }
+
+    puts "Starting app: #{@command}"
+    read, write = IO.pipe
+    @pid = spawn(env, @command, :out => write, :chdir => @dir)
+    @log_thread =
+      Thread.new do
+        while line = read.readline # rubocop:disable Lint/AssignmentInCondition
+          # Output lines as the program runs
+          puts "| #{line}"
+          # Store the output for later
+          @output_mutex.synchronize do
+            @output_lines << line
+          end
+        end
+      rescue EOFError
+        # Do nothing, nothing to read anymore
+      end
+  end
+
+  # Block execution of the Ruby app until the example app has printed the
+  # String supplied in the `message` argument.
+  def wait_for_start!(message, options = {})
+    Timeout.timeout(options.fetch(:timeout, 15), WaitForStartTimeoutError) do
+      loop do
+        raise AppError, output unless running?
+        break if output.include?(message)
+        sleep 0.05
+      end
+    end
+  end
+
+  # Check if the example app is running or not.
+  # It may have crashed or exited on its own.
+  def running?
+    # Check all processes that are started with the given command.
+    # Filter out any defunct processes that haven't been reaped, like in
+    # containers.
+    processes = `ps aux | grep "#{@command}" | grep -v "defunct" | grep -v "grep"`
+    # Any output remaining? The app must be running.
+    processes.lines.length > 0
+  rescue Errno::ESRCH
+    false
+  end
+
+  # Stop the example app if it is running
+  def stop
+    Timeout.timeout(15, StopTimeoutError) do
+      while running?
+        Process.kill 3, @pid
+        sleep 1
+      end
+    end
+    @log_thread.kill
+  end
+
+  # Remove any temporary files from the file system and clean up the output
+  # stored in memory between tests.
+  def cleanup
+    File.delete(@log_path)
+    @output_mutex.synchronize do
+      @output_lines = []
+    end
+  end
+
+  # Return the output (STDOUT) of the example app
+  def output
+    @output_mutex.synchronize do
+      @output_lines.join("\n")
+    end
+  end
+
+  # Read the AppSignal log file from the file system
+  def logs
+    File.read(@log_path)
+  end
+end


### PR DESCRIPTION
Add an AppRunner class with all the logic to start and stop the example
app. Since it knows a bit about the app, we can also ask it about the
output and the log contents.

With this AppRunner all the behavior is put in one place and not all the
integration specs need to reimplement this.

Remove the usage of `Dir.chdir` which changes the entire Ruby app's
current working directory and pass along the `chdir` option to the
`spawn` command that starts the app so that only the example app is run
in that directory.

Based on #424 

---

Note: The build has failed on randomly failing diagnose integration tests. I did not want to retry it a lot to finally get a green build. It is something we need to take a better look at, they should be more stable.