### PR TITLE
Add RuboCop linter for Ruby code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,4 @@ build/
 packages/nodejs-ext/ext/*.tar.gz
 
 packages/*/test/spec/examples.txt
+tmp

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,72 @@
+AllCops:
+  DisplayCopNames: true
+  UseCache: true
+  CacheRootDirectory: ./tmp
+  NewCops: enable
+  Exclude:
+    - "node_modules/**/*"
+    - "test/integration/diagnose/**/*"
+
+Style/Documentation:
+  Enabled: false
+
+Style/StringLiterals:
+  EnforcedStyle: double_quotes
+
+Style/StringLiteralsInInterpolation:
+  EnforcedStyle: double_quotes
+
+Style/HashSyntax:
+  EnforcedStyle: hash_rockets
+
+Layout/HashAlignment:
+  EnforcedLastArgumentHashStyle: ignore_implicit
+
+Layout/ArgumentAlignment:
+  EnforcedStyle: with_fixed_indentation
+
+Layout/ParameterAlignment:
+  EnforcedStyle: with_fixed_indentation
+
+Layout/MultilineMethodCallIndentation:
+  EnforcedStyle: indented
+
+Layout/MultilineOperationIndentation:
+  EnforcedStyle: indented
+
+Layout/FirstArrayElementIndentation:
+  EnforcedStyle: consistent
+
+Layout/LineEndStringConcatenationIndentation:
+  EnforcedStyle: indented
+
+Layout/EmptyLineBetweenDefs:
+  AllowAdjacentOneLineDefs: true
+
+Layout/LineLength:
+  Max: 100
+
+Style/Lambda:
+  EnforcedStyle: lambda
+
+Style/WordArray:
+  Enabled: false
+
+Style/FrozenStringLiteralComment:
+  Enabled: true
+
+Style/SymbolArray:
+  EnforcedStyle: brackets
+
+Metrics/AbcSize:
+  Enabled: false
+
+Metrics/BlockLength:
+  Exclude:
+    - Rakefile
+    - "**/spec/*.rb"
+
+Metrics/MethodLength:
+  Max: 25
+  Exclude:
+    - Rakefile

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -20,6 +20,8 @@ global_job_config:
     value: test
   - name: _PACKAGES_CACHE
     value: v1
+  - name: _BUNDLER_CACHE
+    value: v1
   prologue:
     commands:
     - checkout
@@ -39,6 +41,14 @@ blocks:
   dependencies: []
   task:
     jobs:
+    - name: Ruby Lint (RuboCop)
+      commands:
+      - cache restore $_BUNDLER_CACHE-bundler-$(checksum Gemfile.lock)
+      - bundle config set clean 'true'
+      - bundle config set path .bundle
+      - bundle install --jobs=3 --retry=3
+      - cache store $_BUNDLER_CACHE-bundler-$(checksum Gemfile.lock) .bundle
+      - bundle exec rubocop
     - name: Git Lint (Lintje)
       env_vars:
       - name: LINTJE_VERSION

--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,4 @@
 
 source "https://rubygems.org"
 
-gem "rspec"
+gem "rubocop"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,32 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    ast (2.4.2)
+    parallel (1.20.1)
+    parser (3.0.2.0)
+      ast (~> 2.4.1)
+    rainbow (3.0.0)
+    regexp_parser (2.1.1)
+    rexml (3.2.5)
+    rubocop (1.18.4)
+      parallel (~> 1.10)
+      parser (>= 3.0.0.0)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml
+      rubocop-ast (>= 1.8.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 3.0)
+    rubocop-ast (1.9.1)
+      parser (>= 3.0.1.1)
+    ruby-progressbar (1.11.0)
+    unicode-display_width (2.0.0)
+
+PLATFORMS
+  x86_64-darwin-20
+
+DEPENDENCIES
+  rubocop
+
+BUNDLED WITH
+   2.2.17

--- a/build_matrix.yml
+++ b/build_matrix.yml
@@ -16,6 +16,8 @@ semaphore: # Default `.semaphore/semaphore.yml` contents
       value: test
     - name: _PACKAGES_CACHE
       value: v1
+    - name: _BUNDLER_CACHE
+      value: v1
     prologue:
       commands:
         - checkout
@@ -36,6 +38,14 @@ semaphore: # Default `.semaphore/semaphore.yml` contents
       dependencies: []
       task:
         jobs:
+        - name: Ruby Lint (RuboCop)
+          commands:
+            - cache restore $_BUNDLER_CACHE-bundler-$(checksum Gemfile.lock)
+            - bundle config set clean 'true'
+            - bundle config set path .bundle
+            - bundle install --jobs=3 --retry=3
+            - cache store $_BUNDLER_CACHE-bundler-$(checksum Gemfile.lock) .bundle
+            - bundle exec rubocop
         - name: Git Lint (Lintje)
           env_vars:
             - name: "LINTJE_VERSION"

--- a/packages/express/test/spec/integration_spec.rb
+++ b/packages/express/test/spec/integration_spec.rb
@@ -24,8 +24,8 @@ RSpec.describe "Express" do
 
     it "sets the root span's name" do
       log = @app.logs
-      expect(/Start root span '(\w+)' in 'web'/.match(log)).to be_truthy, log
-      expect(log).to match(%r{Set name 'GET /' for span '#{Regexp.last_match(1)}'})
+      span_id = fetch_root_span_id(log)
+      expect(log).to include("Set name 'GET /' for span '#{span_id}'")
     end
   end
 
@@ -40,8 +40,8 @@ RSpec.describe "Express" do
 
     it "sets the root span's name" do
       log = @app.logs
-      expect(/Start root span '(\w+)' in 'web'/.match(log)).to be_truthy, log
-      expect(log).to match(%r{Set name 'GET /dashboard' for span '#{Regexp.last_match(1)}'})
+      span_id = fetch_root_span_id(log)
+      expect(log).to include("Set name 'GET /dashboard' for span '#{span_id}'")
     end
   end
 
@@ -56,8 +56,8 @@ RSpec.describe "Express" do
 
     it "sets the root span's name" do
       log = @app.logs
-      expect(/Start root span '(\w+)' in 'web'/.match(log)).to be_truthy, log
-      expect(log).to match(%r{Set name 'GET /admin/dashboard' for span '#{Regexp.last_match(1)}'})
+      span_id = fetch_root_span_id(log)
+      expect(log).to include("Set name 'GET /admin/dashboard' for span '#{span_id}'")
     end
   end
 end

--- a/packages/express/test/spec/integration_spec.rb
+++ b/packages/express/test/spec/integration_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "net/http"
 
 EXAMPLE_APP_DIR = File.expand_path(File.join("..", "example"), __dir__)
@@ -13,7 +15,7 @@ RSpec.describe "Express" do
 
   describe "/" do
     before do
-      @result = Net::HTTP.get(URI('http://localhost:4010/?foo=bar'))
+      @result = Net::HTTP.get(URI("http://localhost:4010/?foo=bar"))
     end
 
     it "renders the index page" do
@@ -23,13 +25,13 @@ RSpec.describe "Express" do
     it "sets the root span's name" do
       log = @app.logs
       expect(/Start root span '(\w+)' in 'web'/.match(log)).to be_truthy, log
-      expect(/Set name 'GET \/' for span '#{$1}'/.match(log)).to be_truthy, log
+      expect(log).to match(%r{Set name 'GET /' for span '#{Regexp.last_match(1)}'})
     end
   end
 
   describe "/dashboard" do
     before do
-      @result = Net::HTTP.get(URI('http://localhost:4010/dashboard?foo=bar'))
+      @result = Net::HTTP.get(URI("http://localhost:4010/dashboard?foo=bar"))
     end
 
     it "renders the page" do
@@ -39,13 +41,13 @@ RSpec.describe "Express" do
     it "sets the root span's name" do
       log = @app.logs
       expect(/Start root span '(\w+)' in 'web'/.match(log)).to be_truthy, log
-      expect(/Set name 'GET \/dashboard' for span '#{$1}'/.match(log)).to be_truthy, log
+      expect(log).to match(%r{Set name 'GET /dashboard' for span '#{Regexp.last_match(1)}'})
     end
   end
 
   describe "/admin/dashboard" do
     before do
-      @result = Net::HTTP.get(URI('http://localhost:4010/admin/dashboard?foo=bar'))
+      @result = Net::HTTP.get(URI("http://localhost:4010/admin/dashboard?foo=bar"))
     end
 
     it "renders the page" do
@@ -55,7 +57,7 @@ RSpec.describe "Express" do
     it "sets the root span's name" do
       log = @app.logs
       expect(/Start root span '(\w+)' in 'web'/.match(log)).to be_truthy, log
-      expect(/Set name 'GET \/admin\/dashboard' for span '#{$1}'/.match(log)).to be_truthy, log
+      expect(log).to match(%r{Set name 'GET /admin/dashboard' for span '#{Regexp.last_match(1)}'})
     end
   end
 end

--- a/packages/express/test/spec/spec_helper.rb
+++ b/packages/express/test/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../../../../test/integration/support/app_runner"
 
 RSpec.configure do |config|

--- a/packages/express/test/spec/spec_helper.rb
+++ b/packages/express/test/spec/spec_helper.rb
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 
-require_relative "../../../../test/integration/support/app_runner"
+require_relative "../../../../test/integration/support"
 
 RSpec.configure do |config|
+  config.include IntegrationHelper
+
   config.example_status_persistence_file_path = "spec/examples.txt"
   config.fail_if_no_examples = true
   config.mock_with :rspec do |mocks|

--- a/packages/koa/test/Gemfile
+++ b/packages/koa/test/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source "https://rubygems.org"
 
 gem "rspec"

--- a/packages/koa/test/spec/integration_spec.rb
+++ b/packages/koa/test/spec/integration_spec.rb
@@ -24,8 +24,8 @@ RSpec.describe "Koa" do
 
     it "sets the root span's name" do
       log = @app.logs
-      expect(/Start root span '(\w+)' in 'web'/.match(log)).to be_truthy, log
-      expect(log).to match(%r{Set name 'GET /' for span '#{Regexp.last_match(1)}'})
+      span_id = fetch_root_span_id(log)
+      expect(log).to include("Set name 'GET /' for span '#{span_id}'")
     end
   end
 end

--- a/packages/koa/test/spec/integration_spec.rb
+++ b/packages/koa/test/spec/integration_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "net/http"
 
 EXAMPLE_APP_DIR = File.expand_path(File.join("..", "example"), __dir__)
@@ -11,19 +13,19 @@ RSpec.describe "Koa" do
   after(:context) { @app.stop }
   after { @app.cleanup }
 
-  describe '/' do
+  describe "/" do
     before do
-      @result = Net::HTTP.get(URI('http://localhost:4010/'))
+      @result = Net::HTTP.get(URI("http://localhost:4010/"))
     end
 
-    it 'renders the index page' do
+    it "renders the index page" do
       expect(@result).to match(/Hello World!/)
     end
 
     it "sets the root span's name" do
       log = @app.logs
       expect(/Start root span '(\w+)' in 'web'/.match(log)).to be_truthy, log
-      expect(%r{Set name 'GET /' for span '#{Regexp.last_match(1)}'}.match(log)).to be_truthy, log
+      expect(log).to match(%r{Set name 'GET /' for span '#{Regexp.last_match(1)}'})
     end
   end
 end

--- a/packages/koa/test/spec/spec_helper.rb
+++ b/packages/koa/test/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../../../../test/integration/support/app_runner"
 
 RSpec.configure do |config|

--- a/packages/koa/test/spec/spec_helper.rb
+++ b/packages/koa/test/spec/spec_helper.rb
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 
-require_relative "../../../../test/integration/support/app_runner"
+require_relative "../../../../test/integration/support"
 
 RSpec.configure do |config|
+  config.include IntegrationHelper
+
   config.example_status_persistence_file_path = "spec/examples.txt"
   config.fail_if_no_examples = true
   config.mock_with :rspec do |mocks|

--- a/packages/nextjs/test/Gemfile
+++ b/packages/nextjs/test/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source "https://rubygems.org"
 
 gem "rspec"

--- a/packages/nextjs/test/spec/integration_spec.rb
+++ b/packages/nextjs/test/spec/integration_spec.rb
@@ -24,8 +24,8 @@ RSpec.describe "Next.js" do
 
     it "sets the root span's name" do
       log = @app.logs
-      expect(/Start root span '(\w+)' in 'web'/.match(log)).to be_truthy
-      expect(log).to match(%r{Set name 'GET /' for span '#{Regexp.last_match(1)}'})
+      span_id = fetch_root_span_id(log)
+      expect(log).to include("Set name 'GET /' for span '#{span_id}'")
     end
   end
 
@@ -40,8 +40,8 @@ RSpec.describe "Next.js" do
 
     it "sets the root span's name" do
       log = @app.logs
-      expect(/Start root span '(\w+)' in 'web'/.match(log)).to be_truthy
-      expect(log).to match(%r{Set name 'GET /blog' for span '#{Regexp.last_match(1)}'})
+      span_id = fetch_root_span_id(log)
+      expect(log).to include("Set name 'GET /blog' for span '#{span_id}'")
     end
   end
 
@@ -56,8 +56,8 @@ RSpec.describe "Next.js" do
 
     it "sets the root span's name" do
       log = @app.logs
-      expect(/Start root span '(\w+)' in 'web'/.match(log)).to be_truthy
-      expect(log).to match(%r{Set name 'GET /post/\[id\]' for span '#{Regexp.last_match(1)}'})
+      span_id = fetch_root_span_id(log)
+      expect(log).to include("Set name 'GET /post/[id]' for span '#{span_id}'")
     end
   end
 end

--- a/packages/nextjs/test/spec/integration_spec.rb
+++ b/packages/nextjs/test/spec/integration_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "net/http"
 
 EXAMPLE_APP_DIR = File.expand_path(File.join("..", "example"), __dir__)
@@ -13,7 +15,7 @@ RSpec.describe "Next.js" do
 
   describe "/" do
     before do
-      @result = Net::HTTP.get(URI('http://localhost:4010/'))
+      @result = Net::HTTP.get(URI("http://localhost:4010/"))
     end
 
     it "renders the index page" do
@@ -22,14 +24,14 @@ RSpec.describe "Next.js" do
 
     it "sets the root span's name" do
       log = @app.logs
-      expect(/Start root span '(\w+)' in 'web'/.match(log)).to be_truthy()
-      expect(/Set name 'GET \/' for span '#{$1}'/.match(log)).to be_truthy()
+      expect(/Start root span '(\w+)' in 'web'/.match(log)).to be_truthy
+      expect(log).to match(%r{Set name 'GET /' for span '#{Regexp.last_match(1)}'})
     end
   end
 
   describe "/blog" do
     before do
-      @result = Net::HTTP.get(URI('http://localhost:4010/blog'))
+      @result = Net::HTTP.get(URI("http://localhost:4010/blog"))
     end
 
     it "renders the index page" do
@@ -38,14 +40,14 @@ RSpec.describe "Next.js" do
 
     it "sets the root span's name" do
       log = @app.logs
-      expect(/Start root span '(\w+)' in 'web'/.match(log)).to be_truthy()
-      expect(/Set name 'GET \/blog' for span '#{$1}'/.match(log)).to be_truthy()
+      expect(/Start root span '(\w+)' in 'web'/.match(log)).to be_truthy
+      expect(log).to match(%r{Set name 'GET /blog' for span '#{Regexp.last_match(1)}'})
     end
   end
 
   describe "/post/1" do
     before do
-      @result = Net::HTTP.get(URI('http://localhost:4010/post/1'))
+      @result = Net::HTTP.get(URI("http://localhost:4010/post/1"))
     end
 
     it "renders the post page" do
@@ -54,8 +56,8 @@ RSpec.describe "Next.js" do
 
     it "sets the root span's name" do
       log = @app.logs
-      expect(/Start root span '(\w+)' in 'web'/.match(log)).to be_truthy()
-      expect(/Set name 'GET \/post\/\[id\]' for span '#{$1}'/.match(log)).to be_truthy()
+      expect(/Start root span '(\w+)' in 'web'/.match(log)).to be_truthy
+      expect(log).to match(%r{Set name 'GET /post/\[id\]' for span '#{Regexp.last_match(1)}'})
     end
   end
 end

--- a/packages/nextjs/test/spec/spec_helper.rb
+++ b/packages/nextjs/test/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../../../../test/integration/support/app_runner"
 
 RSpec.configure do |config|

--- a/packages/nextjs/test/spec/spec_helper.rb
+++ b/packages/nextjs/test/spec/spec_helper.rb
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 
-require_relative "../../../../test/integration/support/app_runner"
+require_relative "../../../../test/integration/support"
 
 RSpec.configure do |config|
+  config.include IntegrationHelper
+
   config.example_status_persistence_file_path = "spec/examples.txt"
   config.fail_if_no_examples = true
   config.mock_with :rspec do |mocks|

--- a/test/integration/support.rb
+++ b/test/integration/support.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+require_relative "support/integration_helper"
+require_relative "support/app_runner"

--- a/test/integration/support/app_runner.rb
+++ b/test/integration/support/app_runner.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "timeout"
 require "tempfile"
 
@@ -48,6 +50,7 @@ class AppRunner
       loop do
         raise AppError, output unless running?
         break if output.include?(message)
+
         sleep 0.05
       end
     end
@@ -61,7 +64,7 @@ class AppRunner
     # containers.
     processes = `ps aux | grep "#{@command}" | grep -v "defunct" | grep -v "grep"`
     # Any output remaining? The app must be running.
-    processes.lines.length > 0
+    processes.lines.any?
   rescue Errno::ESRCH
     false
   end

--- a/test/integration/support/integration_helper.rb
+++ b/test/integration/support/integration_helper.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module IntegrationHelper
+  def fetch_root_span_id(log)
+    span_id = /Start root span '(\w+)' in '\w+'/.match(log).captures.last
+    raise "Span ID was empty for root span.\n#{log}" if span_id.strip.empty?
+
+    span_id
+  end
+end


### PR DESCRIPTION
Parts of the repository contains Ruby code. Let's add RuboCop to it to
ensure we follow a common code style.

I modernized the Ruby gem's RuboCop config (as it's locked on an older
version of RuboCop) and made it consistent with the RuboCop config in
the diagnose tests repo.

https://github.com/appsignal/diagnose_tests/pull/6