### PR TITLE
Use fetch_root_span_id helper in integration specs

### DIFF
--- a/packages/express/test/spec/integration_spec.rb
+++ b/packages/express/test/spec/integration_spec.rb
@@ -24,8 +24,8 @@ RSpec.describe "Express" do
 
     it "sets the root span's name" do
       log = @app.logs
-      expect(/Start root span '(\w+)' in 'web'/.match(log)).to be_truthy, log
-      expect(log).to match(%r{Set name 'GET /' for span '#{Regexp.last_match(1)}'})
+      span_id = fetch_root_span_id(log)
+      expect(log).to include("Set name 'GET /' for span '#{span_id}'")
     end
   end
 
@@ -40,8 +40,8 @@ RSpec.describe "Express" do
 
     it "sets the root span's name" do
       log = @app.logs
-      expect(/Start root span '(\w+)' in 'web'/.match(log)).to be_truthy, log
-      expect(log).to match(%r{Set name 'GET /dashboard' for span '#{Regexp.last_match(1)}'})
+      span_id = fetch_root_span_id(log)
+      expect(log).to include("Set name 'GET /dashboard' for span '#{span_id}'")
     end
   end
 
@@ -56,8 +56,8 @@ RSpec.describe "Express" do
 
     it "sets the root span's name" do
       log = @app.logs
-      expect(/Start root span '(\w+)' in 'web'/.match(log)).to be_truthy, log
-      expect(log).to match(%r{Set name 'GET /admin/dashboard' for span '#{Regexp.last_match(1)}'})
+      span_id = fetch_root_span_id(log)
+      expect(log).to include("Set name 'GET /admin/dashboard' for span '#{span_id}'")
     end
   end
 end

--- a/packages/express/test/spec/spec_helper.rb
+++ b/packages/express/test/spec/spec_helper.rb
@@ -1,8 +1,11 @@
 # frozen_string_literal: true
 
+require_relative "../../../../test/integration/support/integration_helper"
 require_relative "../../../../test/integration/support/app_runner"
 
 RSpec.configure do |config|
+  config.include IntegrationHelper
+
   config.example_status_persistence_file_path = "spec/examples.txt"
   config.fail_if_no_examples = true
   config.mock_with :rspec do |mocks|

--- a/packages/express/test/spec/spec_helper.rb
+++ b/packages/express/test/spec/spec_helper.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-require_relative "../../../../test/integration/support/integration_helper"
-require_relative "../../../../test/integration/support/app_runner"
+require_relative "../../../../test/integration/support"
 
 RSpec.configure do |config|
   config.include IntegrationHelper

--- a/packages/koa/test/spec/integration_spec.rb
+++ b/packages/koa/test/spec/integration_spec.rb
@@ -24,8 +24,8 @@ RSpec.describe "Koa" do
 
     it "sets the root span's name" do
       log = @app.logs
-      expect(/Start root span '(\w+)' in 'web'/.match(log)).to be_truthy, log
-      expect(log).to match(%r{Set name 'GET /' for span '#{Regexp.last_match(1)}'})
+      span_id = fetch_root_span_id(log)
+      expect(log).to include("Set name 'GET /' for span '#{span_id}'")
     end
   end
 end

--- a/packages/koa/test/spec/spec_helper.rb
+++ b/packages/koa/test/spec/spec_helper.rb
@@ -1,8 +1,11 @@
 # frozen_string_literal: true
 
+require_relative "../../../../test/integration/support/integration_helper"
 require_relative "../../../../test/integration/support/app_runner"
 
 RSpec.configure do |config|
+  config.include IntegrationHelper
+
   config.example_status_persistence_file_path = "spec/examples.txt"
   config.fail_if_no_examples = true
   config.mock_with :rspec do |mocks|

--- a/packages/koa/test/spec/spec_helper.rb
+++ b/packages/koa/test/spec/spec_helper.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-require_relative "../../../../test/integration/support/integration_helper"
-require_relative "../../../../test/integration/support/app_runner"
+require_relative "../../../../test/integration/support"
 
 RSpec.configure do |config|
   config.include IntegrationHelper

--- a/packages/nextjs/test/spec/integration_spec.rb
+++ b/packages/nextjs/test/spec/integration_spec.rb
@@ -24,8 +24,8 @@ RSpec.describe "Next.js" do
 
     it "sets the root span's name" do
       log = @app.logs
-      expect(/Start root span '(\w+)' in 'web'/.match(log)).to be_truthy
-      expect(log).to match(%r{Set name 'GET /' for span '#{Regexp.last_match(1)}'})
+      span_id = fetch_root_span_id(log)
+      expect(log).to include("Set name 'GET /' for span '#{span_id}'")
     end
   end
 
@@ -40,8 +40,8 @@ RSpec.describe "Next.js" do
 
     it "sets the root span's name" do
       log = @app.logs
-      expect(/Start root span '(\w+)' in 'web'/.match(log)).to be_truthy
-      expect(log).to match(%r{Set name 'GET /blog' for span '#{Regexp.last_match(1)}'})
+      span_id = fetch_root_span_id(log)
+      expect(log).to include("Set name 'GET /blog' for span '#{span_id}'")
     end
   end
 
@@ -56,8 +56,8 @@ RSpec.describe "Next.js" do
 
     it "sets the root span's name" do
       log = @app.logs
-      expect(/Start root span '(\w+)' in 'web'/.match(log)).to be_truthy
-      expect(log).to match(%r{Set name 'GET /post/\[id\]' for span '#{Regexp.last_match(1)}'})
+      span_id = fetch_root_span_id(log)
+      expect(log).to include("Set name 'GET /post/[id]' for span '#{span_id}'")
     end
   end
 end

--- a/packages/nextjs/test/spec/spec_helper.rb
+++ b/packages/nextjs/test/spec/spec_helper.rb
@@ -1,8 +1,11 @@
 # frozen_string_literal: true
 
+require_relative "../../../../test/integration/support/integration_helper"
 require_relative "../../../../test/integration/support/app_runner"
 
 RSpec.configure do |config|
+  config.include IntegrationHelper
+
   config.example_status_persistence_file_path = "spec/examples.txt"
   config.fail_if_no_examples = true
   config.mock_with :rspec do |mocks|

--- a/packages/nextjs/test/spec/spec_helper.rb
+++ b/packages/nextjs/test/spec/spec_helper.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-require_relative "../../../../test/integration/support/integration_helper"
-require_relative "../../../../test/integration/support/app_runner"
+require_relative "../../../../test/integration/support"
 
 RSpec.configure do |config|
   config.include IntegrationHelper

--- a/test/integration/support.rb
+++ b/test/integration/support.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+require_relative "support/integration_helper"
+require_relative "support/app_runner"

--- a/test/integration/support/integration_helper.rb
+++ b/test/integration/support/integration_helper.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module IntegrationHelper
+  def fetch_root_span_id(log)
+    span_id = /Start root span '(\w+)' in '\w+'/.match(log).captures.last
+    raise "Span ID was empty for root span.\n#{log}" if span_id.strip.empty?
+
+    span_id
+  end
+end


### PR DESCRIPTION
Based on #426 
[skip changeset]

## Use fetch_root_span_id helper in integration specs

Add a `fetch_root_span_id` helper that will extract the root span id
from the logs. This mean we won't have to repeat that logic for every
spec or every spec file. It's a common pattern that we do not need to
repeat.

It doesn't match the namespace name now. If we need to match that we can
also add an option to the helper that adds the namespace to the regular
expression.

The log line match we do using the span id doesn't need to be a regular
express, we only match a plain string, remove the regular express and
use `String#include` instead.

## Merge integration support requires into one file

Add a single file that requires all integration spec support files. This
way we don't need to manually require them in every spec_helper for
every page, every time we add a new file. Update the `support.rb` file
and it's included in all specs.

