### PR TITLE
Add Apollo integration tests

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -100,6 +100,22 @@ blocks:
       commands:
       - mono test --package=@appsignal/nodejs-ext
       - mono run --package @appsignal/nodejs-ext -- npm run test:failure
+    - name: "@appsignal/apollo-server - apollo-server@latest - integrations"
+      commands:
+      - script/install_test_example_packages apollo-server apollo-server-plugin-base@latest
+      - script/test_package_integration apollo-server
+    - name: "@appsignal/apollo-server - apollo-server@0.13.0 - integrations"
+      commands:
+      - script/install_test_example_packages apollo-server apollo-server-plugin-base@0.13.0
+      - script/test_package_integration apollo-server
+    - name: "@appsignal/apollo-server - apollo-server@0.12.0 - integrations"
+      commands:
+      - script/install_test_example_packages apollo-server apollo-server-plugin-base@0.12.0
+      - script/test_package_integration apollo-server
+    - name: "@appsignal/apollo-server - apollo-server@0.11.0 - integrations"
+      commands:
+      - script/install_test_example_packages apollo-server apollo-server-plugin-base@0.11.0
+      - script/test_package_integration apollo-server
     - name: "@appsignal/express - express@latest - integrations"
       commands:
       - script/install_test_example_packages express express@latest
@@ -178,6 +194,22 @@ blocks:
       commands:
       - mono test --package=@appsignal/nodejs-ext
       - mono run --package @appsignal/nodejs-ext -- npm run test:failure
+    - name: "@appsignal/apollo-server - apollo-server@latest - integrations"
+      commands:
+      - script/install_test_example_packages apollo-server apollo-server-plugin-base@latest
+      - script/test_package_integration apollo-server
+    - name: "@appsignal/apollo-server - apollo-server@0.13.0 - integrations"
+      commands:
+      - script/install_test_example_packages apollo-server apollo-server-plugin-base@0.13.0
+      - script/test_package_integration apollo-server
+    - name: "@appsignal/apollo-server - apollo-server@0.12.0 - integrations"
+      commands:
+      - script/install_test_example_packages apollo-server apollo-server-plugin-base@0.12.0
+      - script/test_package_integration apollo-server
+    - name: "@appsignal/apollo-server - apollo-server@0.11.0 - integrations"
+      commands:
+      - script/install_test_example_packages apollo-server apollo-server-plugin-base@0.11.0
+      - script/test_package_integration apollo-server
     - name: "@appsignal/express - express@latest - integrations"
       commands:
       - script/install_test_example_packages express express@latest
@@ -256,6 +288,22 @@ blocks:
       commands:
       - mono test --package=@appsignal/nodejs-ext
       - mono run --package @appsignal/nodejs-ext -- npm run test:failure
+    - name: "@appsignal/apollo-server - apollo-server@latest - integrations"
+      commands:
+      - script/install_test_example_packages apollo-server apollo-server-plugin-base@latest
+      - script/test_package_integration apollo-server
+    - name: "@appsignal/apollo-server - apollo-server@0.13.0 - integrations"
+      commands:
+      - script/install_test_example_packages apollo-server apollo-server-plugin-base@0.13.0
+      - script/test_package_integration apollo-server
+    - name: "@appsignal/apollo-server - apollo-server@0.12.0 - integrations"
+      commands:
+      - script/install_test_example_packages apollo-server apollo-server-plugin-base@0.12.0
+      - script/test_package_integration apollo-server
+    - name: "@appsignal/apollo-server - apollo-server@0.11.0 - integrations"
+      commands:
+      - script/install_test_example_packages apollo-server apollo-server-plugin-base@0.11.0
+      - script/test_package_integration apollo-server
     - name: "@appsignal/express - express@latest - integrations"
       commands:
       - script/install_test_example_packages express express@latest
@@ -334,6 +382,22 @@ blocks:
       commands:
       - mono test --package=@appsignal/nodejs-ext
       - mono run --package @appsignal/nodejs-ext -- npm run test:failure
+    - name: "@appsignal/apollo-server - apollo-server@latest - integrations"
+      commands:
+      - script/install_test_example_packages apollo-server apollo-server-plugin-base@latest
+      - script/test_package_integration apollo-server
+    - name: "@appsignal/apollo-server - apollo-server@0.13.0 - integrations"
+      commands:
+      - script/install_test_example_packages apollo-server apollo-server-plugin-base@0.13.0
+      - script/test_package_integration apollo-server
+    - name: "@appsignal/apollo-server - apollo-server@0.12.0 - integrations"
+      commands:
+      - script/install_test_example_packages apollo-server apollo-server-plugin-base@0.12.0
+      - script/test_package_integration apollo-server
+    - name: "@appsignal/apollo-server - apollo-server@0.11.0 - integrations"
+      commands:
+      - script/install_test_example_packages apollo-server apollo-server-plugin-base@0.11.0
+      - script/test_package_integration apollo-server
     - name: "@appsignal/express - express@latest - integrations"
       commands:
       - script/install_test_example_packages express express@latest
@@ -412,6 +476,22 @@ blocks:
       commands:
       - mono test --package=@appsignal/nodejs-ext
       - mono run --package @appsignal/nodejs-ext -- npm run test:failure
+    - name: "@appsignal/apollo-server - apollo-server@latest - integrations"
+      commands:
+      - script/install_test_example_packages apollo-server apollo-server-plugin-base@latest
+      - script/test_package_integration apollo-server
+    - name: "@appsignal/apollo-server - apollo-server@0.13.0 - integrations"
+      commands:
+      - script/install_test_example_packages apollo-server apollo-server-plugin-base@0.13.0
+      - script/test_package_integration apollo-server
+    - name: "@appsignal/apollo-server - apollo-server@0.12.0 - integrations"
+      commands:
+      - script/install_test_example_packages apollo-server apollo-server-plugin-base@0.12.0
+      - script/test_package_integration apollo-server
+    - name: "@appsignal/apollo-server - apollo-server@0.11.0 - integrations"
+      commands:
+      - script/install_test_example_packages apollo-server apollo-server-plugin-base@0.11.0
+      - script/test_package_integration apollo-server
     - name: "@appsignal/express - express@latest - integrations"
       commands:
       - script/install_test_example_packages express express@latest

--- a/build_matrix.yml
+++ b/build_matrix.yml
@@ -94,6 +94,9 @@ matrix:
         - name: "apollo-server@0.11.0"
           packages:
             apollo-server-plugin-base: "0.11.0"
+      extra_tests:
+        integrations:
+          - script/test_package_integration apollo-server
     - package: "@appsignal/express"
       path: "packages/express"
       variations:

--- a/packages/apollo-server/test/.rspec
+++ b/packages/apollo-server/test/.rspec
@@ -1,0 +1,2 @@
+--warnings
+--require spec_helper

--- a/packages/apollo-server/test/Gemfile
+++ b/packages/apollo-server/test/Gemfile
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gem "rspec"

--- a/packages/apollo-server/test/Gemfile.lock
+++ b/packages/apollo-server/test/Gemfile.lock
@@ -1,0 +1,26 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    diff-lcs (1.4.4)
+    rspec (3.10.0)
+      rspec-core (~> 3.10.0)
+      rspec-expectations (~> 3.10.0)
+      rspec-mocks (~> 3.10.0)
+    rspec-core (3.10.1)
+      rspec-support (~> 3.10.0)
+    rspec-expectations (3.10.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.10.0)
+    rspec-mocks (3.10.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.10.0)
+    rspec-support (3.10.2)
+
+PLATFORMS
+  x86_64-darwin-20
+
+DEPENDENCIES
+  rspec
+
+BUNDLED WITH
+   2.2.25

--- a/packages/apollo-server/test/example/index.js
+++ b/packages/apollo-server/test/example/index.js
@@ -1,0 +1,58 @@
+const { Appsignal } = require("../../../nodejs")
+const { createApolloPlugin } = require("../../../apollo-server")
+
+const appsignal = new Appsignal({
+  active: true,
+  name: "<YOUR APPLICATION NAME>",
+  apiKey: "<YOUR API KEY>"
+})
+
+const { ApolloServer, gql } = require("apollo-server")
+
+// A schema is a collection of type definitions (hence "typeDefs")
+// that together define the "shape" of queries that are executed against
+// your data.
+const typeDefs = gql`
+  # Comments in GraphQL strings (such as this one) start with the hash (#) symbol.
+
+  # This "Book" type defines the queryable fields for every book in our data source.
+  type Book {
+    title: String
+    author: String
+  }
+
+  # The "Query" type is special: it lists all of the available queries that
+  # clients can execute, along with the return type for each. In this
+  # case, the "books" query returns an array of zero or more Books (defined above).
+  type Query {
+    books: [Book]
+  }
+`
+
+const books = [
+  {
+    title: "The Awakening",
+    author: "Kate Chopin"
+  },
+  {
+    title: "City of Glass",
+    author: "Paul Auster"
+  }
+]
+
+// Resolvers define the technique for fetching the types defined in the
+// schema. This resolver retrieves books from the "books" array above.
+const resolvers = {
+  Query: {
+    books: () => books
+  }
+}
+
+// The ApolloServer constructor requires two parameters: your schema
+// definition and your set of resolvers.
+const server = new ApolloServer({ typeDefs, resolvers })
+
+// The `listen` method launches a web server.
+server.listen({ port: 4010 }).then(({ url }) => {
+  console.log(`🚀  Server ready at ${url}`)
+})

--- a/packages/apollo-server/test/example/package.json
+++ b/packages/apollo-server/test/example/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "example",
+  "private": true,
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "apollo-server": "*",
+    "graphql": "*"
+  }
+}

--- a/packages/apollo-server/test/spec/integration_spec.rb
+++ b/packages/apollo-server/test/spec/integration_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "net/http"
+
+EXAMPLE_APP_DIR = File.expand_path(File.join("..", "example"), __dir__)
+
+RSpec.describe "Next.js" do
+  before(:context) do
+    @app = AppRunner.new("npm run start", EXAMPLE_APP_DIR)
+    @app.run
+    @app.wait_for_start!("Server ready at")
+  end
+  after(:context) { @app.stop }
+  after { @app.cleanup }
+
+  describe "POST /" do
+    before do
+      uri = URI("http://localhost:4010/")
+      http = Net::HTTP.new(uri.host, uri.port)
+      request = Net::HTTP::Post.new(uri.request_uri)
+      request["Content-Type"] = "application/json"
+      request.body = '{"query":"query { __typename }"}'
+      @response = http.request(request).body
+    end
+
+    it "sets the root span's name" do
+      expect(@response).to match('{"data":{"__typename":"Query"}}')
+
+      log = @app.logs
+      span_id = fetch_root_span_id(log)
+      expect(log).to include("Set name 'POST /' for span '#{span_id}'")
+    end
+  end
+end

--- a/packages/apollo-server/test/spec/spec_helper.rb
+++ b/packages/apollo-server/test/spec/spec_helper.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require_relative "../../../../test/integration/support"
+
+RSpec.configure do |config|
+  config.include IntegrationHelper
+
+  config.example_status_persistence_file_path = "spec/examples.txt"
+  config.fail_if_no_examples = true
+  config.mock_with :rspec do |mocks|
+    mocks.syntax = :expect
+  end
+  config.expect_with :rspec do |expectations|
+    expectations.syntax = :expect
+  end
+end


### PR DESCRIPTION
The example app is based on the "getting started" guide at
https://www.apollographql.com/docs/apollo-server/getting-started/

The integration tests are based on the same structure as the integration
tests for other packages in this repository.

[skip changeset] because it only affects our test suite.
[skip review]

## Blocked on

- https://github.com/appsignal/appsignal-nodejs/pull/431
- https://github.com/appsignal/appsignal-nodejs/pull/432