### PR TITLE
Fix timestamp calculation

### DIFF
--- a/packages/nodejs/.changesets/timestamp-fix.md
+++ b/packages/nodejs/.changesets/timestamp-fix.md
@@ -1,0 +1,5 @@
+---
+bump: "patch"
+---
+
+Bug fix in custom timestamp calculation

--- a/packages/nodejs/src/__tests__/utils.test.ts
+++ b/packages/nodejs/src/__tests__/utils.test.ts
@@ -1,0 +1,12 @@
+import { getAgentTimestamps } from "../utils"
+
+describe("Utils", () => {
+  describe("getAgentTimestamps", () => {
+    it("calculates the timeestamp", () => {
+      const timestamp = getAgentTimestamps(1_589_192_966_108)
+
+      expect(timestamp.sec).toEqual(1_589_192_966)
+      expect(timestamp.nsec).toEqual(108000000)
+    })
+  })
+})

--- a/packages/nodejs/src/utils.ts
+++ b/packages/nodejs/src/utils.ts
@@ -23,8 +23,9 @@ export function getPackageVerson(basedir: string): string {
  * @function
  */
 export function getAgentTimestamps(timestamp: number) {
+  const sec = Math.round(timestamp / 1000)
   return {
-    sec: Math.round(timestamp / 1000), // seconds
-    nsec: Math.round(timestamp * 1e6) // nanoseconds
+    sec: sec, // seconds
+    nsec: timestamp * 1e6 - sec * 1e9 // nanoseconds
   }
 }


### PR DESCRIPTION
We had an incorrect calculation in place for custom timestamps. Add a test for that and fix it.
