### PR TITLE
Improve install report generation

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -65,6 +65,10 @@ blocks:
       - cache restore
       - mono bootstrap --ci
       - cache store
+    epilogue: &1
+      on_fail:
+        commands:
+        - cat /tmp/appsignal-*-install.report
     jobs:
     - name: Build
       commands:
@@ -87,6 +91,7 @@ blocks:
       - cache restore $_PACKAGES_CACHE-packages-$SEMAPHORE_GIT_SHA-v$NODE_VERSION
       - cache restore $_PACKAGES_CACHE-install-report-$SEMAPHORE_GIT_SHA-v$NODE_VERSION
       - mono bootstrap --ci
+    epilogue: *1
     jobs:
     - name: "@appsignal/nodejs - nodejs"
       commands:
@@ -160,6 +165,7 @@ blocks:
       - cache restore
       - mono bootstrap --ci
       - cache store
+    epilogue: *1
     jobs:
     - name: Build
       commands:
@@ -181,6 +187,7 @@ blocks:
       - cache restore $_PACKAGES_CACHE-packages-$SEMAPHORE_GIT_SHA-v$NODE_VERSION
       - cache restore $_PACKAGES_CACHE-install-report-$SEMAPHORE_GIT_SHA-v$NODE_VERSION
       - mono bootstrap --ci
+    epilogue: *1
     jobs:
     - name: "@appsignal/nodejs - nodejs"
       commands:
@@ -254,6 +261,7 @@ blocks:
       - cache restore
       - mono bootstrap --ci
       - cache store
+    epilogue: *1
     jobs:
     - name: Build
       commands:
@@ -275,6 +283,7 @@ blocks:
       - cache restore $_PACKAGES_CACHE-packages-$SEMAPHORE_GIT_SHA-v$NODE_VERSION
       - cache restore $_PACKAGES_CACHE-install-report-$SEMAPHORE_GIT_SHA-v$NODE_VERSION
       - mono bootstrap --ci
+    epilogue: *1
     jobs:
     - name: "@appsignal/nodejs - nodejs"
       commands:
@@ -348,6 +357,7 @@ blocks:
       - cache restore
       - mono bootstrap --ci
       - cache store
+    epilogue: *1
     jobs:
     - name: Build
       commands:
@@ -369,6 +379,7 @@ blocks:
       - cache restore $_PACKAGES_CACHE-packages-$SEMAPHORE_GIT_SHA-v$NODE_VERSION
       - cache restore $_PACKAGES_CACHE-install-report-$SEMAPHORE_GIT_SHA-v$NODE_VERSION
       - mono bootstrap --ci
+    epilogue: *1
     jobs:
     - name: "@appsignal/nodejs - nodejs"
       commands:
@@ -442,6 +453,7 @@ blocks:
       - cache restore
       - mono bootstrap --ci
       - cache store
+    epilogue: *1
     jobs:
     - name: Build
       commands:
@@ -463,6 +475,7 @@ blocks:
       - cache restore $_PACKAGES_CACHE-packages-$SEMAPHORE_GIT_SHA-v$NODE_VERSION
       - cache restore $_PACKAGES_CACHE-install-report-$SEMAPHORE_GIT_SHA-v$NODE_VERSION
       - mono bootstrap --ci
+    epilogue: *1
     jobs:
     - name: "@appsignal/nodejs - nodejs"
       commands:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -73,7 +73,6 @@ blocks:
     - name: Build
       commands:
       - mono build
-      - mono run --package @appsignal/nodejs-ext -- npm run build:ext
       - cache store $_PACKAGES_CACHE-packages-$SEMAPHORE_GIT_SHA-v$NODE_VERSION packages
       - cache store $_PACKAGES_CACHE-install-report-$SEMAPHORE_GIT_SHA-v$NODE_VERSION
         /tmp/appsignal-*-install.report
@@ -170,7 +169,6 @@ blocks:
     - name: Build
       commands:
       - mono build
-      - mono run --package @appsignal/nodejs-ext -- npm run build:ext
       - cache store $_PACKAGES_CACHE-packages-$SEMAPHORE_GIT_SHA-v$NODE_VERSION packages
       - cache store $_PACKAGES_CACHE-install-report-$SEMAPHORE_GIT_SHA-v$NODE_VERSION
         /tmp/appsignal-*-install.report
@@ -266,7 +264,6 @@ blocks:
     - name: Build
       commands:
       - mono build
-      - mono run --package @appsignal/nodejs-ext -- npm run build:ext
       - cache store $_PACKAGES_CACHE-packages-$SEMAPHORE_GIT_SHA-v$NODE_VERSION packages
       - cache store $_PACKAGES_CACHE-install-report-$SEMAPHORE_GIT_SHA-v$NODE_VERSION
         /tmp/appsignal-*-install.report
@@ -362,7 +359,6 @@ blocks:
     - name: Build
       commands:
       - mono build
-      - mono run --package @appsignal/nodejs-ext -- npm run build:ext
       - cache store $_PACKAGES_CACHE-packages-$SEMAPHORE_GIT_SHA-v$NODE_VERSION packages
       - cache store $_PACKAGES_CACHE-install-report-$SEMAPHORE_GIT_SHA-v$NODE_VERSION
         /tmp/appsignal-*-install.report
@@ -458,7 +454,6 @@ blocks:
     - name: Build
       commands:
       - mono build
-      - mono run --package @appsignal/nodejs-ext -- npm run build:ext
       - cache store $_PACKAGES_CACHE-packages-$SEMAPHORE_GIT_SHA-v$NODE_VERSION packages
       - cache store $_PACKAGES_CACHE-install-report-$SEMAPHORE_GIT_SHA-v$NODE_VERSION
         /tmp/appsignal-*-install.report

--- a/Rakefile
+++ b/Rakefile
@@ -27,6 +27,7 @@ namespace :build_matrix do
                 "cache store"
               ]
             },
+            "epilogue" => matrix["epilogue"],
             "jobs" => [
               build_semaphore_job(
                 "name" => "Build",
@@ -107,6 +108,7 @@ namespace :build_matrix do
                   "mono bootstrap --ci"
                 ]
               },
+              "epilogue" => matrix["epilogue"],
               "jobs" => primary_jobs
             }
           )

--- a/Rakefile
+++ b/Rakefile
@@ -33,7 +33,6 @@ namespace :build_matrix do
                 "name" => "Build",
                 "commands" => [
                   "mono build",
-                  "mono run --package @appsignal/nodejs-ext -- npm run build:ext",
                   "cache store $_PACKAGES_CACHE-packages-$SEMAPHORE_GIT_SHA-v$NODE_VERSION " \
                     "packages",
                   "cache store $_PACKAGES_CACHE-install-report-$SEMAPHORE_GIT_SHA-v$NODE_VERSION " \

--- a/build_matrix.yml
+++ b/build_matrix.yml
@@ -51,6 +51,11 @@ semaphore: # Default `.semaphore/semaphore.yml` contents
             - script/lint_git
 
 matrix:
+  epilogue: # Shared for all jobs in the build matrix
+    on_fail:
+      commands:
+        - "cat /tmp/appsignal-*-install.report"
+
   nodejs:
     - nodejs: "16"
       setup:

--- a/packages/nodejs-ext/.changesets/installation-report-improvements.md
+++ b/packages/nodejs-ext/.changesets/installation-report-improvements.md
@@ -1,0 +1,5 @@
+---
+bump: "patch"
+---
+
+Report a more accurate state of the AppSignal extension installation on failures. Useful for the AppSignal team when debugging.

--- a/packages/nodejs-ext/.changesets/track-extension-installation-source.md
+++ b/packages/nodejs-ext/.changesets/track-extension-installation-source.md
@@ -1,0 +1,5 @@
+---
+bump: "patch"
+---
+
+Track AppSignal extension installation source in the installation report. Used by the AppSignal team when debugging.

--- a/packages/nodejs-ext/scripts/extension.js
+++ b/packages/nodejs-ext/scripts/extension.js
@@ -155,18 +155,20 @@ function install() {
   const filename = metadata.downloadUrl.split("/")[4]
   const outputPath = path.join(EXT_PATH, filename)
 
+  report.download = createDownloadReport({
+    download_url: metadata.downloadUrl
+  })
   return download(metadata.downloadUrl, outputPath)
     .then(filepath =>
-      verify(filepath, metadata.checksum).then(() => extract(filepath))
+      verify(filepath, metadata.checksum).then(() => {
+        report.download.checksum = "verified"
+        return extract(filepath)
+      })
     )
     .then(() => {
       // @TODO: add cleanup step
       console.log("The agent has downloaded successfully! Building...")
 
-      report.download = createDownloadReport({
-        verified: true,
-        downloadUrl: metadata.downloadUrl
-      })
       report.result.status = "unknown"
 
       // Once extracted, we hand it off to node-gyp for building
@@ -187,10 +189,6 @@ function install() {
         error: error.message,
         backtrace: error.stack.split("\n")
       }
-      report.download = createDownloadReport({
-        verified: false,
-        downloadUrl: metadata.downloadUrl
-      })
 
       return dumpReport(report).then(() => {
         process.exit(1)

--- a/packages/nodejs-ext/scripts/extension.js
+++ b/packages/nodejs-ext/scripts/extension.js
@@ -155,6 +155,7 @@ function install() {
   const filename = metadata.downloadUrl.split("/")[4]
   const outputPath = path.join(EXT_PATH, filename)
 
+  report.build.source = "remote"
   report.download = createDownloadReport({
     download_url: metadata.downloadUrl
   })

--- a/packages/nodejs-ext/scripts/report.js
+++ b/packages/nodejs-ext/scripts/report.js
@@ -69,11 +69,11 @@ function createBuildReport({ isLocalBuild = false }) {
   }
 }
 
-function createDownloadReport({ verified = false, downloadUrl: download_url }) {
+function createDownloadReport(report) {
   return {
-    checksum: verified ? "verified" : "unverified",
+    checksum: "unverified",
     http_proxy: null,
-    download_url
+    ...report
   }
 }
 


### PR DESCRIPTION
## Print install report on job failure

When the build or test jobs fail, print the extension installation
report. Something may have gone wrong with the installation and being
able to view that right on the job page is very useful. Otherwise we
would need to SSH to the job and read it from the filesystem.

I've added it to the build matrix as a custom property "epilogue"
that's copied to all build and test jobs, so it's easy to customize
it later.

## Remove redundant extension install command

The extension is already installed in the `mono bootstrap` command,
calling `npm install` in each package (calling `npm run install` in the
nodejs-ext package).

Running this script again will only work if the agent and extension
files have already been downloaded and extracted, which is done via
`mono bootstrap`.

## Update diagnose submodule with report fixes

Fix the write location of the dummy install report used by the diagnose
report test suite.

This was changed in #412 but never updated in the diagnose tests repo.

See also PR appsignal/diagnose_tests#8

## Improve install report generation

Only set the download report once, before it's downloaded and update it
along the different steps in the process. Only set if the download was
verified when it was verified, and default to "unverified".

This way we don't have to generate the report twice (success and failure
state), and it's more accurate in reflecting the state throughout the
process, and when it fails during one of the steps.

## Set build source location in the install report

The install report did not track which source was used during
installation. Currently the Node.js install report only supports the
remote source, but I want to update it to also write reports for local
installs later on.

This source key is supported already by the other integrations and this
only updates the Node.js integration to match.

