### PR TITLE
Support local extension files for installer

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -94,6 +94,8 @@ blocks:
     env_vars:
     - name: NODE_VERSION
       value: '16'
+    - name: _APPSIGNAL_EXTENSION_INSTALL
+      value: 'false'
     prologue:
       commands:
       - sem-version c 8
@@ -190,6 +192,8 @@ blocks:
     env_vars:
     - name: NODE_VERSION
       value: '15'
+    - name: _APPSIGNAL_EXTENSION_INSTALL
+      value: 'false'
     prologue:
       commands:
       - cache restore
@@ -285,6 +289,8 @@ blocks:
     env_vars:
     - name: NODE_VERSION
       value: '14'
+    - name: _APPSIGNAL_EXTENSION_INSTALL
+      value: 'false'
     prologue:
       commands:
       - cache restore
@@ -380,6 +386,8 @@ blocks:
     env_vars:
     - name: NODE_VERSION
       value: '13'
+    - name: _APPSIGNAL_EXTENSION_INSTALL
+      value: 'false'
     prologue:
       commands:
       - cache restore
@@ -475,6 +483,8 @@ blocks:
     env_vars:
     - name: NODE_VERSION
       value: '12'
+    - name: _APPSIGNAL_EXTENSION_INSTALL
+      value: 'false'
     prologue:
       commands:
       - cache restore

--- a/Rakefile
+++ b/Rakefile
@@ -98,7 +98,16 @@ namespace :build_matrix do
             "name" => primary_block_name,
             "dependencies" => [build_block_name],
             "task" => {
-              "env_vars" => ["name" => "NODE_VERSION", "value" => nodejs_version],
+              "env_vars" => [
+                {
+                  "name" => "NODE_VERSION",
+                  "value" => nodejs_version
+                },
+                {
+                  "name" => "_APPSIGNAL_EXTENSION_INSTALL",
+                  "value" => "false"
+                }
+              ],
               "prologue" => {
                 "commands" => setup + [
                   "cache restore",

--- a/packages/nodejs-ext/.changesets/support-local-installs-using-npm-install.md
+++ b/packages/nodejs-ext/.changesets/support-local-installs-using-npm-install.md
@@ -1,0 +1,5 @@
+---
+bump: "patch"
+---
+
+Support local installs when using `npm run install`. This will generate an install report for local installs in development.

--- a/packages/nodejs-ext/package.json
+++ b/packages/nodejs-ext/package.json
@@ -18,7 +18,7 @@
     "link:yarn": "yarn link",
     "test": "jest --filter=./test/filter.js",
     "pretest:failure": "npm run clean",
-    "test:failure": "_TEST_APPSIGNAL_EXTENSION_FAILURE=true npm run install; _TEST_APPSIGNAL_EXTENSION_FAILURE=true jest --filter=./test/filter.js"
+    "test:failure": "_TEST_APPSIGNAL_EXTENSION_FAILURE=true _APPSIGNAL_EXTENSION_INSTALL=true npm run install; _TEST_APPSIGNAL_EXTENSION_FAILURE=true jest --filter=./test/filter.js"
   },
   "os": [
     "linux",


### PR DESCRIPTION
When we use local agent and extension files to install and test the
local builds, also run it through the install script. This way we can
just use `npm install` rather than having to run the `npm run build:ext`
script in the `nodejs-ext` package.

Previously the install script would immediately exit on detecting local
files. This is unlike other integrations (Ruby and Elixir). It doesn't
store a install report file, so there's no way of knowing if the
extension was installed correctly (when using the `npm run build:ext`
task to manually install the extension).

With this change there's just one way to install the extension, from
local and remote sources. This will help us debug issues where a local
build is used.

When users install the page from npmjs.org they will not notice a
different. If they run `npm install` the extension is only installed the
first time and not on subsequent `npm install`s.

With this change the extension will be installed on every `npm install`
if the packages are linked using `npm link` locally. This is similar to
how it works in Elixir when specifying the AppSignal package in
`mix.exs`. Users won't generally use `npm link` so this is not a
problem.

Closes #437
Reference: appsignal/integration-guide#45
Makes possible https://github.com/appsignal/appsignal-agent/pull/718