### PR TITLE
Add mirror download support

### DIFF
--- a/packages/nodejs-ext/.changesets/add-mirrors-to-download-the-agent.md
+++ b/packages/nodejs-ext/.changesets/add-mirrors-to-download-the-agent.md
@@ -1,0 +1,5 @@
+---
+bump: "patch"
+---
+
+Add mirrors to download the agent from different online sources in case some sources are not available to the app network.

--- a/packages/nodejs-ext/scripts/extension/constants.js
+++ b/packages/nodejs-ext/scripts/extension/constants.js
@@ -1,78 +1,83 @@
 const AGENT_VERSION = "0318770"
 
+const MIRRORS = [
+  "https://appsignal-agent-releases.global.ssl.fastly.net",
+  "https://d135dj0rjqvssy.cloudfront.net"
+]
+
 const TRIPLES = {
   "x86_64-darwin": {
     checksum:
       "7b17cb76edc58ea54381455f74934d08efbfb7807007e97ae01f751101da8b50",
-    downloadUrl:
-      "https://appsignal-agent-releases.global.ssl.fastly.net/0318770/appsignal-x86_64-darwin-all-static.tar.gz"
+    filename:
+      "appsignal-x86_64-darwin-all-static.tar.gz"
   },
   "universal-darwin": {
     checksum:
       "7b17cb76edc58ea54381455f74934d08efbfb7807007e97ae01f751101da8b50",
-    downloadUrl:
-      "https://appsignal-agent-releases.global.ssl.fastly.net/0318770/appsignal-x86_64-darwin-all-static.tar.gz"
+    filename:
+      "appsignal-x86_64-darwin-all-static.tar.gz"
   },
   "aarch64-darwin": {
     checksum:
       "d90172492ccf83527696fcd0353796d3d0d4e1704ff986ae90a774a7f11a85a2",
-    downloadUrl:
-      "https://appsignal-agent-releases.global.ssl.fastly.net/0318770/appsignal-aarch64-darwin-all-static.tar.gz"
+    filename:
+      "appsignal-aarch64-darwin-all-static.tar.gz"
   },
   "arm64-darwin": {
     checksum:
       "d90172492ccf83527696fcd0353796d3d0d4e1704ff986ae90a774a7f11a85a2",
-    downloadUrl:
-      "https://appsignal-agent-releases.global.ssl.fastly.net/0318770/appsignal-aarch64-darwin-all-static.tar.gz"
+    filename:
+      "appsignal-aarch64-darwin-all-static.tar.gz"
   },
   "arm-darwin": {
     checksum:
       "d90172492ccf83527696fcd0353796d3d0d4e1704ff986ae90a774a7f11a85a2",
-    downloadUrl:
-      "https://appsignal-agent-releases.global.ssl.fastly.net/0318770/appsignal-aarch64-darwin-all-static.tar.gz"
+    filename:
+      "appsignal-aarch64-darwin-all-static.tar.gz"
   },
   "aarch64-linux": {
     checksum:
       "bef06f27d98cc1afc30b2d8fa23af69bd0206407b0d8d2f052278de3b8c5f2b5",
-    downloadUrl:
-      "https://appsignal-agent-releases.global.ssl.fastly.net/0318770/appsignal-aarch64-linux-all-static.tar.gz"
+    filename:
+      "appsignal-aarch64-linux-all-static.tar.gz"
   },
   "i686-linux": {
     checksum:
       "7e0aa277c4e49ebe1b805e9db615544c5488a23d8b439867a2a6357d37c897bc",
-    downloadUrl:
-      "https://appsignal-agent-releases.global.ssl.fastly.net/0318770/appsignal-i686-linux-all-static.tar.gz"
+    filename:
+      "appsignal-i686-linux-all-static.tar.gz"
   },
   "x86-linux": {
     checksum:
       "7e0aa277c4e49ebe1b805e9db615544c5488a23d8b439867a2a6357d37c897bc",
-    downloadUrl:
-      "https://appsignal-agent-releases.global.ssl.fastly.net/0318770/appsignal-i686-linux-all-static.tar.gz"
+    filename:
+      "appsignal-i686-linux-all-static.tar.gz"
   },
   "x86_64-linux": {
     checksum:
       "e918e24ff1f86d939b8f571506b11f2890d81c741de56cb06ac81b5dcc3f70e1",
-    downloadUrl:
-      "https://appsignal-agent-releases.global.ssl.fastly.net/0318770/appsignal-x86_64-linux-all-static.tar.gz"
+    filename:
+      "appsignal-x86_64-linux-all-static.tar.gz"
   },
   "x86_64-linux-musl": {
     checksum:
       "1a90421519d7860bf41d606866252cc7f1cb828a7efb9622045ee4f04d757ebd",
-    downloadUrl:
-      "https://appsignal-agent-releases.global.ssl.fastly.net/0318770/appsignal-x86_64-linux-musl-all-static.tar.gz"
+    filename:
+      "appsignal-x86_64-linux-musl-all-static.tar.gz"
   },
   "x86_64-freebsd": {
     checksum:
       "22cdd8e44e60dd69003d28ea95c994c27d2223a3872c541c966f32dbea3b0462",
-    downloadUrl:
-      "https://appsignal-agent-releases.global.ssl.fastly.net/0318770/appsignal-x86_64-freebsd-all-static.tar.gz"
+    filename:
+      "appsignal-x86_64-freebsd-all-static.tar.gz"
   },
   "amd64-freebsd": {
     checksum:
       "22cdd8e44e60dd69003d28ea95c994c27d2223a3872c541c966f32dbea3b0462",
-    downloadUrl:
-      "https://appsignal-agent-releases.global.ssl.fastly.net/0318770/appsignal-x86_64-freebsd-all-static.tar.gz"
+    filename:
+      "appsignal-x86_64-freebsd-all-static.tar.gz"
   }
 }
 
-module.exports = { AGENT_VERSION, TRIPLES }
+module.exports = { AGENT_VERSION, MIRRORS, TRIPLES }


### PR DESCRIPTION
The agent was always downloaded from a single URL. Adding mirror support
we ensure download availability as we do with Ruby library.