### PR TITLE
Add Prettier to CI build

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -49,6 +49,17 @@ blocks:
       - bundle install --jobs=3 --retry=3
       - cache store $_BUNDLER_CACHE-bundler-$(checksum Gemfile.lock) .bundle
       - bundle exec rubocop
+    - name: Node.js Lint (Prettier)
+      env_vars:
+      - name: NODE_VERSION
+        value: '16'
+      commands:
+      - sem-version c 8
+      - cache restore
+      - mono bootstrap --ci
+      - cache store
+      - mono bootstrap
+      - npm run lint
     - name: Git Lint (Lintje)
       commands:
       - script/lint_git

--- a/build_matrix.yml
+++ b/build_matrix.yml
@@ -46,6 +46,20 @@ semaphore: # Default `.semaphore/semaphore.yml` contents
             - bundle install --jobs=3 --retry=3
             - cache store $_BUNDLER_CACHE-bundler-$(checksum Gemfile.lock) .bundle
             - bundle exec rubocop
+        - name: Node.js Lint (Prettier)
+          env_vars:
+            - name: NODE_VERSION
+              value: "16"
+          commands:
+            # Configure the host to use GCC 8.3 for Node.js 16. This is the minimal
+            # required version for Node.js 16, and the extension won't compile
+            # without it.
+            - sem-version c 8
+            - cache restore
+            - mono bootstrap --ci
+            - cache store
+            - mono bootstrap
+            - npm run lint
         - name: Git Lint (Lintje)
           commands:
             - script/lint_git

--- a/package.json
+++ b/package.json
@@ -30,7 +30,9 @@
     "build:watch": "echo Please run 'mono run npm run build:watch --parallel' instead.",
     "build:ext": "echo Please run 'mono run npm run build:ext --package @appsignal/nodejs-ext' instead.",
     "clean": "echo Please run 'mono clean' instead.",
-    "test": "echo Please run 'mono test' instead."
+    "test": "echo Please run 'mono test' instead.",
+    "lint": "prettier --check **/*.{js,ts}",
+    "lint:write": "prettier --write **/*.{js,ts}"
   },
   "husky": {
     "hooks": {

--- a/packages/nodejs/src/__tests__/config.test.ts
+++ b/packages/nodejs/src/__tests__/config.test.ts
@@ -36,7 +36,9 @@ describe("Configuration", () => {
   })
 
   it("uses a default log file path", () => {
-    expect(process.env["_APPSIGNAL_LOG_FILE_PATH"]).toEqual("/tmp/appsignal.log")
+    expect(process.env["_APPSIGNAL_LOG_FILE_PATH"]).toEqual(
+      "/tmp/appsignal.log"
+    )
   })
 
   describe("Overriden log path with file specified", () => {
@@ -47,7 +49,9 @@ describe("Configuration", () => {
 
     it("uses the overwritten path", () => {
       // Test backwards compatibility with previous behaviour
-      expect(process.env["_APPSIGNAL_LOG_FILE_PATH"]).toEqual("/other_path/appsignal.log")
+      expect(process.env["_APPSIGNAL_LOG_FILE_PATH"]).toEqual(
+        "/other_path/appsignal.log"
+      )
     })
   })
 
@@ -58,7 +62,9 @@ describe("Configuration", () => {
     })
 
     it("uses the overwritten path", () => {
-      expect(process.env["_APPSIGNAL_LOG_FILE_PATH"]).toEqual("/other_path/appsignal.log")
+      expect(process.env["_APPSIGNAL_LOG_FILE_PATH"]).toEqual(
+        "/other_path/appsignal.log"
+      )
     })
   })
 })

--- a/packages/nodejs/src/__tests__/data.test.ts
+++ b/packages/nodejs/src/__tests__/data.test.ts
@@ -16,16 +16,16 @@ describe("Data", () => {
 
   it("creates a map with nested data", () => {
     const nested = {
-      "string": "payload",
-      "int": 9999,
-      "float": 99.0,
+      string: "payload",
+      int: 9999,
+      float: 99.0,
       1: true,
       null: "null_key",
-      "null_value": null,
-      "array": [1, 2, "three"],
-      "map": { "foo": "bʊr" },
-      "nested_array": [1, 2, "three", { "foo": "bar" }],
-      "nested_map": { "foo": "bʊr", "arr": [1, 2] },
+      null_value: null,
+      array: [1, 2, "three"],
+      map: { foo: "bʊr" },
+      nested_array: [1, 2, "three", { foo: "bar" }],
+      nested_map: { foo: "bʊr", arr: [1, 2] }
     }
 
     let map = Data.generate(nested, false)
@@ -34,21 +34,21 @@ describe("Data", () => {
   })
 
   it("creates a map with a non-standard type in it", () => {
-    let map = Data.generate({ "key": SyntaxError() }, false)
+    let map = Data.generate({ key: SyntaxError() }, false)
 
-    expect(Data.toJson(map)).toEqual({ "key": "SyntaxError" })
+    expect(Data.toJson(map)).toEqual({ key: "SyntaxError" })
   })
 
   it("creates a map with undefined in it", () => {
-    let map = Data.generate({ "key": undefined }, false)
+    let map = Data.generate({ key: undefined }, false)
 
-    expect(Data.toJson(map)).toEqual({ "key": "undefined" })
+    expect(Data.toJson(map)).toEqual({ key: "undefined" })
   })
 
   it("creates an array with a big int type in it", () => {
-    let array = Data.generate({ "key": BigInt(9007199254740991) }, false)
+    let array = Data.generate({ key: BigInt(9007199254740991) }, false)
 
-    expect(Data.toJson(array)).toEqual({ "key": "bigint:9007199254740991" })
+    expect(Data.toJson(array)).toEqual({ key: "bigint:9007199254740991" })
   })
 
   it("creates an array with nested data", () => {
@@ -60,8 +60,8 @@ describe("Data", () => {
       9999,
       99.0,
       [1, 2, 3],
-      { "foo": "bʊr" },
-      { "arr": [1, 2, "three"], "foo": "bʊr" }
+      { foo: "bʊr" },
+      { arr: [1, 2, "three"], foo: "bʊr" }
     ]
 
     let array = Data.generate(nested, false)


### PR DESCRIPTION
Also run Prettier on CI to make sure no code style issues are missed
when the Prettier hasn't run locally while committing changes.

The output doesn't say exactly what's wrong. Use the `npm run
lint:write` script to fix any issues automatically.

Fix #443

[skip changeset]
[skip review]

