### PR TITLE
Add rootSpan and addError helpers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "packages/*"
       ],
       "devDependencies": {
-        "@appsignal/types": "^2.0.2",
+        "@appsignal/types": "^2.1.1",
         "@types/jest": "^26.0.19",
         "husky": "^4.3.6",
         "jest": "^26.6.3",
@@ -100,9 +100,9 @@
       "link": true
     },
     "node_modules/@appsignal/types": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@appsignal/types/-/types-2.0.5.tgz",
-      "integrity": "sha512-T2Fi6co9Yft4KY1Ij/RcPV+BUTU8jSgtWXeFanPn5qPaZwRj8kh7jO/3B1inMlP11FYWWkO7Ugz5+HbetSvJ0A=="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@appsignal/types/-/types-2.1.1.tgz",
+      "integrity": "sha512-4GrdUTXsl1Krr/nx9QQStxAyU7yKoqtSil5z95FHB1iKP0Ihazict71Udt1mvOTC75aoPtdw1QppVA4/48QHRQ=="
     },
     "node_modules/@babel/code-frame": {
       "version": "7.12.11",
@@ -10633,7 +10633,7 @@
       "version": "1.0.11",
       "license": "MIT",
       "dependencies": {
-        "@appsignal/types": "^2.0.2",
+        "@appsignal/types": "^2.1.1",
         "apollo-server-plugin-base": "^0.10.3",
         "tslib": "^2.0.3"
       },
@@ -10651,7 +10651,7 @@
       "version": "1.0.12",
       "license": "MIT",
       "dependencies": {
-        "@appsignal/types": "^2.0.2",
+        "@appsignal/types": "^2.1.1",
         "tslib": "^2.0.3"
       },
       "devDependencies": {
@@ -10672,7 +10672,7 @@
       "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
-        "@appsignal/types": "^2.0.1",
+        "@appsignal/types": "^2.1.1",
         "shimmer": "^1.2.1",
         "tslib": "^2.0.3"
       },
@@ -10696,7 +10696,7 @@
       "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
-        "@appsignal/types": "^2.0.2",
+        "@appsignal/types": "^2.1.1",
         "tslib": "^2.0.3"
       },
       "devDependencies": {
@@ -10713,11 +10713,11 @@
     },
     "packages/nodejs": {
       "name": "@appsignal/nodejs",
-      "version": "1.3.2",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "@appsignal/core": "^1.1.4",
-        "@appsignal/types": "^2.0.2",
+        "@appsignal/types": "^2.1.1",
         "require-in-the-middle": "^5.1.0",
         "semver": "^7.3.4",
         "shimmer": "^1.2.1",
@@ -10737,12 +10737,12 @@
         "node": ">= 12"
       },
       "optionalDependencies": {
-        "@appsignal/nodejs-ext": "=1.2.9"
+        "@appsignal/nodejs-ext": "=2.0.0"
       }
     },
     "packages/nodejs-ext": {
       "name": "@appsignal/nodejs-ext",
-      "version": "1.2.9",
+      "version": "2.0.0",
       "cpu": [
         "x64",
         "x86"
@@ -10815,7 +10815,7 @@
     "@appsignal/apollo-server": {
       "version": "file:packages/apollo-server",
       "requires": {
-        "@appsignal/types": "^2.0.2",
+        "@appsignal/types": "^2.1.1",
         "apollo-server-plugin-base": "*",
         "tslib": "^2.0.3"
       },
@@ -10847,7 +10847,7 @@
     "@appsignal/express": {
       "version": "file:packages/express",
       "requires": {
-        "@appsignal/types": "^2.0.2",
+        "@appsignal/types": "^2.1.1",
         "@types/express": "*",
         "express": "*",
         "tslib": "^2.0.3"
@@ -10863,7 +10863,7 @@
     "@appsignal/koa": {
       "version": "file:packages/koa",
       "requires": {
-        "@appsignal/types": "^2.0.1",
+        "@appsignal/types": "^2.1.1",
         "@types/koa": "*",
         "@types/koa__router": "*",
         "@types/shimmer": "*",
@@ -10882,7 +10882,7 @@
     "@appsignal/nextjs": {
       "version": "file:packages/nextjs",
       "requires": {
-        "@appsignal/types": "^2.0.2",
+        "@appsignal/types": "^2.1.1",
         "next": "*",
         "tslib": "^2.0.3"
       },
@@ -10898,8 +10898,8 @@
       "version": "file:packages/nodejs",
       "requires": {
         "@appsignal/core": "^1.1.4",
-        "@appsignal/nodejs-ext": "=1.2.9",
-        "@appsignal/types": "^2.0.2",
+        "@appsignal/nodejs-ext": "=2.0.0",
+        "@appsignal/types": "^2.1.1",
         "@types/pg": "*",
         "@types/redis": "*",
         "@types/semver": "*",
@@ -10934,9 +10934,9 @@
       }
     },
     "@appsignal/types": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@appsignal/types/-/types-2.0.5.tgz",
-      "integrity": "sha512-T2Fi6co9Yft4KY1Ij/RcPV+BUTU8jSgtWXeFanPn5qPaZwRj8kh7jO/3B1inMlP11FYWWkO7Ugz5+HbetSvJ0A=="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@appsignal/types/-/types-2.1.1.tgz",
+      "integrity": "sha512-4GrdUTXsl1Krr/nx9QQStxAyU7yKoqtSil5z95FHB1iKP0Ihazict71Udt1mvOTC75aoPtdw1QppVA4/48QHRQ=="
     },
     "@babel/code-frame": {
       "version": "7.12.11",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "packages/*"
       ],
       "devDependencies": {
-        "@appsignal/types": "^2.1.1",
+        "@appsignal/types": "^2.1.2",
         "@types/jest": "^26.0.19",
         "husky": "^4.3.6",
         "jest": "^26.6.3",
@@ -100,9 +100,9 @@
       "link": true
     },
     "node_modules/@appsignal/types": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@appsignal/types/-/types-2.1.1.tgz",
-      "integrity": "sha512-4GrdUTXsl1Krr/nx9QQStxAyU7yKoqtSil5z95FHB1iKP0Ihazict71Udt1mvOTC75aoPtdw1QppVA4/48QHRQ=="
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@appsignal/types/-/types-2.1.2.tgz",
+      "integrity": "sha512-cxBCFTJPfwxo6MkUuJnVOroAS44L/81I4ap+0OXOajEFaKYLsYsjR5wLH6UA/XYiSi4LdKRq3Tba88moq2ewSg=="
     },
     "node_modules/@babel/code-frame": {
       "version": "7.12.11",
@@ -10633,7 +10633,7 @@
       "version": "1.0.11",
       "license": "MIT",
       "dependencies": {
-        "@appsignal/types": "^2.1.1",
+        "@appsignal/types": "^2.1.2",
         "apollo-server-plugin-base": "^0.10.3",
         "tslib": "^2.0.3"
       },
@@ -10651,7 +10651,7 @@
       "version": "1.0.12",
       "license": "MIT",
       "dependencies": {
-        "@appsignal/types": "^2.1.1",
+        "@appsignal/types": "^2.1.2",
         "tslib": "^2.0.3"
       },
       "devDependencies": {
@@ -10672,7 +10672,7 @@
       "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
-        "@appsignal/types": "^2.1.1",
+        "@appsignal/types": "^2.1.2",
         "shimmer": "^1.2.1",
         "tslib": "^2.0.3"
       },
@@ -10696,7 +10696,7 @@
       "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
-        "@appsignal/types": "^2.1.1",
+        "@appsignal/types": "^2.1.2",
         "tslib": "^2.0.3"
       },
       "devDependencies": {
@@ -10717,7 +10717,7 @@
       "license": "MIT",
       "dependencies": {
         "@appsignal/core": "^1.1.4",
-        "@appsignal/types": "^2.1.1",
+        "@appsignal/types": "^2.1.2",
         "require-in-the-middle": "^5.1.0",
         "semver": "^7.3.4",
         "shimmer": "^1.2.1",
@@ -10815,7 +10815,7 @@
     "@appsignal/apollo-server": {
       "version": "file:packages/apollo-server",
       "requires": {
-        "@appsignal/types": "^2.1.1",
+        "@appsignal/types": "^2.1.2",
         "apollo-server-plugin-base": "*",
         "tslib": "^2.0.3"
       },
@@ -10847,7 +10847,7 @@
     "@appsignal/express": {
       "version": "file:packages/express",
       "requires": {
-        "@appsignal/types": "^2.1.1",
+        "@appsignal/types": "^2.1.2",
         "@types/express": "*",
         "express": "*",
         "tslib": "^2.0.3"
@@ -10863,7 +10863,7 @@
     "@appsignal/koa": {
       "version": "file:packages/koa",
       "requires": {
-        "@appsignal/types": "^2.1.1",
+        "@appsignal/types": "^2.1.2",
         "@types/koa": "*",
         "@types/koa__router": "*",
         "@types/shimmer": "*",
@@ -10882,7 +10882,7 @@
     "@appsignal/nextjs": {
       "version": "file:packages/nextjs",
       "requires": {
-        "@appsignal/types": "^2.1.1",
+        "@appsignal/types": "^2.1.2",
         "next": "*",
         "tslib": "^2.0.3"
       },
@@ -10899,7 +10899,7 @@
       "requires": {
         "@appsignal/core": "^1.1.4",
         "@appsignal/nodejs-ext": "=2.0.0",
-        "@appsignal/types": "^2.1.1",
+        "@appsignal/types": "^2.1.2",
         "@types/pg": "*",
         "@types/redis": "*",
         "@types/semver": "*",
@@ -10934,9 +10934,9 @@
       }
     },
     "@appsignal/types": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@appsignal/types/-/types-2.1.1.tgz",
-      "integrity": "sha512-4GrdUTXsl1Krr/nx9QQStxAyU7yKoqtSil5z95FHB1iKP0Ihazict71Udt1mvOTC75aoPtdw1QppVA4/48QHRQ=="
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@appsignal/types/-/types-2.1.2.tgz",
+      "integrity": "sha512-cxBCFTJPfwxo6MkUuJnVOroAS44L/81I4ap+0OXOajEFaKYLsYsjR5wLH6UA/XYiSi4LdKRq3Tba88moq2ewSg=="
     },
     "@babel/code-frame": {
       "version": "7.12.11",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "packages/*"
   ],
   "devDependencies": {
-    "@appsignal/types": "^2.1.1",
+    "@appsignal/types": "^2.1.2",
     "@types/jest": "^26.0.19",
     "husky": "^4.3.6",
     "jest": "^26.6.3",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "packages/*"
   ],
   "devDependencies": {
-    "@appsignal/types": "^2.0.2",
+    "@appsignal/types": "^2.1.1",
     "@types/jest": "^26.0.19",
     "husky": "^4.3.6",
     "jest": "^26.6.3",

--- a/packages/apollo-server/package.json
+++ b/packages/apollo-server/package.json
@@ -5,7 +5,7 @@
   "types": "dist/index",
   "license": "MIT",
   "dependencies": {
-    "@appsignal/types": "^2.0.2",
+    "@appsignal/types": "^2.1.1",
     "apollo-server-plugin-base": "^0.10.3",
     "tslib": "^2.0.3"
   },

--- a/packages/apollo-server/package.json
+++ b/packages/apollo-server/package.json
@@ -5,7 +5,7 @@
   "types": "dist/index",
   "license": "MIT",
   "dependencies": {
-    "@appsignal/types": "^2.1.1",
+    "@appsignal/types": "^2.1.2",
     "apollo-server-plugin-base": "^0.10.3",
     "tslib": "^2.0.3"
   },

--- a/packages/apollo-server/src/index.ts
+++ b/packages/apollo-server/src/index.ts
@@ -25,7 +25,7 @@ export const createApolloPlugin = (appsignal: NodeClient, _options = {}) => {
 
           return {
             executionDidEnd: err => {
-              if (err) tracer.addError(err)
+              if (err) tracer.setError(err)
               execSpan.close()
             }
           }
@@ -34,7 +34,7 @@ export const createApolloPlugin = (appsignal: NodeClient, _options = {}) => {
           const parseSpan = rootSpan.child().setCategory("parse.graphql")
 
           return err => {
-            if (err) tracer.addError(err)
+            if (err) tracer.setError(err)
             parseSpan.close()
           }
         },
@@ -43,7 +43,7 @@ export const createApolloPlugin = (appsignal: NodeClient, _options = {}) => {
 
           return err => {
             // take only the first error
-            if (err) tracer.addError(err[0])
+            if (err) tracer.setError(err[0])
             validateSpan.close()
           }
         }

--- a/packages/apollo-server/src/index.ts
+++ b/packages/apollo-server/src/index.ts
@@ -25,7 +25,7 @@ export const createApolloPlugin = (appsignal: NodeClient, _options = {}) => {
 
           return {
             executionDidEnd: err => {
-              if (err) execSpan.addError(err)
+              if (err) tracer.addError(err)
               execSpan.close()
             }
           }
@@ -34,7 +34,7 @@ export const createApolloPlugin = (appsignal: NodeClient, _options = {}) => {
           const parseSpan = rootSpan.child().setCategory("parse.graphql")
 
           return err => {
-            if (err) parseSpan.addError(err)
+            if (err) tracer.addError(err)
             parseSpan.close()
           }
         },
@@ -43,7 +43,7 @@ export const createApolloPlugin = (appsignal: NodeClient, _options = {}) => {
 
           return err => {
             // take only the first error
-            if (err) validateSpan.addError(err[0])
+            if (err) tracer.addError(err[0])
             validateSpan.close()
           }
         }

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -5,7 +5,7 @@
   "types": "dist/index",
   "license": "MIT",
   "dependencies": {
-    "@appsignal/types": "^2.1.1",
+    "@appsignal/types": "^2.1.2",
     "tslib": "^2.0.3"
   },
   "peerDependencies": {

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -5,7 +5,7 @@
   "types": "dist/index",
   "license": "MIT",
   "dependencies": {
-    "@appsignal/types": "^2.0.2",
+    "@appsignal/types": "^2.1.1",
     "tslib": "^2.0.3"
   },
   "peerDependencies": {

--- a/packages/express/src/middleware/index.ts
+++ b/packages/express/src/middleware/index.ts
@@ -76,7 +76,7 @@ export function expressErrorHandler(
     // if there's no `status` property, forward the error
     // we also ignore client errors here
     if (err && (!err.status || (err.status && err.status >= 500))) {
-      tracer.addError(err)
+      tracer.setError(err)
     }
 
     return next(err)

--- a/packages/express/src/middleware/index.ts
+++ b/packages/express/src/middleware/index.ts
@@ -66,7 +66,8 @@ export function expressErrorHandler(
     res: Response,
     next: NextFunction
   ) {
-    const span = appsignal.tracer().currentSpan()
+    const tracer = appsignal.tracer()
+    const span = tracer.currentSpan()
 
     if (!span) {
       return next()
@@ -75,7 +76,7 @@ export function expressErrorHandler(
     // if there's no `status` property, forward the error
     // we also ignore client errors here
     if (err && (!err.status || (err.status && err.status >= 500))) {
-      span.addError(err)
+      tracer.addError(err)
     }
 
     return next(err)

--- a/packages/koa/README.md
+++ b/packages/koa/README.md
@@ -44,9 +44,7 @@ const Router = require("@koa/router"); // @koa/router is also supported out of t
 app.on("error", (error) => {
   appsignal
     .tracer()
-    .currentSpan()
-    .addError(error)
-    .close()
+    .setError(error)
 });
 
 const app = new Koa();

--- a/packages/koa/package.json
+++ b/packages/koa/package.json
@@ -5,7 +5,7 @@
   "types": "dist/index",
   "license": "MIT",
   "dependencies": {
-    "@appsignal/types": "^2.0.1",
+    "@appsignal/types": "^2.1.1",
     "shimmer": "^1.2.1",
     "tslib": "^2.0.3"
   },

--- a/packages/koa/package.json
+++ b/packages/koa/package.json
@@ -5,7 +5,7 @@
   "types": "dist/index",
   "license": "MIT",
   "dependencies": {
-    "@appsignal/types": "^2.1.1",
+    "@appsignal/types": "^2.1.2",
     "shimmer": "^1.2.1",
     "tslib": "^2.0.3"
   },

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -5,7 +5,7 @@
   "types": "dist/index",
   "license": "MIT",
   "dependencies": {
-    "@appsignal/types": "^2.1.1",
+    "@appsignal/types": "^2.1.2",
     "tslib": "^2.0.3"
   },
   "peerDependencies": {

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -5,7 +5,7 @@
   "types": "dist/index",
   "license": "MIT",
   "dependencies": {
-    "@appsignal/types": "^2.0.2",
+    "@appsignal/types": "^2.1.1",
     "tslib": "^2.0.3"
   },
   "peerDependencies": {

--- a/packages/nodejs/.changesets/add-root-span-and-add-error-helpers.md
+++ b/packages/nodejs/.changesets/add-root-span-and-add-error-helpers.md
@@ -1,0 +1,10 @@
+---
+bump: "minor"
+---
+
+Add rootSpan and addError helpers.
+
+Errors added to child spans are ignored by the agent. Now the rootSpan is
+always accessible from the tracer object as well as addError. The addError
+function allows to track errors on demand and they will be always attached
+to the main current span, so they don't get ignored by the agent.

--- a/packages/nodejs/.changesets/add-root-span-and-add-error-helpers.md
+++ b/packages/nodejs/.changesets/add-root-span-and-add-error-helpers.md
@@ -2,9 +2,9 @@
 bump: "minor"
 ---
 
-Add rootSpan and addError helpers.
+Add rootSpan and setError helpers.
 
 Errors added to child spans are ignored by the agent. Now the rootSpan is
-always accessible from the tracer object as well as addError. The addError
+always accessible from the tracer object as well as setError. The setError
 function allows to track errors on demand and they will be always attached
 to the main current span, so they don't get ignored by the agent.

--- a/packages/nodejs/package.json
+++ b/packages/nodejs/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@appsignal/core": "^1.1.4",
-    "@appsignal/types": "^2.1.1",
+    "@appsignal/types": "^2.1.2",
     "require-in-the-middle": "^5.1.0",
     "semver": "^7.3.4",
     "shimmer": "^1.2.1",

--- a/packages/nodejs/package.json
+++ b/packages/nodejs/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@appsignal/core": "^1.1.4",
-    "@appsignal/types": "^2.0.2",
+    "@appsignal/types": "^2.1.1",
     "require-in-the-middle": "^5.1.0",
     "semver": "^7.3.4",
     "shimmer": "^1.2.1",

--- a/packages/nodejs/src/__tests__/scope.test.ts
+++ b/packages/nodejs/src/__tests__/scope.test.ts
@@ -1,5 +1,5 @@
 import { ScopeManager } from "../scope"
-import { RootSpan } from "../span"
+import { RootSpan, ChildSpan } from "../span"
 
 describe("ScopeManager", () => {
   let scopeManager: ScopeManager
@@ -70,8 +70,9 @@ describe("ScopeManager", () => {
     })
 
     it("should finally restore an old scope", done => {
-      const scope1 = new RootSpan({ namespace: "scope1" })
-      const scope2 = new RootSpan({ namespace: "scope2" })
+      const rootSpan = new RootSpan()
+      const scope1 = new ChildSpan(rootSpan)
+      const scope2 = new ChildSpan(rootSpan)
 
       scopeManager.withContext(scope1, () => {
         expect(scopeManager.active()).toStrictEqual(scope1)
@@ -84,6 +85,8 @@ describe("ScopeManager", () => {
 
         return done()
       })
+
+      expect(scopeManager.active()).toStrictEqual(scopeManager.root())
     })
   })
 

--- a/packages/nodejs/src/demo.ts
+++ b/packages/nodejs/src/demo.ts
@@ -30,14 +30,12 @@ export function demo(tracer: Tracer) {
 
   // error sample
   tracer.withSpan(tracer.createSpan(), span => {
-    span
-      .setName("GET /demo")
-      .setCategory("process_request.http")
-      .addError(
-        new Error(
-          "Hello world! This is an error used for demonstration purposes."
-        )
+    tracer.setError(
+      new Error(
+        "Hello world! This is an error used for demonstration purposes."
       )
-      .close()
+    )
+
+    span.setName("GET /demo").setCategory("process_request.http").close()
   })
 }

--- a/packages/nodejs/src/instrumentation/http/lifecycle/outgoing.ts
+++ b/packages/nodejs/src/instrumentation/http/lifecycle/outgoing.ts
@@ -109,7 +109,8 @@ function outgoingRequestFunction(
       try {
         req = original.apply(this, [urlOrOptions, ...args])
       } catch (err) {
-        span.addError(err).close()
+        tracer.setError(err)
+        span.close()
         throw err
       }
 
@@ -128,7 +129,8 @@ function outgoingRequestFunction(
       })
 
       req.on("error", (error: Error) => {
-        span.addError(error).close()
+        tracer.setError(error)
+        span.close()
       })
 
       return req

--- a/packages/nodejs/src/instrumentation/pg/index.ts
+++ b/packages/nodejs/src/instrumentation/pg/index.ts
@@ -61,7 +61,7 @@ export const instrument = (
           if (returned instanceof EventEmitter) {
             tracer.wrapEmitter(returned)
           } else if (typeof returned.then === "function") {
-            returned = patchPromise(span, returned)
+            returned = patchPromise(tracer, span, returned)
           }
         }
 

--- a/packages/nodejs/src/instrumentation/redis/index.ts
+++ b/packages/nodejs/src/instrumentation/redis/index.ts
@@ -12,7 +12,7 @@ type RedisCallback = <T>(err: Error | null, reply: T) => void
 function wrapCallback(tracer: Tracer, span: NodeSpan, done: RedisCallback) {
   // @TODO: add results to span here?
   const fn = function <T>(err: Error | null, res: T) {
-    if (err) span.addError(err)
+    if (err) tracer.setError(err)
 
     span.close()
 

--- a/packages/nodejs/src/noops/span.ts
+++ b/packages/nodejs/src/noops/span.ts
@@ -17,7 +17,7 @@ export class NoopSpan implements NodeSpan {
     return new NoopSpan()
   }
 
-  public addError(error: Error): this {
+  public setError(error: Error): this {
     return this
   }
 

--- a/packages/nodejs/src/noops/tracer.ts
+++ b/packages/nodejs/src/noops/tracer.ts
@@ -21,6 +21,14 @@ export class NoopTracer implements Tracer {
     return new NoopSpan()
   }
 
+  public rootSpan(): NodeSpan {
+    return new NoopSpan()
+  }
+
+  public addError(error: Error): NodeSpan {
+    return new NoopSpan()
+  }
+
   public withSpan<T>(span: NodeSpan, fn: (s: NodeSpan) => T): T {
     return fn(span)
   }

--- a/packages/nodejs/src/noops/tracer.ts
+++ b/packages/nodejs/src/noops/tracer.ts
@@ -25,7 +25,7 @@ export class NoopTracer implements Tracer {
     return new NoopSpan()
   }
 
-  public addError(error: Error): NodeSpan {
+  public setError(error: Error): NodeSpan {
     return new NoopSpan()
   }
 

--- a/packages/nodejs/src/scope.ts
+++ b/packages/nodejs/src/scope.ts
@@ -50,6 +50,7 @@ export class ScopeManager {
 
         if (this.#scopes.get(currentId)) {
           this.#scopes.set(id, this.#scopes.get(currentId))
+          this.#roots.set(id, this.#roots.get(currentId))
         }
       } else {
         /**
@@ -62,6 +63,7 @@ export class ScopeManager {
          */
         if (this.#scopes.get(triggerId)) {
           this.#scopes.set(id, this.#scopes.get(triggerId))
+          this.#roots.set(id, this.#roots.get(triggerId))
         }
       }
     }
@@ -137,7 +139,7 @@ export class ScopeManager {
     try {
       return fn(span)
     } catch (err) {
-      rootSpan?.addError(err)
+      rootSpan?.setError(err)
       throw err
     } finally {
       // revert to the previous span
@@ -146,6 +148,7 @@ export class ScopeManager {
         this.#roots.delete(uid)
       } else {
         this.#scopes.set(uid, oldScope)
+        this.#roots.set(uid, rootSpan)
       }
     }
   }

--- a/packages/nodejs/src/scope.ts
+++ b/packages/nodejs/src/scope.ts
@@ -32,10 +32,12 @@ type ContextWrapped<T> = T & { [WRAPPED]?: boolean }
  * @class
  */
 export class ScopeManager {
+  #roots: Map<number, NodeSpan | undefined>
   #scopes: Map<number, NodeSpan | undefined>
   #asyncHook: asyncHooks.AsyncHook
 
   constructor() {
+    this.#roots = new Map()
     this.#scopes = new Map()
 
     const init = (id: number, type: string, triggerId: number) => {
@@ -70,6 +72,7 @@ export class ScopeManager {
      */
     const destroy = (id: number) => {
       this.#scopes.delete(id)
+      this.#roots.delete(id)
     }
 
     this.#asyncHook = asyncHooks.createHook({
@@ -106,23 +109,41 @@ export class ScopeManager {
   }
 
   /**
+   * Sets the root `Span`
+   */
+  public setRoot(rootSpan: NodeSpan) {
+    const uid = asyncHooks.executionAsyncId()
+    this.#roots.set(uid, rootSpan)
+  }
+
+  /*
+   * Returns the current root `Span`.
+   */
+  public root(): NodeSpan | undefined {
+    const uid = asyncHooks.executionAsyncId()
+    return this.#roots.get(uid)
+  }
+
+  /**
    * Executes a given function within the context of a given `Span`.
    */
   public withContext<T>(span: NodeSpan, fn: (s: NodeSpan) => T): T {
     const uid = asyncHooks.executionAsyncId()
     const oldScope = this.#scopes.get(uid)
+    const rootSpan = this.#roots.get(uid)
 
     this.#scopes.set(uid, span)
 
     try {
       return fn(span)
     } catch (err) {
-      span?.addError(err)
+      rootSpan?.addError(err)
       throw err
     } finally {
       // revert to the previous span
       if (oldScope === undefined) {
         this.#scopes.delete(uid)
+        this.#roots.delete(uid)
       } else {
         this.#scopes.set(uid, oldScope)
       }

--- a/packages/nodejs/src/span.ts
+++ b/packages/nodejs/src/span.ts
@@ -144,18 +144,11 @@ export class BaseSpan implements NodeSpan {
   }
 
   /**
-   * Adds a given `Error` object to the current `Span`.
-   * @deprecated Since version 2.1.0. Will be deleted in version 3.0.0
-   * use tracer.addError() instead.
+   * Set a given `Error` object to the current `Span`.
+   * Use tracer.setError() instead.
    */
-  public addError(error: Error): this {
-    if (!error) return this
-
-    const stackdata = Data.generate(
-      error.stack ? error.stack.split("\n") : ["No stacktrace available."]
-    )
-
-    span.addSpanError(this._ref, error.name, error.message, stackdata)
+  public setError(error: Error): this {
+    console.warn("setError() can only be called from a RootSpan object")
 
     return this
   }
@@ -245,9 +238,9 @@ export class RootSpan extends BaseSpan {
   }
 
   /*
-   * Adds a given `Error` object to the current `RootSpan`.
+   * Sets a given `Error` object to the current `RootSpan`.
    */
-  public addError(error: Error): this {
+  public setError(error: Error): this {
     if (!error) return this
 
     const stackdata = Data.generate(

--- a/packages/nodejs/src/span.ts
+++ b/packages/nodejs/src/span.ts
@@ -145,6 +145,8 @@ export class BaseSpan implements NodeSpan {
 
   /**
    * Adds a given `Error` object to the current `Span`.
+   * @deprecated Since version 2.1.0. Will be deleted in version 3.0.0
+   * use tracer.addError() instead.
    */
   public addError(error: Error): this {
     if (!error) return this
@@ -240,5 +242,20 @@ export class RootSpan extends BaseSpan {
     } else {
       this._ref = span.createRootSpan(namespace)
     }
+  }
+
+  /*
+   * Adds a given `Error` object to the current `RootSpan`.
+   */
+  public addError(error: Error): this {
+    if (!error) return this
+
+    const stackdata = Data.generate(
+      error.stack ? error.stack.split("\n") : ["No stacktrace available."]
+    )
+
+    span.addSpanError(this._ref, error.name, error.message, stackdata)
+
+    return this
   }
 }

--- a/packages/nodejs/src/tracer.ts
+++ b/packages/nodejs/src/tracer.ts
@@ -85,10 +85,10 @@ export class BaseTracer implements Tracer {
    * If there is no root Span available, a NoopSpan will be used instead,
    * and nothing will be tracked.
    */
-  public addError(error: Error): NodeSpan | undefined {
+  public setError(error: Error): NodeSpan | undefined {
     const activeRootSpan = this.rootSpan()
 
-    activeRootSpan.addError(error)
+    activeRootSpan.setError(error)
 
     return activeRootSpan
   }


### PR DESCRIPTION
## Add rootSpan and addError helpers

Root span wasn't accessible when working with contexts, only the current
child span was. Now there's a different storage for root spans and
they're always accessible from the tracer object.

A new `addError` function has been added to the tracer object and this
is the one that must be used when sending errors to AppSignal. It'll
look for the root span no matter the context or the current span, and
will attach the errors to it so they don't get ignored by the agent.

## Rename addError helpers to setError

In order to comply with AppSignal naming rules, we rename the addError
helper to setError