### PR TITLE
Deprecate addError functions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "packages/*"
       ],
       "devDependencies": {
-        "@appsignal/types": "^2.1.2",
+        "@appsignal/types": "^2.1.3",
         "@types/jest": "^26.0.19",
         "husky": "^4.3.6",
         "jest": "^26.6.3",
@@ -100,9 +100,9 @@
       "link": true
     },
     "node_modules/@appsignal/types": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@appsignal/types/-/types-2.1.2.tgz",
-      "integrity": "sha512-cxBCFTJPfwxo6MkUuJnVOroAS44L/81I4ap+0OXOajEFaKYLsYsjR5wLH6UA/XYiSi4LdKRq3Tba88moq2ewSg=="
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@appsignal/types/-/types-2.1.3.tgz",
+      "integrity": "sha512-slMFN+nhFr8jnhTbE+vNsHKd4VrUrtv7RCuYnHn5ataGI8BD75YMWBcwqwQD/0NZlVUuvbDlS0G6M+JzZUN/AA=="
     },
     "node_modules/@babel/code-frame": {
       "version": "7.12.11",
@@ -10633,7 +10633,7 @@
       "version": "1.0.11",
       "license": "MIT",
       "dependencies": {
-        "@appsignal/types": "^2.1.2",
+        "@appsignal/types": "^2.1.3",
         "apollo-server-plugin-base": "^0.10.3",
         "tslib": "^2.0.3"
       },
@@ -10651,7 +10651,7 @@
       "version": "1.0.12",
       "license": "MIT",
       "dependencies": {
-        "@appsignal/types": "^2.1.2",
+        "@appsignal/types": "^2.1.3",
         "tslib": "^2.0.3"
       },
       "devDependencies": {
@@ -10672,7 +10672,7 @@
       "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
-        "@appsignal/types": "^2.1.2",
+        "@appsignal/types": "^2.1.3",
         "shimmer": "^1.2.1",
         "tslib": "^2.0.3"
       },
@@ -10696,7 +10696,7 @@
       "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
-        "@appsignal/types": "^2.1.2",
+        "@appsignal/types": "^2.1.3",
         "tslib": "^2.0.3"
       },
       "devDependencies": {
@@ -10717,7 +10717,7 @@
       "license": "MIT",
       "dependencies": {
         "@appsignal/core": "^1.1.4",
-        "@appsignal/types": "^2.1.2",
+        "@appsignal/types": "^2.1.3",
         "require-in-the-middle": "^5.1.0",
         "semver": "^7.3.4",
         "shimmer": "^1.2.1",
@@ -10815,7 +10815,7 @@
     "@appsignal/apollo-server": {
       "version": "file:packages/apollo-server",
       "requires": {
-        "@appsignal/types": "^2.1.2",
+        "@appsignal/types": "^2.1.3",
         "apollo-server-plugin-base": "*",
         "tslib": "^2.0.3"
       },
@@ -10847,7 +10847,7 @@
     "@appsignal/express": {
       "version": "file:packages/express",
       "requires": {
-        "@appsignal/types": "^2.1.2",
+        "@appsignal/types": "^2.1.3",
         "@types/express": "*",
         "express": "*",
         "tslib": "^2.0.3"
@@ -10863,7 +10863,7 @@
     "@appsignal/koa": {
       "version": "file:packages/koa",
       "requires": {
-        "@appsignal/types": "^2.1.2",
+        "@appsignal/types": "^2.1.3",
         "@types/koa": "*",
         "@types/koa__router": "*",
         "@types/shimmer": "*",
@@ -10882,7 +10882,7 @@
     "@appsignal/nextjs": {
       "version": "file:packages/nextjs",
       "requires": {
-        "@appsignal/types": "^2.1.2",
+        "@appsignal/types": "^2.1.3",
         "next": "*",
         "tslib": "^2.0.3"
       },
@@ -10899,7 +10899,7 @@
       "requires": {
         "@appsignal/core": "^1.1.4",
         "@appsignal/nodejs-ext": "=2.0.0",
-        "@appsignal/types": "^2.1.2",
+        "@appsignal/types": "^2.1.3",
         "@types/pg": "*",
         "@types/redis": "*",
         "@types/semver": "*",
@@ -10934,9 +10934,9 @@
       }
     },
     "@appsignal/types": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@appsignal/types/-/types-2.1.2.tgz",
-      "integrity": "sha512-cxBCFTJPfwxo6MkUuJnVOroAS44L/81I4ap+0OXOajEFaKYLsYsjR5wLH6UA/XYiSi4LdKRq3Tba88moq2ewSg=="
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@appsignal/types/-/types-2.1.3.tgz",
+      "integrity": "sha512-slMFN+nhFr8jnhTbE+vNsHKd4VrUrtv7RCuYnHn5ataGI8BD75YMWBcwqwQD/0NZlVUuvbDlS0G6M+JzZUN/AA=="
     },
     "@babel/code-frame": {
       "version": "7.12.11",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "packages/*"
   ],
   "devDependencies": {
-    "@appsignal/types": "^2.1.2",
+    "@appsignal/types": "^2.1.3",
     "@types/jest": "^26.0.19",
     "husky": "^4.3.6",
     "jest": "^26.6.3",

--- a/packages/apollo-server/package.json
+++ b/packages/apollo-server/package.json
@@ -5,7 +5,7 @@
   "types": "dist/index",
   "license": "MIT",
   "dependencies": {
-    "@appsignal/types": "^2.1.2",
+    "@appsignal/types": "^2.1.3",
     "apollo-server-plugin-base": "^0.10.3",
     "tslib": "^2.0.3"
   },

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -5,7 +5,7 @@
   "types": "dist/index",
   "license": "MIT",
   "dependencies": {
-    "@appsignal/types": "^2.1.2",
+    "@appsignal/types": "^2.1.3",
     "tslib": "^2.0.3"
   },
   "peerDependencies": {

--- a/packages/koa/package.json
+++ b/packages/koa/package.json
@@ -5,7 +5,7 @@
   "types": "dist/index",
   "license": "MIT",
   "dependencies": {
-    "@appsignal/types": "^2.1.2",
+    "@appsignal/types": "^2.1.3",
     "shimmer": "^1.2.1",
     "tslib": "^2.0.3"
   },

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -5,7 +5,7 @@
   "types": "dist/index",
   "license": "MIT",
   "dependencies": {
-    "@appsignal/types": "^2.1.2",
+    "@appsignal/types": "^2.1.3",
     "tslib": "^2.0.3"
   },
   "peerDependencies": {

--- a/packages/nodejs/.changesets/deprecate-adderror-function.md
+++ b/packages/nodejs/.changesets/deprecate-adderror-function.md
@@ -1,0 +1,5 @@
+---
+bump: "patch"
+---
+
+Deprecate the addError function on the Span interface. Instead use the Tracer's `setError` function to set the error on the root span.

--- a/packages/nodejs/package.json
+++ b/packages/nodejs/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@appsignal/core": "^1.1.4",
-    "@appsignal/types": "^2.1.2",
+    "@appsignal/types": "^2.1.3",
     "require-in-the-middle": "^5.1.0",
     "semver": "^7.3.4",
     "shimmer": "^1.2.1",

--- a/packages/nodejs/src/noops/span.ts
+++ b/packages/nodejs/src/noops/span.ts
@@ -17,6 +17,13 @@ export class NoopSpan implements NodeSpan {
     return new NoopSpan()
   }
 
+  public addError(error: Error): this {
+    console.warn(
+      "DEPRECATED: Please use the `tracer.setError` helper instead to set the error on the root span."
+    )
+    return this
+  }
+
   public setError(error: Error): this {
     return this
   }

--- a/packages/nodejs/src/span.ts
+++ b/packages/nodejs/src/span.ts
@@ -144,11 +144,29 @@ export class BaseSpan implements NodeSpan {
   }
 
   /**
+   * Add a given `Error` object to the current `Span`.
+   * Use `tracer.setError()` instead.
+   *
+   * @deprecated since Node.js version 2.1.0
+   */
+  public addError(error: Error): this {
+    console.warn(
+      "DEPRECATED: Please use the `tracer.setError` helper instead to set the error on the root span."
+    )
+
+    return this
+  }
+
+  /**
    * Set a given `Error` object to the current `Span`.
-   * Use tracer.setError() instead.
+   * Use `tracer.setError()` instead.
+   *
+   * @deprecated since Node.js version 2.1.0
    */
   public setError(error: Error): this {
-    console.warn("setError() can only be called from a RootSpan object")
+    console.warn(
+      "DEPRECATED: Please use the `tracer.setError` helper instead to set the error on the root span."
+    )
 
     return this
   }


### PR DESCRIPTION
In PR #446 we removed the `addError` helper and renamed it `setError`
without leaving in place a placeholder function for `addError` that
prints a deprecation warning. Without this placeholder function users
could run into an error when calling a function that does not exist.

I've readded the `addError` function and made it print a deprecation
warning. I've updated the `setError` function to print the same
deprecation warning.

The types package has been updated to include the `addError` function
again on the Span interface.