### PR TITLE
Read extension install status from report

### DIFF
--- a/packages/nodejs/.changesets/fix-diagnose-installation-status.md
+++ b/packages/nodejs/.changesets/fix-diagnose-installation-status.md
@@ -1,0 +1,5 @@
+---
+bump: "patch"
+---
+
+Fix diagnose installation status reporting. It previously always reported "success", but will now also print failures.

--- a/packages/nodejs/src/cli/diagnose.ts
+++ b/packages/nodejs/src/cli/diagnose.ts
@@ -33,7 +33,17 @@ export class Diagnose {
 
     console.log(`Extension installation report`)
     console.log(`  Installation result`)
-    console.log(`    Status: success`)
+    const installReport = data["installation"]
+    console.log(`    Status: ${installReport["result"]["status"]}`)
+    const resultMessage = data["installation"]["result"]["message"]
+    if (resultMessage) {
+      console.log(`    Message: ${resultMessage}`)
+    }
+    const resultError = data["installation"]["result"]["error"]
+    if (resultError) {
+      console.log(`    Error: ${resultError}`)
+    }
+
     console.log(`  Language details`)
     console.log(
       `    Node.js version: ${data["installation"]["language"]["version"]}`


### PR DESCRIPTION
The installation result was hardcoded to always be `success`, because
previously we couldn't track it. But since PR #409 we now run the
`node-gyp` command from the `extension.js` install script so we can
track the installation result.

Read the status from the report so the diagnose report is more accurate.

Since there are more fields in case of an error or failure, print those
as well if present.