### PR TITLE
Fix checksum verification error handling

### DIFF
--- a/packages/nodejs-ext/.changesets/fix-verification-failure-on-installation.md
+++ b/packages/nodejs-ext/.changesets/fix-verification-failure-on-installation.md
@@ -1,0 +1,5 @@
+---
+bump: "patch"
+---
+
+Fix the checksum verification failure on extension installation. If the download checksum verification failed it would not write a diagnose report and it would be difficult to debug the cause for the AppSignal team.

--- a/packages/nodejs-ext/scripts/extension.js
+++ b/packages/nodejs-ext/scripts/extension.js
@@ -212,7 +212,7 @@ function install() {
     result = download(MIRRORS, filename, outputPath).then(url => {
       report.download.download_url = url
 
-      verify(outputPath, metadata.checksum).then(() => {
+      return verify(outputPath, metadata.checksum).then(() => {
         report.download.checksum = "verified"
 
         return extract(outputPath)


### PR DESCRIPTION
During the extension installation we verify if the download's checksum
matches the expected checksum.

When this verification fails, it should write this error to the
installation report, but instead it would not write a report at all.

```
The agent has downloaded successfully! Building...
/integration/packages/nodejs-ext/scripts/extension.js:110
          return reject(new Error("Checksum verification failed"))
                        ^

Error: Checksum verification failed
    at Hash.<anonymous> (/integration/packages/nodejs-ext/scripts/extension.js:110:25)
    at Hash.emit (node:events:388:22)
    at finish (node:internal/streams/writable:741:10)
    at processTicksAndRejections (node:internal/process/task_queues:80:21)
Error: Command failed with status `1`
```

This error should have been caught by the catch statement on line 238,
but wasn't because the promise result wasn't returned from the
`download`'s promise handler that called the `verify` function. Instead
it was not handled at all. You can tell by the output being printed
including: "The agent has downloaded successfully!", indicating it
continued as if no error occurred.

I would have expected an unhandled promise error here actually, but for
whatever reason it just prints the error instead and exits with a
failure like we expect, but without it writing an installation report
file.

This broke in commit bf11c4b (PR #440),
that was released in version 2.1.0. Originally the `verify` function
result was the only thing in the `download`'s promise handler, and was
implicitly returned. It was changed to a multi statement handler that
had no explicit return.

Fixes #455