### PR TITLE
Remove extra bootstrap from Ruby Lint job

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -58,7 +58,6 @@ blocks:
       - cache restore
       - mono bootstrap --ci
       - cache store
-      - mono bootstrap
       - npm run lint
     - name: Git Lint (Lintje)
       commands:

--- a/build_matrix.yml
+++ b/build_matrix.yml
@@ -58,7 +58,6 @@ semaphore: # Default `.semaphore/semaphore.yml` contents
             - cache restore
             - mono bootstrap --ci
             - cache store
-            - mono bootstrap
             - npm run lint
         - name: Git Lint (Lintje)
           commands:


### PR DESCRIPTION
CI Ruby Lint job had an extra unneeded bootstrap command. This commits
removes it.

[skip changeset]