### PR TITLE
Add Node 17 to the build matrix

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -62,6 +62,112 @@ blocks:
     - name: Git Lint (Lintje)
       commands:
       - script/lint_git
+- name: Node.js 17 - Build
+  dependencies:
+  - Validation
+  task:
+    env_vars:
+    - &1
+      name: NODE_OPTIONS
+      value: "--openssl-legacy-provider"
+    - name: NODE_VERSION
+      value: '17'
+    prologue:
+      commands:
+      - sem-version c 8
+      - cache restore
+      - mono bootstrap --ci
+      - cache store
+    epilogue: &2
+      on_fail:
+        commands:
+        - cat /tmp/appsignal-*-install.report
+    jobs:
+    - name: Build
+      commands:
+      - mono build
+      - cache store $_PACKAGES_CACHE-packages-$SEMAPHORE_GIT_SHA-v$NODE_VERSION packages
+      - cache store $_PACKAGES_CACHE-install-report-$SEMAPHORE_GIT_SHA-v$NODE_VERSION
+        /tmp/appsignal-*-install.report
+- name: Node.js 17 - Tests
+  dependencies:
+  - Node.js 17 - Build
+  task:
+    env_vars:
+    - *1
+    - name: NODE_VERSION
+      value: '17'
+    - name: _APPSIGNAL_EXTENSION_INSTALL
+      value: 'false'
+    prologue:
+      commands:
+      - sem-version c 8
+      - cache restore
+      - cache restore $_PACKAGES_CACHE-packages-$SEMAPHORE_GIT_SHA-v$NODE_VERSION
+      - cache restore $_PACKAGES_CACHE-install-report-$SEMAPHORE_GIT_SHA-v$NODE_VERSION
+      - mono bootstrap --ci
+    epilogue: *2
+    jobs:
+    - name: "@appsignal/nodejs - nodejs"
+      commands:
+      - mono test --package=@appsignal/nodejs
+    - name: "@appsignal/nodejs - nodejs - diagnose"
+      commands:
+      - git submodule init
+      - git submodule update
+      - LANGUAGE=nodejs test/integration/diagnose/bin/test
+    - name: "@appsignal/nodejs-ext - nodejs-ext"
+      commands:
+      - mono test --package=@appsignal/nodejs-ext
+      - mono run --package @appsignal/nodejs-ext -- npm run test:failure
+    - name: "@appsignal/apollo-server - apollo-server@latest - integrations"
+      commands:
+      - script/install_test_example_packages apollo-server apollo-server-plugin-base@latest
+      - script/test_package_integration apollo-server
+    - name: "@appsignal/apollo-server - apollo-server@0.13.0 - integrations"
+      commands:
+      - script/install_test_example_packages apollo-server apollo-server-plugin-base@0.13.0
+      - script/test_package_integration apollo-server
+    - name: "@appsignal/apollo-server - apollo-server@0.12.0 - integrations"
+      commands:
+      - script/install_test_example_packages apollo-server apollo-server-plugin-base@0.12.0
+      - script/test_package_integration apollo-server
+    - name: "@appsignal/apollo-server - apollo-server@0.11.0 - integrations"
+      commands:
+      - script/install_test_example_packages apollo-server apollo-server-plugin-base@0.11.0
+      - script/test_package_integration apollo-server
+    - name: "@appsignal/express - express@latest - integrations"
+      commands:
+      - script/install_test_example_packages express express@latest
+      - script/test_package_integration express
+    - name: "@appsignal/express - express@4.17.1 - integrations"
+      commands:
+      - script/install_test_example_packages express express@4.17.1
+      - script/test_package_integration express
+    - name: "@appsignal/koa - koa@latest - integrations"
+      commands:
+      - script/install_test_example_packages koa koa@latest
+      - script/test_package_integration koa
+    - name: "@appsignal/koa - koa@2.13.1 - integrations"
+      commands:
+      - script/install_test_example_packages koa koa@2.13.1
+      - script/test_package_integration koa
+    - name: "@appsignal/koa - koa@2.12.1 - integrations"
+      commands:
+      - script/install_test_example_packages koa koa@2.12.1
+      - script/test_package_integration koa
+    - name: "@appsignal/nextjs - next.js@latest - integrations"
+      commands:
+      - script/install_test_example_packages nextjs next@latest react@latest react-dom@latest
+      - script/test_package_integration nextjs
+    - name: "@appsignal/nextjs - next.js@11.0.1 - integrations"
+      commands:
+      - script/install_test_example_packages nextjs next@11.0.1 react@17.0.2 react-dom@17.0.2
+      - script/test_package_integration nextjs
+    - name: "@appsignal/nextjs - next.js@10.2.3 - integrations"
+      commands:
+      - script/install_test_example_packages nextjs next@10.2.3 react@16.14.0 react-dom@16.14.0
+      - script/test_package_integration nextjs
 - name: Node.js 16 - Build
   dependencies:
   - Validation
@@ -75,10 +181,7 @@ blocks:
       - cache restore
       - mono bootstrap --ci
       - cache store
-    epilogue: &1
-      on_fail:
-        commands:
-        - cat /tmp/appsignal-*-install.report
+    epilogue: *2
     jobs:
     - name: Build
       commands:
@@ -102,7 +205,7 @@ blocks:
       - cache restore $_PACKAGES_CACHE-packages-$SEMAPHORE_GIT_SHA-v$NODE_VERSION
       - cache restore $_PACKAGES_CACHE-install-report-$SEMAPHORE_GIT_SHA-v$NODE_VERSION
       - mono bootstrap --ci
-    epilogue: *1
+    epilogue: *2
     jobs:
     - name: "@appsignal/nodejs - nodejs"
       commands:
@@ -176,7 +279,7 @@ blocks:
       - cache restore
       - mono bootstrap --ci
       - cache store
-    epilogue: *1
+    epilogue: *2
     jobs:
     - name: Build
       commands:
@@ -199,7 +302,7 @@ blocks:
       - cache restore $_PACKAGES_CACHE-packages-$SEMAPHORE_GIT_SHA-v$NODE_VERSION
       - cache restore $_PACKAGES_CACHE-install-report-$SEMAPHORE_GIT_SHA-v$NODE_VERSION
       - mono bootstrap --ci
-    epilogue: *1
+    epilogue: *2
     jobs:
     - name: "@appsignal/nodejs - nodejs"
       commands:
@@ -273,7 +376,7 @@ blocks:
       - cache restore
       - mono bootstrap --ci
       - cache store
-    epilogue: *1
+    epilogue: *2
     jobs:
     - name: Build
       commands:
@@ -296,7 +399,7 @@ blocks:
       - cache restore $_PACKAGES_CACHE-packages-$SEMAPHORE_GIT_SHA-v$NODE_VERSION
       - cache restore $_PACKAGES_CACHE-install-report-$SEMAPHORE_GIT_SHA-v$NODE_VERSION
       - mono bootstrap --ci
-    epilogue: *1
+    epilogue: *2
     jobs:
     - name: "@appsignal/nodejs - nodejs"
       commands:
@@ -370,7 +473,7 @@ blocks:
       - cache restore
       - mono bootstrap --ci
       - cache store
-    epilogue: *1
+    epilogue: *2
     jobs:
     - name: Build
       commands:
@@ -393,7 +496,7 @@ blocks:
       - cache restore $_PACKAGES_CACHE-packages-$SEMAPHORE_GIT_SHA-v$NODE_VERSION
       - cache restore $_PACKAGES_CACHE-install-report-$SEMAPHORE_GIT_SHA-v$NODE_VERSION
       - mono bootstrap --ci
-    epilogue: *1
+    epilogue: *2
     jobs:
     - name: "@appsignal/nodejs - nodejs"
       commands:
@@ -467,7 +570,7 @@ blocks:
       - cache restore
       - mono bootstrap --ci
       - cache store
-    epilogue: *1
+    epilogue: *2
     jobs:
     - name: Build
       commands:
@@ -490,7 +593,7 @@ blocks:
       - cache restore $_PACKAGES_CACHE-packages-$SEMAPHORE_GIT_SHA-v$NODE_VERSION
       - cache restore $_PACKAGES_CACHE-install-report-$SEMAPHORE_GIT_SHA-v$NODE_VERSION
       - mono bootstrap --ci
-    epilogue: *1
+    epilogue: *2
     jobs:
     - name: "@appsignal/nodejs - nodejs"
       commands:

--- a/build_matrix.yml
+++ b/build_matrix.yml
@@ -70,12 +70,22 @@ matrix:
         - "cat /tmp/appsignal-*-install.report"
 
   nodejs:
-    - nodejs: "16"
-      setup:
-        # Configure the host to use GCC 8.3 for Node.js 16. This is the minimal
-        # required version for Node.js 16, and the extension won't compile
-        # without it.
+    - nodejs: "17"
+      setup: &gcc8
+        # Configure the host to use GCC 8.3 for Node.js 16 and above. This
+        # is the minimal required version for Node.js 16 and above, and the
+        # extension won't compile without it.
         - sem-version c 8
+      env_vars:
+        # Set `NODE_OPTIONS` to `--openssl-legacy-provider`, as a workaround
+        # for this `webpack` bug affecting the `@appsignal/nextjs` tests
+        # when running on Node 17:
+        # https://github.com/webpack/webpack/issues/14532
+        # https://github.com/nodejs/node/issues/40455
+        - name: NODE_OPTIONS
+          value: "--openssl-legacy-provider"
+    - nodejs: "16"
+      setup: *gcc8
     - nodejs: "15"
     - nodejs: "14"
     - nodejs: "13"


### PR DESCRIPTION
Modify the build matrix to add Node 17 to the environments under test. The GCC setup from Node 16 is reused here.

As a workaround for a bug caused by Node 17 switching to OpenSSL 3, we add the `--openssl-legacy-provider` option to the `NODE_OPTIONS` environment variable. See [this node issue][node] and [this webpack issue][webpack] for details.

[node]: https://github.com/nodejs/node/issues/40455
[webpack]: https://github.com/webpack/webpack/issues/14532

Closes #464.

[skip changeset]