### PR TITLE
Fix diagnose report's Push API key transmission

### DIFF
--- a/packages/nodejs/.changesets/diagnose-api-key-transmission.md
+++ b/packages/nodejs/.changesets/diagnose-api-key-transmission.md
@@ -1,0 +1,5 @@
+---
+bump: "patch"
+---
+
+Fix diagnose report recognition when sent to the server. It was sent without an `api_key` parameter, which resulted in apps not being linked to the parent organization based on the known Push API key.


### PR DESCRIPTION
## The problem

The diagnose report was transmitted without the Push API key as the
`api_key` query parameter. This caused the reports to not be properly
linked to their parent organizations on AppSignal.com, making it more
difficult to find them back for users.

It also caused the issues described in this server side issue:
https://github.com/appsignal/appsignal-server/issues/7710

## The solution

The request to submit the report now includes the `api_key` query
parameter.

I've moved the report transmission to the DiagnoseTool, because the
AppSignal config is available there, and I didn't want to initialize it
again in the Diagnose CLI class or move it to the Diagnose CLI class, or
fetch it from the Diagnose Tool's generated report. There's no big
design idea behind it, this was just easiest.

I've implemented error handling when the server returned an error code,
because otherwise it would print an ugly backtrace with where the JSON
parsing failed.

This behavior's tests should be implemented in the diagnose tests
submodule when we test the transmitted report as well.