### PR TITLE
Allow configuration of diagnose endpoint

### DIFF
--- a/packages/nodejs/src/diagnose.ts
+++ b/packages/nodejs/src/diagnose.ts
@@ -51,7 +51,6 @@ export class DiagnoseTool {
       library: this.getLibraryData(),
       installation: this.getInstallationReport(),
       host: this.getHostData(),
-      app: {},
       agent: this.#extension.diagnose(),
       config: {
         options: this.getConfigData(),

--- a/packages/nodejs/src/diagnose.ts
+++ b/packages/nodejs/src/diagnose.ts
@@ -197,7 +197,7 @@ export class DiagnoseTool {
   }
 
   public sendReport(data: object) {
-    const json = JSON.stringify(data)
+    const json = JSON.stringify({ diagnose: data })
 
     const config = this.#config.data
     const params = new URLSearchParams({ api_key: config["apiKey"] || "" })

--- a/packages/nodejs/src/diagnose.ts
+++ b/packages/nodejs/src/diagnose.ts
@@ -1,6 +1,7 @@
 import fs from "fs"
 import path from "path"
 import https from "https"
+import http from "http"
 import { URL, URLSearchParams } from "url"
 import { createHash } from "crypto"
 
@@ -201,11 +202,16 @@ export class DiagnoseTool {
     const config = this.#config.data
     const params = new URLSearchParams({ api_key: config["apiKey"] || "" })
 
+    const diagnoseEndpoint =
+      process.env.APPSIGNAL_DIAGNOSE_ENDPOINT || "https://appsignal.com/diag"
+    const url = new URL(diagnoseEndpoint)
+
     const opts = {
-      port: 443,
       method: "POST",
-      host: "appsignal.com",
-      path: `/diag?${params.toString()}`,
+      protocol: url.protocol,
+      host: url.hostname,
+      port: url.port,
+      path: `${url.pathname}?${params.toString()}`,
       headers: {
         "Content-Type": "application/json",
         "Content-Length": json.length
@@ -216,7 +222,8 @@ export class DiagnoseTool {
       )
     }
 
-    const request = https.request(opts, (response: any) => {
+    const requestModule = url.protocol == "http:" ? http : https
+    const request = requestModule.request(opts, (response: any) => {
       const responseStatus = response.statusCode
       response.setEncoding("utf8")
 


### PR DESCRIPTION
## Allow configuration of diagnose endpoint

For the diagnose tests we need to send the diagnose JSON report to a
custom endpoint. This change introduces the APPSIGNAL_DIAGNOSE_ENDPOINT
environment variable for this purpose.

The APPSIGNAL_DIAGNOSE_ENDPOINT environment variable is not a variable
we'll document publicly, because it's only meant for testing purposes.

The Node.js app needs to either use the https or http module, for the
production or local server. I didn't find a way to call `http:` protocol
endpoints with the https module.

## Wrap diagnose report in diagnose key

The diagnose CLIs in the Ruby and Elixir integrations wrap the diagnose
report in a "diagnose" key. This is because of how the Rails endpoint
was originally written.

Update the Node.js integration to match, because that's the least amount
of work.

## Remove unused app key from diagnose report

The app key is non-standard, no other integrations transmit this key as
part of the diagnose report. It's also empty, so we do not do anything
with it. Remove it.

## Update diagnose tests submodule

Includes tests for the transmitted diagnose JSON report.

Update the diagnose tests to match the new diagnose format without an
`app` key in the JSON report and transmit it wrapped in a `diagnose`
key.

Relies on https://github.com/appsignal/diagnose_tests/pull/23


[skip changeset]