### PR TITLE
Diagnose report updates

### DIFF
--- a/packages/nodejs/.changesets/fix-diagnose-report-path-modes-format.md
+++ b/packages/nodejs/.changesets/fix-diagnose-report-path-modes-format.md
@@ -1,0 +1,5 @@
+---
+bump: "patch"
+---
+
+Transmit the path file modes in the diagnose report as an octal number. Previously it send values like `33188` and now it transmits `100644`, which is a bit more human readable.

--- a/packages/nodejs/src/cli/diagnose.ts
+++ b/packages/nodejs/src/cli/diagnose.ts
@@ -251,6 +251,8 @@ export class Diagnose {
   }
 
   sendReport(data: object) {
+    console.log("  Transmitting diagnostics report")
+    console.log("")
     this.#diagnose.sendReport(data)
   }
 

--- a/packages/nodejs/src/cli/diagnose.ts
+++ b/packages/nodejs/src/cli/diagnose.ts
@@ -224,7 +224,7 @@ export class Diagnose {
         `  Not sending report. (Specified with the --no-send-report option.)`
       )
     } else if (process.argv.includes("--send-report")) {
-      this.#diagnose.sendReport(data)
+      this.sendReport(data)
     } else {
       const rl = readline.createInterface({
         input: process.stdin,
@@ -237,7 +237,7 @@ export class Diagnose {
         function (answer: String) {
           switch (answer || "y") {
             case "y":
-              self.#diagnose.sendReport(data)
+              self.sendReport(data)
               break
 
             default:
@@ -248,6 +248,10 @@ export class Diagnose {
         }
       )
     }
+  }
+
+  sendReport(data: object) {
+    this.#diagnose.sendReport(data)
   }
 
   printAgentDiagnose(report: HashMap<any>) {

--- a/packages/nodejs/src/diagnose.ts
+++ b/packages/nodejs/src/diagnose.ts
@@ -13,7 +13,7 @@ import { JS_TO_RUBY_MAPPING } from "./config/configmap"
 interface FileMetadata {
   content?: string[]
   exists: boolean
-  mode?: number
+  mode?: string
   ownership?: {
     gid: number
     uid: number
@@ -161,7 +161,7 @@ export class DiagnoseTool {
         paths[key] = {
           ...data,
           exists: true,
-          mode,
+          mode: mode.toString(8),
           ownership: {
             gid,
             uid

--- a/packages/nodejs/src/diagnose.ts
+++ b/packages/nodejs/src/diagnose.ts
@@ -231,7 +231,7 @@ export class DiagnoseTool {
           const { token } = JSON.parse(responseData.toString())
           console.log(`  Your support token:`, token)
           console.log(
-            `  View this report: https://appsignal.com/diagnose/${token}`
+            `  View this report:   https://appsignal.com/diagnose/${token}`
           )
         } else {
           console.error(


### PR DESCRIPTION
Requires https://github.com/appsignal/diagnose_tests/pull/25

## Move diagnose send report to separate function

Move the logic to call transmit the report to one location in the
diagnose CLI class.

This because we'll need to move the output back here again from the
`src/diagnose.ts` file that I moved there a little while ago. The
`console.log` call shouldn't be there.

## Update diagnose transmit output 

Update the diagnose report transmission output to match the Ruby gem,
and the other integrations.

- Print a line informing the user the report is being transmitted.
- Align the diagnose report link with the report token.

## Update the FileMetadata mode type to String

The Ruby gem transmits this value as a String, because I think we
decided to this to make sure we transmit the value in a format we expect
to be human readable, like `00777` or `100777`. It's more flexible as a
String format.

Previously the value would be send as `33188`, but transformed it sends
it as `"100644"`.

## Update diagnose submodule

Update to match new standardized format for transmitted JSON reports and
terminal output.

