### PR TITLE
Add query params to diagnose report transmission

### DIFF
--- a/packages/nodejs/.changesets/send-diagnose-report-with-correct-query-params.md
+++ b/packages/nodejs/.changesets/send-diagnose-report-with-correct-query-params.md
@@ -1,0 +1,5 @@
+---
+bump: "patch"
+---
+
+Send the diagnose report with correct query parameters to help link the report to the app and organization on AppSignal.com.

--- a/packages/nodejs/src/diagnose.ts
+++ b/packages/nodejs/src/diagnose.ts
@@ -199,7 +199,12 @@ export class DiagnoseTool {
     const json = JSON.stringify({ diagnose: data })
 
     const config = this.#config.data
-    const params = new URLSearchParams({ api_key: config["apiKey"] || "" })
+    const params = new URLSearchParams({
+      api_key: config["apiKey"] || "",
+      name: config["name"] || "",
+      environment: config["environment"] || "",
+      hostname: config["hostname"] || ""
+    })
 
     const diagnoseEndpoint =
       process.env.APPSIGNAL_DIAGNOSE_ENDPOINT || "https://appsignal.com/diag"


### PR DESCRIPTION
The query params to submit the diagnose report weren't included. This
way it matches the other integrations.

Depends on https://github.com/appsignal/diagnose_tests/pull/30