### PR TITLE
Print all install report fields in diagnose report

### DIFF
--- a/packages/nodejs/.changesets/print-dependencies-and-flags-for-install-in-diagnose-report.md
+++ b/packages/nodejs/.changesets/print-dependencies-and-flags-for-install-in-diagnose-report.md
@@ -1,0 +1,5 @@
+---
+bump: "patch"
+---
+
+Print the extension installation dependencies and flags in the diagnose report output.

--- a/packages/nodejs/src/cli/diagnose.ts
+++ b/packages/nodejs/src/cli/diagnose.ts
@@ -108,6 +108,14 @@ export class Diagnose {
           data["installation"]["build"]["library_type"]
         )}`
       )
+      console.log(
+        `    Dependencies: ${format_value(
+          data["installation"]["build"]["dependencies"]
+        )}`
+      )
+      console.log(
+        `    Flags: ${format_value(data["installation"]["build"]["flags"])}`
+      )
       console.log(`  Host details`)
       console.log(
         `    Root user: ${format_value(


### PR DESCRIPTION
The dependencies and flags fields were missing from the Node.js
integration diagnose report output. It was sent, just not printed.
Now it matches the other integrations output.

Depends on https://github.com/appsignal/diagnose_tests/pull/31