### PR TITLE
Standardize key validation request

### DIFF
--- a/packages/nodejs/.changesets/standardize-diagnose-validation-error-message.md
+++ b/packages/nodejs/.changesets/standardize-diagnose-validation-error-message.md
@@ -1,0 +1,5 @@
+---
+bump: "patch"
+---
+
+Standardize diagnose validation failure message. Explain the diagnose request failed and why.

--- a/packages/nodejs/src/diagnose.ts
+++ b/packages/nodejs/src/diagnose.ts
@@ -112,21 +112,27 @@ export class DiagnoseTool {
   private async validatePushApiKey() {
     return new Promise((resolve, reject) => {
       const config = this.#config.data
-      const params = new URLSearchParams({ api_key: config["apiKey"] })
+      const params = new URLSearchParams({
+        api_key: config["apiKey"] || "",
+        name: config["name"] || "",
+        environment: config["environment"] || "",
+        hostname: config["hostname"] || ""
+      })
       const url = new URL(`/1/auth?${params.toString()}`, config["endpoint"])
       const options = { method: "POST" }
 
-      const request = https.request(url, options, function (response) {
+      const requestModule = url.protocol == "http:" ? http : https
+      const request = requestModule.request(url, options, function (response) {
         const status = response.statusCode
         if (status === 200) {
           resolve("valid")
         } else if (status === 401) {
           reject("invalid")
         } else {
-          reject(`Failed with status ${status}`)
+          reject(`Failed to validate: status ${status}`)
         }
       })
-      request.write("{}") // Send empty JSON body
+      request.write("") // Send empty body
       request.end()
     })
   }


### PR DESCRIPTION
Add the other query params to the auth request.

Update the error message to be standard for all integrations. Not all
integrations necessarily have the response status code on error, so
make sure all integrations start with "Failed to validate".

I removed the empty JSON body from the request, because we don't parse
the body in this request and our test server interpreted it as the
parameter `{}` with the value of an empty String.

Add test for diagnose Push API key output and report.
Update the diagnose tests with tests for the Push API key validation in
the diagnose CLI.

Depends on https://github.com/appsignal/diagnose_tests/pull/37
Blocked on https://github.com/appsignal/appsignal-nodejs/pull/484. Should be rebased after.