### PR TITLE
Print config opts camelcase

### DIFF
--- a/packages/nodejs/.changesets/diagnose-report-config-opts-are-now-printed-in-camel-case-format.md
+++ b/packages/nodejs/.changesets/diagnose-report-config-opts-are-now-printed-in-camel-case-format.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+---
+
+Diagnose report config opts are now printed in camel case format,
+matching how the configuration options are provided to the `Appsignal` object

--- a/packages/nodejs/src/__tests__/diagnose.test.ts
+++ b/packages/nodejs/src/__tests__/diagnose.test.ts
@@ -20,10 +20,10 @@ describe("DiagnoseTool", () => {
 
     expect(output.config.options).toHaveProperty("debug")
     expect(output.config.options).toHaveProperty("log")
-    expect(output.config.options).toHaveProperty("log_path")
-    expect(output.config.options).toHaveProperty("ca_file_path")
+    expect(output.config.options).toHaveProperty("logPath")
+    expect(output.config.options).toHaveProperty("caFilePath")
     expect(output.config.options).toHaveProperty("endpoint")
-    expect(output.config.options).toHaveProperty("env")
+    expect(output.config.options).toHaveProperty("environment")
 
     expect(output.process.uid).toEqual(process.getuid())
   })

--- a/packages/nodejs/src/diagnose.ts
+++ b/packages/nodejs/src/diagnose.ts
@@ -10,6 +10,7 @@ import { Configuration } from "./config"
 import { AGENT_VERSION, VERSION } from "./version"
 import { JS_TO_RUBY_MAPPING } from "./config/configmap"
 import { AppsignalOptions } from "."
+import { HashMap } from "@appsignal/types"
 
 interface FileMetadata {
   content?: string[]
@@ -54,8 +55,8 @@ export class DiagnoseTool {
       host: this.getHostData(),
       agent: this.#extension.diagnose(),
       config: {
-        options: this.getConfigData(),
-        sources: this.getSources()
+        options: this.#config.data,
+        sources: this.#config.sources
       },
       validation: { push_api_key: pushApiKeyValidation },
       process: {
@@ -222,7 +223,9 @@ export class DiagnoseTool {
     )
   }
 
-  public sendReport(data: object) {
+  public sendReport(data: HashMap<any>) {
+    data.config.options = this.getConfigData()
+    data.config.sources = this.getSources()
     const json = JSON.stringify({ diagnose: data })
 
     const config = this.#config.data


### PR DESCRIPTION
## Use camelcase for config opts in report 

Diagnose report now displays config options written in camelcase, and
the diagnose JSON still sends them written in snake case.

The transformation functions `getConfigData()` and `getSources` are
now only used to build the JSON.

`Diagnose` object holds sources and options in camel case directly from
the `Configuration` object.

## Update diagnose tests to fit with camel case opts

As diagnose object config options are now written in camel case, tests
need an update for it.

Closes #491 