### PR TITLE
Add AppSignal client to global object

### DIFF
--- a/packages/nodejs/.changesets/appsignal-client-is-available-in-global-object.md
+++ b/packages/nodejs/.changesets/appsignal-client-is-available-in-global-object.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+---
+
+The AppSignal client is stored on the global object as to make
+access easier for AppSignal developers.

--- a/packages/nodejs/src/__tests__/client.test.ts
+++ b/packages/nodejs/src/__tests__/client.test.ts
@@ -28,6 +28,10 @@ describe("BaseClient", () => {
     expect(client.isActive).toBeFalsy()
   })
 
+  it("stores the client on global object", () => {
+    expect(global.__APPSIGNAL__).toEqual(client)
+  })
+
   it("does not start the client if config is not valid", () => {
     process.env["APPSIGNAL_PUSH_API_KEY"] = undefined
     client = new BaseClient({ name, enableMinutelyProbes: false })

--- a/packages/nodejs/src/client.ts
+++ b/packages/nodejs/src/client.ts
@@ -45,6 +45,8 @@ export class BaseClient implements Client {
 
     initCorePlugins(this.instrumentation, { ignoreInstrumentation })
     initCoreProbes(this.metrics(), { enableMinutelyProbes })
+
+    this.storeInGlobal()
   }
 
   /**
@@ -144,5 +146,12 @@ export class BaseClient implements Client {
    */
   public demo() {
     return demo(this.tracer())
+  }
+
+  /**
+   * Stores the client in global object after initializing
+   */
+  private storeInGlobal(): void {
+    global.__APPSIGNAL__ = this
   }
 }

--- a/packages/nodejs/vendor.d.ts
+++ b/packages/nodejs/vendor.d.ts
@@ -17,3 +17,9 @@ declare module "require-in-the-middle" {
 
   export = Hook
 }
+
+declare module NodeJS {
+  interface Global {
+    __APPSIGNAL__: any
+  }
+}


### PR DESCRIPTION
The client entity is added to the global object under the name of
`__APPSIGNAL__` after initialization.

This helps to not to pass the client instance everywhere to perform
operations.

Closes #499 