### PR TITLE
Deprecate using a filename in logPath

### DIFF
--- a/packages/nodejs/.changesets/deprecate-passing-a-file-to-logpath-config-option.md
+++ b/packages/nodejs/.changesets/deprecate-passing-a-file-to-logpath-config-option.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+---
+
+Print deprecation message when passing a filename to `logPath` config option.
+This was already deprecated. Now it also prints a warning message on app start.

--- a/packages/nodejs/src/__tests__/config.test.ts
+++ b/packages/nodejs/src/__tests__/config.test.ts
@@ -129,13 +129,19 @@ describe("Configuration", () => {
     })
 
     describe("with logPath option with file specified", () => {
-      beforeEach(() => {
-        config = new Configuration({ logPath: "/other_path/appsignal.log" })
-      })
+      it("uses the overwritten path but changes the file name", () => {
+        const warnMock = jest
+          .spyOn(console, "warn")
+          .mockImplementation(() => {})
+        config = new Configuration({ logPath: "/other_path/foo.log" })
 
-      it("uses the overwritten path", () => {
+        expect(warnMock).toBeCalledWith(
+          "DEPRECATED: File names are no longer supported in the 'logPath' config option. Changing the filename to 'appsignal.log'"
+        )
         // Test backwards compatibility with previous behaviour
         expect(config.logFilePath).toEqual("/other_path/appsignal.log")
+
+        warnMock.mockReset()
       })
     })
   })

--- a/packages/nodejs/src/config.ts
+++ b/packages/nodejs/src/config.ts
@@ -48,11 +48,15 @@ export class Configuration {
   public get logFilePath(): string {
     let logPath = this.data["logPath"]!
 
-    if (!logPath.endsWith("appsignal.log")) {
-      logPath = path.join(logPath, "appsignal.log")
+    if (path.extname(logPath) != "") {
+      console.warn(
+        "DEPRECATED: File names are no longer supported in the 'logPath' config option. Changing the filename to 'appsignal.log'"
+      )
+
+      logPath = path.dirname(logPath)
     }
 
-    return logPath
+    return path.join(logPath, "appsignal.log")
   }
 
   /**


### PR DESCRIPTION
Using a filename in the logPath config option is no longer supported.
Now, if a filename is received, a deprecation message is shown and the
provided filename is changed to `appsignal.log`

Closes #490 