### PR TITLE
Change global augmentation for newer TS

### DIFF
--- a/packages/nodejs/.changesets/fix-compatibility-for-global-object-augmentation.md
+++ b/packages/nodejs/.changesets/fix-compatibility-for-global-object-augmentation.md
@@ -1,0 +1,5 @@
+---
+bump: "patch"
+---
+
+Fix TypeScript compatibility for global object augmentation.

--- a/packages/nodejs/global.d.ts
+++ b/packages/nodejs/global.d.ts
@@ -1,0 +1,5 @@
+export {}
+
+declare global {
+  var __APPSIGNAL__: any
+}

--- a/packages/nodejs/tsconfig.json
+++ b/packages/nodejs/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["src/**/*", "vendor.d.ts"],
+  "include": ["src/**/*", "vendor.d.ts", "global.d.ts"],
   "exclude": [
     "src/**/__tests__",
     "src/**/__mocks__"

--- a/packages/nodejs/vendor.d.ts
+++ b/packages/nodejs/vendor.d.ts
@@ -17,9 +17,3 @@ declare module "require-in-the-middle" {
 
   export = Hook
 }
-
-declare module NodeJS {
-  interface Global {
-    __APPSIGNAL__: any
-  }
-}


### PR DESCRIPTION
Newer TypeScript versions don't accept the way we augment the global
object making the build fail sometimes. Doing it this way, we ensure it
always works.