### PR TITLE
Add request headers allowlist

### DIFF
--- a/packages/express/.changesets/requestheaders-config-option-is-now-available.md
+++ b/packages/express/.changesets/requestheaders-config-option-is-now-available.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+---
+
+Collect request headers from express requests by default. See also our new `requestHeaders` config
+option, added in the @appsignal/nodejs package.

--- a/packages/nodejs/.changesets/requestheaders-config-option-is-now-available.md
+++ b/packages/nodejs/.changesets/requestheaders-config-option-is-now-available.md
@@ -1,0 +1,8 @@
+---
+bump: "patch"
+---
+
+The `requestHeaders` config option is now available. An allow list that gives the ability to define
+which request headers you want to be shown in sample detail views. The default is a list of common
+headers that do not include [personal identifiable information](https://docs.appsignal.com/appsignal/gdpr.html#allowed-request-headers-only).
+Read more about [request headers](https://docs.appsignal.com/application/header-filtering.html) on our documentation website.

--- a/packages/nodejs/global.d.ts
+++ b/packages/nodejs/global.d.ts
@@ -1,5 +1,7 @@
 export {}
 
+import { Client } from "./src/interfaces"
+
 declare global {
-  var __APPSIGNAL__: any
+  var __APPSIGNAL__: Client
 }

--- a/packages/nodejs/src/__tests__/config.test.ts
+++ b/packages/nodejs/src/__tests__/config.test.ts
@@ -29,6 +29,22 @@ describe("Configuration", () => {
     ignoreNamespaces: [],
     log: "file",
     logPath: "/tmp",
+    requestHeaders: [
+      "accept",
+      "accept-charset",
+      "accept-encoding",
+      "accept-language",
+      "cache-control",
+      "connection",
+      "content-length",
+      "path-info",
+      "range",
+      "request-method",
+      "request-uri",
+      "server-name",
+      "server-port",
+      "server-protocol"
+    ],
     transactionDebugMode: false
   }
 

--- a/packages/nodejs/src/__tests__/config.test.ts
+++ b/packages/nodejs/src/__tests__/config.test.ts
@@ -37,13 +37,7 @@ describe("Configuration", () => {
       "cache-control",
       "connection",
       "content-length",
-      "path-info",
-      "range",
-      "request-method",
-      "request-uri",
-      "server-name",
-      "server-port",
-      "server-protocol"
+      "range"
     ],
     transactionDebugMode: false
   }

--- a/packages/nodejs/src/cli/diagnose.ts
+++ b/packages/nodejs/src/cli/diagnose.ts
@@ -416,5 +416,9 @@ export class Diagnose {
 }
 
 function format_value(value: any) {
-  return util.inspect(value)
+  if (typeof value == "object") {
+    return JSON.stringify(value)
+  } else {
+    return util.inspect(value)
+  }
 }

--- a/packages/nodejs/src/config.ts
+++ b/packages/nodejs/src/config.ts
@@ -128,13 +128,7 @@ export class Configuration {
         "cache-control",
         "connection",
         "content-length",
-        "path-info",
-        "range",
-        "request-method",
-        "request-uri",
-        "server-name",
-        "server-port",
-        "server-protocol"
+        "range"
       ],
       transactionDebugMode: false
     }

--- a/packages/nodejs/src/config.ts
+++ b/packages/nodejs/src/config.ts
@@ -120,6 +120,22 @@ export class Configuration {
       ignoreNamespaces: [],
       log: "file",
       logPath: this._tmpdir(),
+      requestHeaders: [
+        "accept",
+        "accept-charset",
+        "accept-encoding",
+        "accept-language",
+        "cache-control",
+        "connection",
+        "content-length",
+        "path-info",
+        "range",
+        "request-method",
+        "request-uri",
+        "server-name",
+        "server-port",
+        "server-protocol"
+      ],
       transactionDebugMode: false
     }
   }

--- a/packages/nodejs/src/config/configmap.ts
+++ b/packages/nodejs/src/config/configmap.ts
@@ -79,6 +79,7 @@ export const JS_TO_RUBY_MAPPING: { [key: string]: string } = {
   log: "log",
   logPath: "log_path",
   name: "name",
+  requestHeaders: "request_headers",
   revision: "revision",
   runningInContainer: "running_in_container",
   transactionDebugMode: "transaction_debug_mode",


### PR DESCRIPTION
## Add requestHeaders config option and defaults

`requestHeaders` is a configurable option now. Default values are based
on the other integrations using Node.js naming conventions for them.

## Add requestHeaders allow list feature

`requestHeaders` allow list is now implemented. Now users are able to
define a list of headers they want to be shown in AppSignal. All
integrations except from Express make use of the core HTTP
instrumentation.

As we don't have helpers yet to access the Client stored in global
object, the code is repeated in HTTP instrumentation, and in Express
integration. This will be removed in favor of global helpers in the
future.

Closes #487 