### PR TITLE
Rename apiKey config option to pushApiKey

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ const { Appsignal } = require("@appsignal/nodejs");
 const appsignal = new Appsignal({
   active: true,
   name: "<YOUR APPLICATION NAME>"
-  apiKey: "<YOUR API KEY>"
+  pushApiKey: "<YOUR API KEY>"
 });
 
 // ...all the rest of your code goes here!

--- a/packages/apollo-server/README.md
+++ b/packages/apollo-server/README.md
@@ -35,7 +35,7 @@ const { ApolloServer } = require("apollo-server")
 const appsignal = new Appsignal({
   active: true,
   name: "<YOUR APPLICATION NAME>",
-  apiKey: "<YOUR API KEY>"
+  pushApiKey: "<YOUR API KEY>"
 })
 
 // The GraphQL schema

--- a/packages/apollo-server/test/example/index.js
+++ b/packages/apollo-server/test/example/index.js
@@ -4,7 +4,7 @@ const { createApolloPlugin } = require("../../../apollo-server")
 const appsignal = new Appsignal({
   active: true,
   name: "<YOUR APPLICATION NAME>",
-  apiKey: "<YOUR API KEY>"
+  pushApiKey: "<YOUR API KEY>"
 })
 
 const { ApolloServer, gql } = require("apollo-server")

--- a/packages/express/README.md
+++ b/packages/express/README.md
@@ -29,7 +29,7 @@ const { Appsignal } = require("@appsignal/nodejs")
 const appsignal = new Appsignal({
   active: true,
   name: "<YOUR APPLICATION NAME>",
-  apiKey: "<YOUR API KEY>"
+  pushApiKey: "<YOUR API KEY>"
 })
 
 const express = require("express")
@@ -51,7 +51,7 @@ const { Appsignal } = require("@appsignal/nodejs")
 const appsignal = new Appsignal({
   active: true,
   name: "<YOUR APPLICATION NAME>"
-  apiKey: "<YOUR API KEY>"
+  pushApiKey: "<YOUR API KEY>"
 })
 
 const express = require("express")

--- a/packages/express/test/example/index.js
+++ b/packages/express/test/example/index.js
@@ -3,7 +3,7 @@ const { Appsignal } = require("../../../nodejs")
 const appsignal = new Appsignal({
   active: true,
   name: "<YOUR APPLICATION NAME>",
-  apiKey: "<YOUR API KEY>"
+  pushApiKey: "<YOUR API KEY>"
 })
 
 const express = require("express")

--- a/packages/koa/README.md
+++ b/packages/koa/README.md
@@ -29,7 +29,7 @@ const { Appsignal } = require("@appsignal/nodejs");
 const appsignal = new Appsignal({
   active: true,
   name: "<YOUR APPLICATION NAME>",
-  apiKey: "<YOUR API KEY>"
+  pushApiKey: "<YOUR API KEY>"
 });
 
 appsignal.instrument(require("@appsignal/koa"));

--- a/packages/koa/test/example/index.js
+++ b/packages/koa/test/example/index.js
@@ -3,7 +3,7 @@ const { Appsignal } = require("../../../nodejs")
 const appsignal = new Appsignal({
   active: true,
   name: "<YOUR APPLICATION NAME>",
-  apiKey: "<YOUR API KEY>"
+  pushApiKey: "<YOUR API KEY>"
 })
 
 appsignal.instrument(require("@appsignal/koa"))

--- a/packages/nextjs/README.md
+++ b/packages/nextjs/README.md
@@ -37,7 +37,7 @@ const { Appsignal } = require("@appsignal/nodejs");
 const appsignal = new Appsignal({
   active: true,
   name: "<YOUR APPLICATION NAME>",
-  apiKey: "<YOUR API KEY>",
+  pushApiKey: "<YOUR API KEY>",
 });
 
 const { getRequestHandler } = require("@appsignal/nextjs");
@@ -82,7 +82,7 @@ const { Appsignal } = require("@appsignal/nodejs");
 const appsignal = new Appsignal({
   active: true,
   name: "<YOUR APPLICATION NAME>",
-  apiKey: "<YOUR API KEY>",
+  pushApiKey: "<YOUR API KEY>",
 });
 
 const { getRequestHandler } = require("@appsignal/nextjs");
@@ -129,7 +129,7 @@ const { Appsignal } = require("@appsignal/nodejs");
 const appsignal = new Appsignal({
   active: true,
   name: "<YOUR APPLICATION NAME>",
-  apiKey: "<YOUR API KEY>",
+  pushApiKey: "<YOUR API KEY>",
 });
 
 const {

--- a/packages/nextjs/test/example/server.js
+++ b/packages/nextjs/test/example/server.js
@@ -5,7 +5,7 @@ const { Appsignal } = require("../../../nodejs")
 const appsignal = new Appsignal({
   active: true,
   name: "<YOUR APPLICATION NAME>",
-  apiKey: "<YOUR API KEY>"
+  pushApiKey: "<YOUR API KEY>"
 })
 
 const { getRequestHandler } = require("../../../nextjs")

--- a/packages/nodejs/.changesets/rename-apikey-option-to-pushapikey.md
+++ b/packages/nodejs/.changesets/rename-apikey-option-to-pushapikey.md
@@ -1,0 +1,5 @@
+---
+bump: "patch"
+---
+
+Rename the `apiKey` option to `pushApiKey` to match other AppSignal integrations. If `apiKey` is set it will automatically set `pushApiKey`. The `apiKey` option will be removed in the next major version of this package.

--- a/packages/nodejs/README.md
+++ b/packages/nodejs/README.md
@@ -33,7 +33,7 @@ const { Appsignal } = require("@appsignal/nodejs");
 const appsignal = new Appsignal({
   active: true,
   name: "<YOUR APPLICATION NAME>"
-  apiKey: "<YOUR API KEY>"
+  pushApiKey: "<YOUR API KEY>"
 });
 
 // ...all the rest of your code goes here!

--- a/packages/nodejs/src/__tests__/client.test.ts
+++ b/packages/nodejs/src/__tests__/client.test.ts
@@ -7,12 +7,12 @@ jest.mock("../tracer")
 
 describe("BaseClient", () => {
   const name = "TEST APP"
-  const apiKey = "TEST_API_KEY"
+  const pushApiKey = "TEST_API_KEY"
 
   let client: BaseClient
 
   // enableMinutelyProbes is set to false so we don't leak timers
-  const DEFAULT_OPTS = { name, apiKey, enableMinutelyProbes: false }
+  const DEFAULT_OPTS = { name, pushApiKey, enableMinutelyProbes: false }
 
   beforeEach(() => {
     client = new BaseClient({ ...DEFAULT_OPTS })

--- a/packages/nodejs/src/__tests__/config.test.ts
+++ b/packages/nodejs/src/__tests__/config.test.ts
@@ -1,10 +1,11 @@
+import os from "os"
 import path from "path"
 import { VERSION } from "../version"
 import { Configuration } from "../config"
 
 describe("Configuration", () => {
   const name = "TEST APP"
-  const apiKey = "TEST_API_KEY"
+  const pushApiKey = "TEST_API_KEY"
 
   let config: Configuration
   let initialEnv: { [key: string]: any }
@@ -110,9 +111,25 @@ describe("Configuration", () => {
     })
   })
 
+  describe("apiKey option", () => {
+    it("sets the pushApiKey config option with the apiKey value", () => {
+      const warnMock = jest.spyOn(console, "warn").mockImplementation(() => {})
+      const apiKey = "my key"
+      config = new Configuration({ apiKey })
+
+      expect(config.data.pushApiKey).toEqual(apiKey)
+      expect(config.data.apiKey).toBeUndefined()
+      expect(config.sources.initial.pushApiKey).toEqual(apiKey)
+      expect(config.sources.initial.apiKey).toBeUndefined()
+      expect(warnMock).toBeCalledWith(
+        "DEPRECATED: The `apiKey` config option was renamed to `pushApiKey`. Please rename the config option given to the Appsignal module."
+      )
+    })
+  })
+
   describe("logFilePath", () => {
     it("uses the default log file path", () => {
-      config = new Configuration({ name, apiKey })
+      config = new Configuration({ name, pushApiKey })
 
       expect(config.logFilePath).toEqual("/tmp/appsignal.log")
     })
@@ -193,7 +210,7 @@ describe("Configuration", () => {
         new Configuration({
           name,
           active: true,
-          apiKey,
+          pushApiKey,
           debug: true,
           dnsServers: ["8.8.8.8", "8.8.4.4"],
           enableHostMetrics: false,
@@ -242,7 +259,7 @@ describe("Configuration", () => {
         expect(env("_APPSIGNAL_PUSH_API_ENDPOINT")).toEqual(
           "https://push.appsignal.com"
         )
-        expect(env("_APPSIGNAL_PUSH_API_KEY")).toEqual(apiKey)
+        expect(env("_APPSIGNAL_PUSH_API_KEY")).toEqual(pushApiKey)
         expect(env("_APPSIGNAL_RUNNING_IN_CONTAINER")).toEqual("true")
         // Only set because `debug` is set to true
         // @TODO: https://github.com/appsignal/appsignal-nodejs/issues/379
@@ -255,23 +272,23 @@ describe("Configuration", () => {
   })
 
   describe(".isValid", () => {
-    it("is valid if apiKey is present", () => {
-      config = new Configuration({ apiKey })
+    it("is valid if pushApiKey is present", () => {
+      config = new Configuration({ pushApiKey })
       expect(config.isValid).toBeTruthy()
     })
 
-    it("is invalid if apiKey is not present", () => {
+    it("is invalid if pushApiKey is not present", () => {
       config = new Configuration({ name })
       expect(config.isValid).toBeFalsy()
     })
 
-    it("is invalid if apiKey is an empty string", () => {
-      config = new Configuration({ name, apiKey: "" })
+    it("is invalid if pushApiKey is an empty string", () => {
+      config = new Configuration({ name, pushApiKey: "" })
       expect(config.isValid).toBeFalsy()
     })
 
-    it("is invalid if apiKey is a string with only whitespaces", () => {
-      config = new Configuration({ name, apiKey: "  " })
+    it("is invalid if pushApiKey is a string with only whitespaces", () => {
+      config = new Configuration({ name, pushApiKey: "  " })
       expect(config.isValid).toBeFalsy()
     })
   })

--- a/packages/nodejs/src/config.ts
+++ b/packages/nodejs/src/config.ts
@@ -1,3 +1,4 @@
+import os from "os"
 import path from "path"
 
 import { VERSION } from "./version"
@@ -18,6 +19,13 @@ export class Configuration {
   sources: HashMap<Partial<AppsignalOptions>>
 
   constructor(options: Partial<AppsignalOptions>) {
+    if (options.apiKey) {
+      console.warn(
+        "DEPRECATED: The `apiKey` config option was renamed to `pushApiKey`. Please rename the config option given to the Appsignal module."
+      )
+      options.pushApiKey = options.apiKey
+      delete options.apiKey
+    }
     this.sources = {
       default: this._defaultValues(),
       env: this._loadFromEnvironment(),
@@ -42,7 +50,7 @@ export class Configuration {
    * Returns `true` if the current configuration is valid.
    */
   public get isValid(): boolean {
-    return (this.data.apiKey || "").trim() !== ""
+    return (this.data.pushApiKey || "").trim() !== ""
   }
 
   public get logFilePath(): string {

--- a/packages/nodejs/src/config/configmap.ts
+++ b/packages/nodejs/src/config/configmap.ts
@@ -20,7 +20,7 @@ export const ENV_TO_KEY_MAPPING: { [key: string]: string } = {
   APPSIGNAL_LOG: "log",
   APPSIGNAL_LOG_PATH: "logPath",
   APPSIGNAL_PUSH_API_ENDPOINT: "endpoint",
-  APPSIGNAL_PUSH_API_KEY: "apiKey",
+  APPSIGNAL_PUSH_API_KEY: "pushApiKey",
   APPSIGNAL_REQUEST_HEADERS: "requestHeaders",
   APPSIGNAL_RUNNING_IN_CONTAINER: "runningInContainer",
   APPSIGNAL_SEND_PARAMS: "sendParams",
@@ -50,7 +50,7 @@ export const PRIVATE_ENV_MAPPING: { [key: string]: string } = {
   _APPSIGNAL_IGNORE_NAMESPACES: "ignoreNamespaces",
   _APPSIGNAL_LOG: "log",
   _APPSIGNAL_PUSH_API_ENDPOINT: "endpoint",
-  _APPSIGNAL_PUSH_API_KEY: "apiKey",
+  _APPSIGNAL_PUSH_API_KEY: "pushApiKey",
   _APPSIGNAL_RUNNING_IN_CONTAINER: "runningInContainer",
   _APPSIGNAL_TRANSACTION_DEBUG_MODE: "debug",
   _APPSIGNAL_WORKING_DIRECTORY_PATH: "workingDirectoryPath",
@@ -60,7 +60,7 @@ export const PRIVATE_ENV_MAPPING: { [key: string]: string } = {
 
 export const JS_TO_RUBY_MAPPING: { [key: string]: string } = {
   active: "active",
-  apiKey: "push_api_key",
+  pushApiKey: "push_api_key",
   caFilePath: "ca_file_path",
   debug: "debug",
   dnsServers: "dns_servers",

--- a/packages/nodejs/src/diagnose.ts
+++ b/packages/nodejs/src/diagnose.ts
@@ -114,7 +114,7 @@ export class DiagnoseTool {
     return new Promise((resolve, reject) => {
       const config = this.#config.data
       const params = new URLSearchParams({
-        api_key: config["apiKey"] || "",
+        api_key: config["pushApiKey"] || "",
         name: config["name"] || "",
         environment: config["environment"] || "",
         hostname: config["hostname"] || ""
@@ -230,7 +230,7 @@ export class DiagnoseTool {
 
     const config = this.#config.data
     const params = new URLSearchParams({
-      api_key: config["apiKey"] || "",
+      api_key: config["pushApiKey"] || "",
       name: config["name"] || "",
       environment: config["environment"] || "",
       hostname: config["hostname"] || ""

--- a/packages/nodejs/src/interfaces/options.ts
+++ b/packages/nodejs/src/interfaces/options.ts
@@ -21,6 +21,7 @@ export interface AppsignalOptions {
   log: string
   logPath: string
   name: string
+  pushApiKey: string
   requestHeaders: string[]
   revision: string
   runningInContainer: boolean


### PR DESCRIPTION
Rename the `apiKey` config option to `pushApiKey` to match the naming in
the other integrations (Ruby & Elixir).

If the `apiKey` config option is set (which will be the case for
everyone upgrading) the `pushApiKey` config option will be set with the
`apiKey` value.

It does only for the `apiKey` option given to the constructor, the env
var is mapped to the new key by the config keys map.