### PR TITLE
Check if logPath is a writable dir

### DIFF
--- a/packages/nodejs/.changesets/logpath-config-option-only-allows-writable-paths--if-the-provided-path-is-not-writable,-it'll-automatically-change-to-default-os-tmp-path-after-a-warning-.md
+++ b/packages/nodejs/.changesets/logpath-config-option-only-allows-writable-paths--if-the-provided-path-is-not-writable,-it'll-automatically-change-to-default-os-tmp-path-after-a-warning-.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+---
+
+The logPath config option only allows writable paths. If the provided path is not writable,
+it'll automatically change to the Operating System's temporary directory (`/tmp`).

--- a/packages/nodejs/src/__tests__/config.test.ts
+++ b/packages/nodejs/src/__tests__/config.test.ts
@@ -1,5 +1,7 @@
 import os from "os"
 import path from "path"
+import fs from "fs"
+
 import { VERSION } from "../version"
 import { Configuration } from "../config"
 
@@ -44,6 +46,7 @@ describe("Configuration", () => {
 
   beforeAll(() => {
     initialEnv = Object.assign({}, process.env)
+    jest.clearAllMocks()
   })
 
   afterAll(() => {
@@ -129,6 +132,9 @@ describe("Configuration", () => {
 
   describe("logFilePath", () => {
     it("uses the default log file path", () => {
+      const fsAccessSpy = jest
+        .spyOn(fs, "accessSync")
+        .mockImplementation(() => {})
       config = new Configuration({ name, pushApiKey })
 
       expect(config.logFilePath).toEqual("/tmp/appsignal.log")
@@ -140,12 +146,41 @@ describe("Configuration", () => {
       })
 
       it("uses the overwritten path", () => {
+        const fsAccessSpy = jest
+          .spyOn(fs, "accessSync")
+          .mockImplementation(() => {})
+
+        jest.spyOn(fs, "accessSync").mockImplementation(() => {})
         expect(config.logFilePath).toEqual("/other_path/appsignal.log")
+      })
+    })
+
+    describe("when logPath is not writtable", () => {
+      it("switches it to default tmp dir", () => {
+        const fsAccessSpy = jest
+          .spyOn(fs, "accessSync")
+          .mockImplementation(() => {
+            throw "Error"
+          })
+        const warnMock = jest
+          .spyOn(console, "warn")
+          .mockImplementation(() => {})
+
+        config = new Configuration({ logPath: "/foo_dir" })
+
+        expect(warnMock).toBeCalledWith(
+          `Unable to log to '/foo_dir'. Logging to '/tmp' instead. Please check the permissions for the configured 'logPath' directory`
+        )
+        expect(config.logFilePath).toEqual("/tmp/appsignal.log")
       })
     })
 
     describe("with logPath option with file specified", () => {
       it("uses the overwritten path but changes the file name", () => {
+        const fsAccessSpy = jest
+          .spyOn(fs, "accessSync")
+          .mockImplementation(() => {})
+
         const warnMock = jest
           .spyOn(console, "warn")
           .mockImplementation(() => {})
@@ -156,8 +191,6 @@ describe("Configuration", () => {
         )
         // Test backwards compatibility with previous behaviour
         expect(config.logFilePath).toEqual("/other_path/appsignal.log")
-
-        warnMock.mockReset()
       })
     })
   })

--- a/packages/nodejs/src/__tests__/diagnose.test.ts
+++ b/packages/nodejs/src/__tests__/diagnose.test.ts
@@ -5,8 +5,11 @@ import { VERSION, AGENT_VERSION } from "../version"
 describe("DiagnoseTool", () => {
   let tool: DiagnoseTool
 
+  const fsAccessSpy = jest.spyOn(fs, "accessSync").mockImplementation(() => {})
+
   beforeEach(() => {
     tool = new DiagnoseTool({})
+    jest.clearAllMocks()
   })
 
   it("generates a configuration", async () => {

--- a/packages/nodejs/src/config.ts
+++ b/packages/nodejs/src/config.ts
@@ -1,5 +1,6 @@
-import os from "os"
 import path from "path"
+import os from "os"
+import fs from "fs"
 
 import { VERSION } from "./version"
 import { AppsignalOptions } from "./interfaces/options"
@@ -64,7 +65,35 @@ export class Configuration {
       logPath = path.dirname(logPath)
     }
 
+    try {
+      fs.accessSync(logPath, fs.constants.W_OK)
+    } catch (_err) {
+      const newLogPath = this._tmpdir()
+
+      console.warn(
+        `Unable to log to '${logPath}'. Logging to '${newLogPath}' instead. Please check the permissions for the configured 'logPath' directory`
+      )
+
+      logPath = newLogPath
+    }
+
     return path.join(logPath, "appsignal.log")
+  }
+
+  /**
+   * Returns default OS tmp dir. Uses OS package for Windows. Linux and macOS
+   * have `/tmp` hardcoded as a default
+   *
+   * @private
+   */
+  private _tmpdir(): string {
+    const isWindows = process.platform == "win32"
+
+    if (isWindows) {
+      return os.tmpdir()
+    } else {
+      return "/tmp"
+    }
   }
 
   /**
@@ -89,7 +118,7 @@ export class Configuration {
       ignoreErrors: [],
       ignoreNamespaces: [],
       log: "file",
-      logPath: "/tmp",
+      logPath: this._tmpdir(),
       transactionDebugMode: false
     }
   }


### PR DESCRIPTION
When writing `logFilePath` based on the provided `logPath`, now we
perform a check to see if the dir is writable. If the provided dir is
not writable, it is switched by `/tmp` on Linux and macOS, and to the
system default for Windows.

Closes #492 