### PR TITLE
Set log output to stdout on Heroku hosts

### DIFF
--- a/packages/nodejs/.changesets/log-stdout-on-heroku.md
+++ b/packages/nodejs/.changesets/log-stdout-on-heroku.md
@@ -1,0 +1,5 @@
+---
+bump: "patch"
+---
+
+Default log output to app STDOUT on Heroku dyno's. This makes the AppSignal logs available in the Heroku app's logs.

--- a/packages/nodejs/src/__tests__/config.test.ts
+++ b/packages/nodejs/src/__tests__/config.test.ts
@@ -62,6 +62,23 @@ describe("Configuration", () => {
       expect(config.data).toEqual(expectedDefaultConfig)
 
       expect(config.sources.default).toEqual(expectedDefaultConfig)
+      expect(config.sources.system).toEqual({})
+      expect(config.sources.initial).toEqual({})
+      expect(config.sources.env).toEqual({})
+    })
+  })
+
+  describe("system values", () => {
+    it("sets log output to stdout on Heroku", () => {
+      process.env.DYNO = "web.1"
+      const systemConfig = { log: "stdout" }
+      config = new Configuration({})
+      delete process.env.DYNO
+
+      expect(config.data).toEqual({ ...expectedDefaultConfig, ...systemConfig })
+
+      expect(config.sources.default).toEqual(expectedDefaultConfig)
+      expect(config.sources.system).toEqual(systemConfig)
       expect(config.sources.initial).toEqual({})
       expect(config.sources.env).toEqual({})
     })
@@ -84,6 +101,7 @@ describe("Configuration", () => {
       expect(config.data).toEqual(options)
 
       expect(config.sources.default).toEqual(expectedDefaultConfig)
+      expect(config.sources.system).toEqual({})
       expect(config.sources.initial).toEqual(initialOptions)
       expect(config.sources.env).toEqual({})
     })
@@ -106,6 +124,7 @@ describe("Configuration", () => {
       expect(config.data).toEqual(expectedConfig)
 
       expect(config.sources.default).toEqual(expectedDefaultConfig)
+      expect(config.sources.system).toEqual({})
       expect(config.sources.initial).toEqual({})
       expect(config.sources.env).toEqual(envOptions)
     })

--- a/packages/nodejs/src/config.ts
+++ b/packages/nodejs/src/config.ts
@@ -28,6 +28,7 @@ export class Configuration {
     }
     this.sources = {
       default: this._defaultValues(),
+      system: this._systemValues(),
       env: this._loadFromEnvironment(),
       initial: options
     }
@@ -92,6 +93,19 @@ export class Configuration {
       logPath: "/tmp",
       transactionDebugMode: false
     }
+  }
+
+  /**
+   * Config options based on the host environment.
+   *
+   * @private
+   */
+  private _systemValues(): { [key: string]: any } {
+    const config = {} as { [key: string]: any }
+    if (process.env.DYNO) {
+      config["log"] = "stdout"
+    }
+    return config
   }
 
   /**


### PR DESCRIPTION
When the host is detected as a Heroku dyno (env var DYNO is set), we
default the log output to "stdout". We have the same behavior in our
other integrations.

Heroku has its own log drain to read all the app logs, and it's
difficult to access the `appsignal.log` file on dyno's, as we've noticed
for the diagnose report as well.

I've not made an exception for Dokku, as we've recently done for the
host metrics. Dokku also sets a DYNO env var and thus the log will
default to "stdout" on Dokku too. We've had no reports about problems
with this in the past in our other integrations.

Note that this config option only applies to the process output and
extension logger. The agent will always log to a file as it's a separate
process.

Fixes https://github.com/appsignal/appsignal-nodejs/issues/495
Relies on https://github.com/appsignal/diagnose_tests/pull/48