### PR TITLE
Fix diagnose log_dir_path value

### DIFF
--- a/packages/nodejs/.changesets/fix-diagnose-log_dir_path-path.md
+++ b/packages/nodejs/.changesets/fix-diagnose-log_dir_path-path.md
@@ -1,0 +1,5 @@
+---
+bump: "patch"
+---
+
+Fix the diagnose's `log_dir_path` path check. It now always checks the actual log file's parent directory, rather than the configured path. These two values may differ as the package does a permission check to see if the `logPath` is writable or not.

--- a/packages/nodejs/src/diagnose.ts
+++ b/packages/nodejs/src/diagnose.ts
@@ -148,7 +148,7 @@ export class DiagnoseTool {
         path: process.cwd()
       },
       log_dir_path: {
-        path: this.#config.data.logPath!.replace("/appsignal.log", "")
+        path: path.dirname(logFilePath)
       },
       "appsignal.log": {
         path: logFilePath,

--- a/packages/nodejs/src/diagnose.ts
+++ b/packages/nodejs/src/diagnose.ts
@@ -143,8 +143,7 @@ export class DiagnoseTool {
 
     const logFilePath = this.#config.logFilePath
 
-    // add any paths we want to check to this object!
-    const files = {
+    const pathsToCheck = {
       working_dir: {
         path: process.cwd()
       },
@@ -157,7 +156,7 @@ export class DiagnoseTool {
       }
     }
 
-    Object.entries(files).forEach(([key, data]) => {
+    Object.entries(pathsToCheck).forEach(([key, data]) => {
       const { path } = data
 
       try {


### PR DESCRIPTION
## Rename variable with paths to pathsToCheck

The diagnose doesn't only check "files", but also directories. Use the
`pathsToCheck` variable name to be more descriptive and not confuse
readers.

Remove the comment as it's redundant.

## Fix diagnose log_dir_path value

Use the `logFilePath`'s value as a base and get the parent directory
path to check.

This way the `log_dir_path` and `appsignal.log` paths don't point at
different directories. This could have happen because the `logFilePath`
getter (used by `appsignal.log`) does a permission check and falls back
on the system `/tmp` dir if the user configured path can't be written
to.
