### PR TITLE
Fix writable path check in diagnose

### DIFF
--- a/packages/nodejs/.changesets/fix-writable-check-in-diagnose-report.md
+++ b/packages/nodejs/.changesets/fix-writable-check-in-diagnose-report.md
@@ -1,0 +1,5 @@
+---
+bump: "patch"
+---
+
+Fix writable check for paths in the diagnose report. Previously it only checked if a path was readable, not writable.

--- a/packages/nodejs/src/diagnose.ts
+++ b/packages/nodejs/src/diagnose.ts
@@ -173,7 +173,7 @@ export class DiagnoseTool {
             uid
           },
           type: getPathType(stats),
-          writable: isWriteableFile(path)
+          writable: isWriteable(path)
         }
       } catch (_) {
         paths[key] = {
@@ -295,9 +295,9 @@ function reportPath(): string {
   return path.join(`/tmp/appsignal-${reportPathDigest}-install.report`)
 }
 
-function isWriteableFile(path: string): boolean {
+function isWriteable(path: string): boolean {
   try {
-    fs.accessSync(path, fs.constants.R_OK)
+    fs.accessSync(path, fs.constants.W_OK)
     return true
   } catch (e) {
     return false


### PR DESCRIPTION
The `fs.accessSync` in the `isWriteableFile` function only checked if
the path was readable with `fs.constants.R_OK`. Not if it was writable
with `fs.constants.W_OK`.

> - `F_OK`: Flag indicating that the file is visible to the calling
>    process. This is useful for determining if a file exists, but says
>    nothing about rwx permissions. Default if no mode is specified.
> - `R_OK`: Flag indicating that the file can be read by the calling
>    process.
> - `W_OK`: Flag indicating that the file can be written by the calling
>    process.
> - `X_OK`: Flag indicating that the file can be executed by the
>    calling process. This has no effect on Windows (will behave like
>    fs.constants.F_OK).

Source: https://nodejs.org/api/fs.html#file-access-constants

I've also renamed the function to `isWriteable` because it doesn't only
check files, but also directories.