### PR TITLE
Check if logPath fallback is writable

### DIFF
--- a/packages/nodejs/.changesets/fix-log-writable-check.md
+++ b/packages/nodejs/.changesets/fix-log-writable-check.md
@@ -1,0 +1,5 @@
+---
+bump: "patch"
+---
+
+Check if the fallback log directory can be written to and print a warning if no log can be written there.

--- a/packages/nodejs/src/__tests__/config.test.ts
+++ b/packages/nodejs/src/__tests__/config.test.ts
@@ -28,7 +28,6 @@ describe("Configuration", () => {
     ignoreErrors: [],
     ignoreNamespaces: [],
     log: "file",
-    logPath: "/tmp",
     requestHeaders: [
       "accept",
       "accept-charset",
@@ -170,11 +169,8 @@ describe("Configuration", () => {
     })
 
     describe("with logPath option", () => {
-      beforeEach(() => {
+      it("uses the configured path", () => {
         config = new Configuration({ logPath: "/other_path" })
-      })
-
-      it("uses the overwritten path", () => {
         const fsAccessSpy = jest
           .spyOn(fs, "accessSync")
           .mockImplementation(() => {})
@@ -182,25 +178,25 @@ describe("Configuration", () => {
         jest.spyOn(fs, "accessSync").mockImplementation(() => {})
         expect(config.logFilePath).toEqual("/other_path/appsignal.log")
       })
-    })
 
-    describe("when logPath is not writtable", () => {
-      it("switches it to default tmp dir", () => {
-        const fsAccessSpy = jest
-          .spyOn(fs, "accessSync")
-          .mockImplementation(() => {
-            throw "Error"
-          })
-        const warnMock = jest
-          .spyOn(console, "warn")
-          .mockImplementation(() => {})
+      describe("when the logPath directory can't be written to", () => {
+        it("uses the system tmp dir", () => {
+          const fsAccessSpy = jest
+            .spyOn(fs, "accessSync")
+            .mockImplementation(path => {
+              throw "Error"
+            })
+          const warnMock = jest
+            .spyOn(console, "warn")
+            .mockImplementation(() => {})
 
-        config = new Configuration({ logPath: "/foo_dir" })
+          config = new Configuration({ logPath: "/foo_dir" })
 
-        expect(warnMock).toBeCalledWith(
-          `Unable to log to '/foo_dir'. Logging to '/tmp' instead. Please check the permissions for the configured 'logPath' directory`
-        )
-        expect(config.logFilePath).toEqual("/tmp/appsignal.log")
+          expect(warnMock).toHaveBeenLastCalledWith(
+            `Unable to log to '/foo_dir'. Logging to '/tmp' instead. Please check the permissions of the 'logPath' directory.`
+          )
+          expect(config.logFilePath).toEqual("/tmp/appsignal.log")
+        })
       })
     })
 
@@ -215,7 +211,7 @@ describe("Configuration", () => {
           .mockImplementation(() => {})
         config = new Configuration({ logPath: "/other_path/foo.log" })
 
-        expect(warnMock).toBeCalledWith(
+        expect(warnMock).toHaveBeenLastCalledWith(
           "DEPRECATED: File names are no longer supported in the 'logPath' config option. Changing the filename to 'appsignal.log'"
         )
         // Test backwards compatibility with previous behaviour

--- a/packages/nodejs/src/__tests__/diagnose.test.ts
+++ b/packages/nodejs/src/__tests__/diagnose.test.ts
@@ -23,7 +23,6 @@ describe("DiagnoseTool", () => {
 
     expect(output.config.options).toHaveProperty("debug")
     expect(output.config.options).toHaveProperty("log")
-    expect(output.config.options).toHaveProperty("logPath")
     expect(output.config.options).toHaveProperty("caFilePath")
     expect(output.config.options).toHaveProperty("endpoint")
     expect(output.config.options).toHaveProperty("environment")

--- a/packages/nodejs/src/config.ts
+++ b/packages/nodejs/src/config.ts
@@ -3,6 +3,7 @@ import os from "os"
 import fs from "fs"
 
 import { VERSION } from "./version"
+import { isWritable } from "./utils"
 import { AppsignalOptions } from "./interfaces/options"
 import { ENV_TO_KEY_MAPPING, PRIVATE_ENV_MAPPING } from "./config/configmap"
 import { HashMap } from "@appsignal/types"
@@ -66,9 +67,7 @@ export class Configuration {
       logPath = path.dirname(logPath)
     }
 
-    try {
-      fs.accessSync(logPath, fs.constants.W_OK)
-    } catch (_err) {
+    if (!isWritable(logPath)) {
       const newLogPath = this._tmpdir()
 
       console.warn(

--- a/packages/nodejs/src/config.ts
+++ b/packages/nodejs/src/config.ts
@@ -57,9 +57,9 @@ export class Configuration {
   }
 
   public get logFilePath(): string {
-    let logPath = this.data["logPath"]!
-
-    if (path.extname(logPath) != "") {
+    const filename = "appsignal.log"
+    let logPath = this.data["logPath"]
+    if (logPath && path.extname(logPath) != "") {
       console.warn(
         "DEPRECATED: File names are no longer supported in the 'logPath' config option. Changing the filename to 'appsignal.log'"
       )
@@ -67,17 +67,17 @@ export class Configuration {
       logPath = path.dirname(logPath)
     }
 
-    if (!isWritable(logPath)) {
-      const newLogPath = this._tmpdir()
-
-      console.warn(
-        `Unable to log to '${logPath}'. Logging to '${newLogPath}' instead. Please check the permissions for the configured 'logPath' directory`
-      )
-
-      logPath = newLogPath
+    if (logPath && isWritable(logPath)) {
+      return path.join(logPath, filename)
+    } else {
+      const tmpDir = this._tmpdir()
+      if (logPath) {
+        console.warn(
+          `Unable to log to '${logPath}'. Logging to '${tmpDir}' instead. Please check the permissions of the 'logPath' directory.`
+        )
+      }
+      return path.join(tmpDir, filename)
     }
-
-    return path.join(logPath, "appsignal.log")
   }
 
   /**
@@ -118,7 +118,6 @@ export class Configuration {
       ignoreErrors: [],
       ignoreNamespaces: [],
       log: "file",
-      logPath: this._tmpdir(),
       requestHeaders: [
         "accept",
         "accept-charset",

--- a/packages/nodejs/src/diagnose.ts
+++ b/packages/nodejs/src/diagnose.ts
@@ -149,33 +149,42 @@ export class DiagnoseTool {
         path: process.cwd()
       },
       log_dir_path: {
-        path: path.dirname(logFilePath)
+        path: logFilePath ? path.dirname(logFilePath) : ""
       },
       "appsignal.log": {
-        path: logFilePath,
-        content: safeReadFromPath(logFilePath).trimEnd().split("\n")
+        path: logFilePath || "",
+        content: logFilePath
+          ? safeReadFromPath(logFilePath).trimEnd().split("\n")
+          : []
       }
     }
 
     Object.entries(pathsToCheck).forEach(([key, data]) => {
       const { path } = data
 
-      try {
-        const stats = fs.statSync(path)
-        const { mode, gid, uid } = stats
+      if (fs.existsSync(path)) {
+        try {
+          let stats = fs.statSync(path)
+          const { mode, gid, uid } = stats
 
-        paths[key] = {
-          ...data,
-          exists: true,
-          mode: mode.toString(8),
-          ownership: {
-            gid,
-            uid
-          },
-          type: getPathType(stats),
-          writable: isWritable(path)
+          paths[key] = {
+            ...data,
+            exists: true,
+            mode: mode.toString(8),
+            ownership: {
+              gid,
+              uid
+            },
+            type: getPathType(stats),
+            writable: isWritable(path)
+          }
+        } catch (_) {
+          paths[key] = {
+            ...data,
+            exists: true
+          }
         }
-      } catch (_) {
+      } else {
         paths[key] = {
           ...data,
           exists: false

--- a/packages/nodejs/src/diagnose.ts
+++ b/packages/nodejs/src/diagnose.ts
@@ -5,6 +5,7 @@ import http from "http"
 import { URL, URLSearchParams } from "url"
 import { createHash } from "crypto"
 
+import { isWritable } from "./utils"
 import { Extension } from "./extension"
 import { Configuration } from "./config"
 import { AGENT_VERSION, VERSION } from "./version"
@@ -172,7 +173,7 @@ export class DiagnoseTool {
             uid
           },
           type: getPathType(stats),
-          writable: isWriteable(path)
+          writable: isWritable(path)
         }
       } catch (_) {
         paths[key] = {
@@ -292,15 +293,6 @@ function reportPath(): string {
   hash.update(appPath)
   const reportPathDigest = hash.digest("hex")
   return path.join(`/tmp/appsignal-${reportPathDigest}-install.report`)
-}
-
-function isWriteable(path: string): boolean {
-  try {
-    fs.accessSync(path, fs.constants.W_OK)
-    return true
-  } catch (e) {
-    return false
-  }
 }
 
 function getPathType(stats: fs.Stats) {

--- a/packages/nodejs/src/utils.ts
+++ b/packages/nodejs/src/utils.ts
@@ -1,3 +1,4 @@
+import fs from "fs"
 import path from "path"
 
 /**
@@ -27,5 +28,17 @@ export function getAgentTimestamps(timestamp: number) {
   return {
     sec: sec, // seconds
     nsec: timestamp * 1e6 - sec * 1e9 // nanoseconds
+  }
+}
+
+/**
+ * Checks if the given path is writable by the process.
+ */
+export function isWritable(path: string) {
+  try {
+    fs.accessSync(path, fs.constants.W_OK)
+    return true
+  } catch (e) {
+    return false
   }
 }


### PR DESCRIPTION
## Move isWritable helper to utils

The config and diagnose modules both had checks for writable paths. Move
the diagnose's helper function to utils and use it in the config module.

Rename the function so that it doesn't contain a typo.

## Remove default logPath option value

Remove the default value of the logPath option and only fall back on
the system tmp directory if no value is set. This way it matches its
behavior with the other integrations.

This will also make it easier to distinguish between user configured
paths and fallback paths in the future when we check if the fallback
directory is writable or not.

Fixes #510

## Check if logPath fallback is writable

When the configured logPath is not writable, the integration falls back
on the system tmp dir. This commit checks if that directory is also
writable by the app process or not. We've seen this happen before in the
Ruby integration, so let's add the same check here.

This change means that the `logFilePath` getter can sometimes return an
`undefined` value. The integration will then not set the
`_APPSIGNAL_LOG_FILE_PATH` env variable, as it would point to a path
that can't be written to. In this case the agent will try to find a log
directory on its own, which will probably not succeed either and it will
shut down.

