### PR TITLE
Update package-lock.json on mono publish

### DIFF
--- a/mono.yml
+++ b/mono.yml
@@ -3,3 +3,5 @@ language: nodejs
 repo: "https://github.com/appsignal/appsignal-nodejs"
 npm_client: "npm"
 packages_dir: "packages"
+publish:
+  pre: "npm install"


### PR DESCRIPTION
I noticed that after publishing new versions of the packages, running
`npm install` causes changes in the `package-lock.json` file that
weren't committed during publishing.

This is because the version numbers have been changed in the publish
process and those version numbers are listed in the lock file.

Fix this by running `npm install` after the package versions have been
updated, but before they are actually published. The `npm install`
command will work with npm workspaces, it won't check to see if the new
version has already been published yet. Then after the publishing is
done, mono will include the change in the publish commit.

I didn't make this change in mono, because I don't think most packages
will have their lock file committed, so it's repository specific
behavior. We should also revisit why we do this.

I remember reading this issue that this speeds up the dependency
resolving on CI: https://github.com/appsignal/integration-guide/issues/7

> Ruby and Elixir integrations don't check lockfiles into source
> control, while the Node integration does. This is because the
> yarn.lock file includes resolved dependency URLs that speeds up
> resolution on a different machine.

[ci skip]
[skip changeset]
[skip review]