### PR TITLE
Add send_environment_metadata config option

### DIFF
--- a/packages/nodejs/.changesets/add-send_environment_metadata-config-option.md
+++ b/packages/nodejs/.changesets/add-send_environment_metadata-config-option.md
@@ -1,0 +1,5 @@
+---
+bump: "patch"
+---
+
+Add `send_environment_metadata` config option to configure the environment metadata collection. For more information, see our [environment metadata docs](https://docs.appsignal.com/application/environment-metadata.html).

--- a/packages/nodejs/src/__tests__/config.test.ts
+++ b/packages/nodejs/src/__tests__/config.test.ts
@@ -38,6 +38,7 @@ describe("Configuration", () => {
       "content-length",
       "range"
     ],
+    sendEnvironmentMetadata: true,
     transactionDebugMode: false
   }
 
@@ -341,6 +342,7 @@ describe("Configuration", () => {
         )
         expect(env("_APPSIGNAL_PUSH_API_KEY")).toEqual(pushApiKey)
         expect(env("_APPSIGNAL_RUNNING_IN_CONTAINER")).toEqual("true")
+        expect(env("_APPSIGNAL_SEND_ENVIRONMENT_METADATA")).toEqual("true")
         // Only set because `debug` is set to true
         // @TODO: https://github.com/appsignal/appsignal-nodejs/issues/379
         expect(env("_APPSIGNAL_TRANSACTION_DEBUG_MODE")).toEqual("true")

--- a/packages/nodejs/src/config.ts
+++ b/packages/nodejs/src/config.ts
@@ -138,6 +138,7 @@ export class Configuration {
         "content-length",
         "range"
       ],
+      sendEnvironmentMetadata: true,
       transactionDebugMode: false
     }
   }

--- a/packages/nodejs/src/config/configmap.ts
+++ b/packages/nodejs/src/config/configmap.ts
@@ -23,6 +23,7 @@ export const ENV_TO_KEY_MAPPING: { [key: string]: string } = {
   APPSIGNAL_PUSH_API_KEY: "pushApiKey",
   APPSIGNAL_REQUEST_HEADERS: "requestHeaders",
   APPSIGNAL_RUNNING_IN_CONTAINER: "runningInContainer",
+  APPSIGNAL_SEND_ENVIRONMENT_METADATA: "sendEnvironmentMetadata",
   APPSIGNAL_SEND_PARAMS: "sendParams",
   APPSIGNAL_SKIP_SESSION_DATA: "skipSessionData",
   APPSIGNAL_TRANSACTION_DEBUG_MODE: "transactionDebugMode",
@@ -52,6 +53,7 @@ export const PRIVATE_ENV_MAPPING: { [key: string]: string } = {
   _APPSIGNAL_PUSH_API_ENDPOINT: "endpoint",
   _APPSIGNAL_PUSH_API_KEY: "pushApiKey",
   _APPSIGNAL_RUNNING_IN_CONTAINER: "runningInContainer",
+  _APPSIGNAL_SEND_ENVIRONMENT_METADATA: "sendEnvironmentMetadata",
   _APPSIGNAL_TRANSACTION_DEBUG_MODE: "debug",
   _APPSIGNAL_WORKING_DIRECTORY_PATH: "workingDirectoryPath",
   _APPSIGNAL_WORKING_DIR_PATH: "workingDirPath",
@@ -82,6 +84,7 @@ export const JS_TO_RUBY_MAPPING: { [key: string]: string } = {
   requestHeaders: "request_headers",
   revision: "revision",
   runningInContainer: "running_in_container",
+  sendEnvironmentMetadata: "send_environment_metadata",
   transactionDebugMode: "transaction_debug_mode",
   workingDirPath: "working_dir_path",
   workingDirectoryPath: "working_directory_path"


### PR DESCRIPTION
Allow users to enable/disable the environment metadata collection. This
is on by default.

This behavior is already implemented in the extension and agent. This
just makes it configurable for the user. No Node.js specific metadata
is currently collected.

Closes #522

For more information about this feature:
https://docs.appsignal.com/application/environment-metadata.html