### PR TITLE
Unset the default logLevel in the integration

### DIFF
--- a/packages/nodejs/.changesets/fix-debug-and-transaction_debug_mode-log-options.md
+++ b/packages/nodejs/.changesets/fix-debug-and-transaction_debug_mode-log-options.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Fix debug and transaction_debug_mode log options. If set, previously the log_level would remain "info", since version 2.2.6.

--- a/packages/nodejs/src/__tests__/config.test.ts
+++ b/packages/nodejs/src/__tests__/config.test.ts
@@ -28,7 +28,6 @@ describe("Configuration", () => {
     ignoreErrors: [],
     ignoreNamespaces: [],
     log: "file",
-    logLevel: "info",
     requestHeaders: [
       "accept",
       "accept-charset",
@@ -266,7 +265,7 @@ describe("Configuration", () => {
       expect(env("_APPSIGNAL_IGNORE_ERRORS")).toBeUndefined()
       expect(env("_APPSIGNAL_IGNORE_NAMESPACES")).toBeUndefined()
       expect(env("_APPSIGNAL_LOG")).toEqual("file")
-      expect(env("_APPSIGNAL_LOG_LEVEL")).toEqual("info")
+      expect(env("_APPSIGNAL_LOG_LEVEL")).toBeUndefined()
       expect(env("_APPSIGNAL_LOG_FILE_PATH")).toEqual("/tmp/appsignal.log")
       expect(env("_APPSIGNAL_PUSH_API_ENDPOINT")).toEqual(
         "https://push.appsignal.com"

--- a/packages/nodejs/src/config.ts
+++ b/packages/nodejs/src/config.ts
@@ -128,7 +128,6 @@ export class Configuration {
       ignoreErrors: [],
       ignoreNamespaces: [],
       log: "file",
-      logLevel: "info",
       requestHeaders: [
         "accept",
         "accept-charset",


### PR DESCRIPTION
If the logLevel was set by default by the Node.js integration it would
always use that level, even if `debug` was set. This option is
deprecated, but if set, and `logLevel` is not configured by the app, we
should listen to these options.

I've removed the default `logLevel` from the integration, but it will be
set by the extension and agent's log_level behavior. Since there's no
centralized logger in the Node.js integration yet, we do not need
to update any configuration for the integration's logger.

Depends on https://github.com/appsignal/diagnose_tests/pull/54