### PR TITLE
Allow transmitters to use cafile

### DIFF
--- a/packages/nodejs/.changesets/cafilepath-works-for-diagnose-script-external-requests.md
+++ b/packages/nodejs/.changesets/cafilepath-works-for-diagnose-script-external-requests.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "add"
+---
+
+The `caFilePath` config option now works for diagnose script external requests.

--- a/packages/nodejs/src/cli/diagnose.ts
+++ b/packages/nodejs/src/cli/diagnose.ts
@@ -209,7 +209,7 @@ export class Diagnose {
         `  Not sending report. (Specified with the --no-send-report option.)`
       )
     } else if (process.argv.includes("--send-report")) {
-      this.sendReport(data)
+      await this.sendReport(data)
     } else {
       const rl = readline.createInterface({
         input: process.stdin,
@@ -219,10 +219,10 @@ export class Diagnose {
       let self = this
       rl.question(
         `  Send diagnostics report to AppSignal? (Y/n): `,
-        function (answer: String) {
+        async function (answer: String) {
           switch (answer || "y") {
             case "y":
-              self.sendReport(data)
+              await self.sendReport(data)
               break
 
             default:
@@ -235,10 +235,10 @@ export class Diagnose {
     }
   }
 
-  sendReport(data: object) {
+  async sendReport(data: object) {
     console.log("  Transmitting diagnostics report")
     console.log("")
-    this.#diagnose.sendReport(data)
+    await this.#diagnose.sendReport(data)
   }
 
   printAgentDiagnose(report: HashMap<any>) {

--- a/packages/nodejs/src/diagnose.ts
+++ b/packages/nodejs/src/diagnose.ts
@@ -253,7 +253,9 @@ export class DiagnoseTool {
           "  Error: Something went wrong while submitting the report to AppSignal."
         )
         console.error(`  Response code: ${responseData["status"]}`)
-        console.error(`  Response body:\n${responseData["body"]}`)
+        console.error(
+          `  Response body:\n${JSON.stringify(responseData["body"])}`
+        )
       })
   }
 }

--- a/packages/nodejs/src/transmitter.ts
+++ b/packages/nodejs/src/transmitter.ts
@@ -75,10 +75,22 @@ export class Transmitter {
         "Content-Type": "application/json",
         "Content-Length": this.#data.length
       },
-      cert: fs.readFileSync(
-        path.resolve(__dirname, "../cert/cacert.pem"),
-        "utf-8"
+      ca: this.certificateFile()
+    }
+  }
+
+  private certificateFile(): string {
+    const configData = this.#config.data
+    const caFilePathFromConfig = configData["caFilePath"] || ""
+
+    try {
+      fs.accessSync(caFilePathFromConfig, fs.constants.R_OK)
+      return fs.readFileSync(caFilePathFromConfig, "utf-8").toString()
+    } catch {
+      console.warn(
+        `Provided caFilePath: '${caFilePathFromConfig}' is not readable.`
       )
+      return ""
     }
   }
 }

--- a/packages/nodejs/src/transmitter.ts
+++ b/packages/nodejs/src/transmitter.ts
@@ -1,0 +1,84 @@
+import fs from "fs"
+import path from "path"
+import https from "https"
+import http from "http"
+
+import { Configuration } from "./config"
+import { URL, URLSearchParams } from "url"
+import { HashMap } from "@appsignal/types"
+
+export class Transmitter {
+  #config: Configuration
+  #url: string
+  #data: string
+
+  constructor(url: string, data = "", active = true) {
+    this.#config = new Configuration({ active })
+    this.#url = url
+    this.#data = data
+  }
+
+  public async transmit() {
+    return new Promise<HashMap<any>>((resolve, reject) => {
+      const config_data = this.#config.data
+      const params = new URLSearchParams({
+        api_key: config_data["pushApiKey"] || "",
+        name: config_data["name"] || "",
+        environment: config_data["environment"] || "",
+        hostname: config_data["hostname"] || ""
+      })
+
+      const url = new URL(`${this.#url}?${params.toString()}`)
+      const opts = this.requestOptions(url)
+      const requestModule = url.protocol == "http:" ? http : https
+
+      const request = requestModule.request(opts, (stream: any) => {
+        const responseStatus = stream.statusCode
+        stream.setEncoding("utf8")
+        let responseBody = ""
+
+        stream
+          .on("data", (chunk: any) => {
+            responseBody += chunk
+          })
+          .on("end", () => {
+            let parsedResponse
+            try {
+              parsedResponse = JSON.parse(responseBody)
+            } catch {
+              parsedResponse = {}
+            }
+
+            if (responseStatus == 200) {
+              resolve({ status: responseStatus, body: parsedResponse })
+            } else {
+              reject({ status: responseStatus, body: parsedResponse })
+            }
+          })
+      })
+
+      request.write(this.#data)
+      request.end()
+    })
+  }
+
+  private requestOptions(requestUrl: URL): HashMap<any> {
+    const configData = this.#config.data
+
+    return {
+      method: "POST",
+      protocol: requestUrl.protocol,
+      host: requestUrl.hostname,
+      port: requestUrl.port,
+      path: requestUrl.toString(),
+      headers: {
+        "Content-Type": "application/json",
+        "Content-Length": this.#data.length
+      },
+      cert: fs.readFileSync(
+        path.resolve(__dirname, "../cert/cacert.pem"),
+        "utf-8"
+      )
+    }
+  }
+}


### PR DESCRIPTION
## Create a single transmitter for Diagnose

Diagnose script performs two external HTTP calls, one for push api key
validation, and another one to send the diagnose results to AppSignal if
the user wants.

These calls were written separatedly inside the diagnose script, now
they are done through a new class called `Transmitter`.

## Allow transmitter calls to use caFilePath

`caFilePath` config option was only used by the agent. With this change,
the certificate file will also be used by the diagnose transmitter to
validate the api key and to send the diagnose results to AppSignal.

## Protect transmitter JSON parsing 

Sometimes, the server response received by the transmitter is not a
parseable JSON. Added a try/catch to protect the script.

Closes: #517 