### PR TITLE
Add helper for globally stored client

### DIFF
--- a/packages/nodejs/.changesets/add-helper-to-access-the-globally-stored-appsignal-client.md
+++ b/packages/nodejs/.changesets/add-helper-to-access-the-globally-stored-appsignal-client.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "add"
+---
+
+Add helper to access the globally stored AppSignal client.

--- a/packages/nodejs/src/__tests__/client.test.ts
+++ b/packages/nodejs/src/__tests__/client.test.ts
@@ -32,6 +32,14 @@ describe("BaseClient", () => {
     expect(global.__APPSIGNAL__).toEqual(client)
   })
 
+  it("returns the client from global object", () => {
+    expect(BaseClient.client).toEqual(client)
+  })
+
+  it("returns the client config from global object", () => {
+    expect(BaseClient.config).toEqual(client.config)
+  })
+
   it("does not start the client if config is not valid", () => {
     process.env["APPSIGNAL_PUSH_API_KEY"] = undefined
     client = new BaseClient({ name, enableMinutelyProbes: false })

--- a/packages/nodejs/src/client.ts
+++ b/packages/nodejs/src/client.ts
@@ -29,6 +29,17 @@ export class BaseClient implements Client {
   #metrics: Metrics = new BaseMetrics()
 
   /**
+   * Global accessors to Client and Config
+   */
+  static get client(): Client {
+    return global.__APPSIGNAL__
+  }
+
+  static get config(): Configuration {
+    return global.__APPSIGNAL__?.config
+  }
+
+  /**
    * Creates a new instance of the `Appsignal` object
    */
   constructor(options: Partial<AppsignalOptions> = {}) {


### PR DESCRIPTION
A new static helper method is available from `BaseClient` (exported as
`Appsignal`). It allows access to the globally stored client when
AppSignal is initialized.

This will give us the ability to develop missing features that are based
on config options.