### PR TITLE
Implement sendParams config option

### DIFF
--- a/packages/nodejs/.changesets/sendparams-config-option-is-now-available.md
+++ b/packages/nodejs/.changesets/sendparams-config-option-is-now-available.md
@@ -1,0 +1,7 @@
+---
+bump: "patch"
+type: "add"
+---
+
+The `sendParams` config option is now available. When set to `false`, it prevents the integration
+from sending request params to AppSignal.

--- a/packages/nodejs/src/__tests__/config.test.ts
+++ b/packages/nodejs/src/__tests__/config.test.ts
@@ -39,6 +39,7 @@ describe("Configuration", () => {
       "range"
     ],
     sendEnvironmentMetadata: true,
+    sendParams: true,
     transactionDebugMode: false
   }
 

--- a/packages/nodejs/src/__tests__/span.test.ts
+++ b/packages/nodejs/src/__tests__/span.test.ts
@@ -1,4 +1,7 @@
 import { ChildSpan, RootSpan } from "../span"
+import { span } from "../extension_wrapper"
+import { BaseClient } from "../client"
+import { Data } from "../internal/data"
 
 type SpanData = {
   closed: boolean
@@ -176,5 +179,46 @@ describe("ChildSpan", () => {
     internal = JSON.parse(span.toJSON())
 
     expect(internal.closed).toBeTruthy()
+  })
+})
+
+describe(".setSampleData()", () => {
+  const name = "TEST APP"
+  const pushApiKey = "TEST_API_KEY"
+  const DEFAULT_OPTS = { name, pushApiKey, enableMinutelyProbes: false }
+  const sampleData = { foo: "bar" }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it("calls the extension with the desired data if sendParams is active", () => {
+    new BaseClient({ ...DEFAULT_OPTS })
+
+    const rootSpan = new RootSpan()
+    const spanMock = jest
+      .spyOn(span, "setSpanSampleData")
+      .mockImplementation(() => {})
+
+    rootSpan.setSampleData("params", sampleData)
+
+    expect(spanMock).toHaveBeenCalledWith(
+      {},
+      "params",
+      Data.generate(sampleData)
+    )
+  })
+
+  it("does not call the extension with the desired data if sendParams is inactive", () => {
+    new BaseClient({ ...DEFAULT_OPTS, sendParams: false })
+
+    const rootSpan = new RootSpan()
+    const spanMock = jest
+      .spyOn(span, "setSpanSampleData")
+      .mockImplementation(() => {})
+
+    rootSpan.setSampleData("params", sampleData)
+
+    expect(spanMock).not.toHaveBeenCalled()
   })
 })

--- a/packages/nodejs/src/config.ts
+++ b/packages/nodejs/src/config.ts
@@ -139,6 +139,7 @@ export class Configuration {
         "range"
       ],
       sendEnvironmentMetadata: true,
+      sendParams: true,
       transactionDebugMode: false
     }
   }

--- a/packages/nodejs/src/config/configmap.ts
+++ b/packages/nodejs/src/config/configmap.ts
@@ -88,6 +88,7 @@ export const JS_TO_RUBY_MAPPING: { [key: string]: string } = {
   revision: "revision",
   runningInContainer: "running_in_container",
   sendEnvironmentMetadata: "send_environment_metadata",
+  sendParams: "send_params",
   transactionDebugMode: "transaction_debug_mode",
   workingDirPath: "working_dir_path",
   workingDirectoryPath: "working_directory_path"

--- a/packages/nodejs/src/interfaces/options.ts
+++ b/packages/nodejs/src/interfaces/options.ts
@@ -25,7 +25,7 @@ export interface AppsignalOptions {
   requestHeaders: string[]
   revision: string
   runningInContainer: boolean
-  sendParams: string[]
+  sendParams: boolean
   skipSessionData: boolean
   workingDirPath: string
   workingDirectoryPath: string

--- a/packages/nodejs/src/span.ts
+++ b/packages/nodejs/src/span.ts
@@ -5,6 +5,7 @@ import { Span, SpanOptions, SpanContext } from "./interfaces"
 import { span } from "./extension_wrapper"
 import { Data } from "./internal/data"
 import { getAgentTimestamps } from "./utils"
+import { BaseClient } from "./client"
 
 /**
  * The `Span` object represents a length of time in the flow of execution
@@ -125,6 +126,7 @@ export class BaseSpan implements Span {
         >
   ): this {
     if (!key || !data) return this
+    if (key == "params" && !BaseClient.config.data.sendParams) return this
 
     try {
       span.setSpanSampleData(this._ref, key, Data.generate(data))


### PR DESCRIPTION
## Add sendParams config option

The `sendParams` config option is now available and its default value is
`true`. It'll be used to globally determine if the users want to send
request params in the spans or not.

## Implement sendParams config option

The `sendParams` config option allows the users to decide if they want
to send request params to AppSignal. Its default value is `true`.

`Span#setSampleData()` now checks if the `sendParams` option is enabled
when sending `params` to decide if they're going to be sent to AppSignal
or not.

Closes #514 