### PR TITLE
Check if the process is running in a container from the extension

### DIFF
--- a/packages/nodejs-ext/.changesets/runningincontainer-function-is-now-available-from-the-extension.md
+++ b/packages/nodejs-ext/.changesets/runningincontainer-function-is-now-available-from-the-extension.md
@@ -1,0 +1,7 @@
+---
+bump: "patch"
+type: "add"
+---
+
+RunningInContainer function is now available from the extension. It checks if the agent is running
+in a container.

--- a/packages/nodejs-ext/.changesets/runningincontainer-function-is-now-available-from-the-extension.md
+++ b/packages/nodejs-ext/.changesets/runningincontainer-function-is-now-available-from-the-extension.md
@@ -3,5 +3,5 @@ bump: "patch"
 type: "add"
 ---
 
-RunningInContainer function is now available from the extension. It checks if the agent is running
-in a container.
+Implement the `RunningInContainer` function available in the extension. It is
+used to check if the agent is running in a container.

--- a/packages/nodejs-ext/ext/appsignal_extension.cpp
+++ b/packages/nodejs-ext/ext/appsignal_extension.cpp
@@ -33,6 +33,12 @@ Napi::Value DiagnoseRaw(const Napi::CallbackInfo &info) {
   return Napi::String::New(env, str.buf, str.len);
 }
 
+Napi::Value RunningInContainer(const Napi::CallbackInfo &info) {
+  bool running_in_container = !!appsignal_running_in_container();
+
+  return Napi::Value::From(info.Env(), running_in_container);
+}
+
 // Data Array encoding
 
 Napi::Value CreateDataArray(const Napi::CallbackInfo &info) {
@@ -632,6 +638,8 @@ Napi::Object CreateExtensionObject(Napi::Env env, Napi::Object exports) {
   extension.Set(Napi::String::New(env, "stop"), Napi::Function::New(env, Stop));
   extension.Set(Napi::String::New(env, "diagnoseRaw"),
                 Napi::Function::New(env, DiagnoseRaw));
+  extension.Set(Napi::String::New(env, "runningInContainer"),
+                Napi::Function::New(env, RunningInContainer));
 
   return extension;
 }

--- a/packages/nodejs/.changesets/extension-now-checks-running-in-container.md
+++ b/packages/nodejs/.changesets/extension-now-checks-running-in-container.md
@@ -1,0 +1,7 @@
+---
+bump: "patch"
+type: "change"
+---
+
+The extension is now responsible of determining if the process is running in a container. This check
+was previously made by the Node.js integration code.

--- a/packages/nodejs/src/diagnose.ts
+++ b/packages/nodejs/src/diagnose.ts
@@ -86,10 +86,7 @@ export class DiagnoseTool {
       language_version: process.versions.node,
       heroku,
       root: process.getuid() === 0,
-      // @TODO: this is pretty much just a guess right now
-      // it assumes docker. no jails, lxc etc.
-      // we'll need to adjust this a little later
-      running_in_container: hasDockerEnv() || hasDockerCGroup() || heroku
+      running_in_container: this.#extension.runningInContainer()
     }
   }
 
@@ -325,26 +322,5 @@ function readFileOptions(path: string, bytesToRead: number) {
       readLength: bytesToRead,
       startPosition
     }
-  }
-}
-
-/**
- * the following lines are borrowed from https://github.com/sindresorhus/is-docker/
- * thanks sindre! <3
- */
-function hasDockerEnv(): boolean {
-  try {
-    fs.statSync("/.dockerenv")
-    return true
-  } catch (_) {
-    return false
-  }
-}
-
-function hasDockerCGroup(): boolean {
-  try {
-    return fs.readFileSync("/proc/self/cgroup", "utf8").includes("docker")
-  } catch (_) {
-    return false
   }
 }

--- a/packages/nodejs/src/extension.ts
+++ b/packages/nodejs/src/extension.ts
@@ -66,4 +66,11 @@ export class Extension {
       return {}
     }
   }
+
+  /**
+   * Determines if the app is running inside a container
+   */
+  public runningInContainer(): boolean {
+    return extension.runningInContainer()
+  }
 }


### PR DESCRIPTION
## Add RunningInContainer function to extension

This function checks if the agent is running in a container. The Ruby
and the Elixir integrations already use this function in the diagnose
report.

This commit makes the function available to be used in the integration.

## Use extension to check if the process is running in container

The runningInContainer check is now run through the extension.

Removed the old code that made the checks using JS.