### PR TITLE
Handle request errors on diagnose HTTP transmitter

### DIFF
--- a/packages/nodejs/.changesets/handle-request-errors-on-diagnose-http-transmitter-.md
+++ b/packages/nodejs/.changesets/handle-request-errors-on-diagnose-http-transmitter-.md
@@ -1,0 +1,7 @@
+---
+bump: "patch"
+type: "add"
+---
+
+Handle request errors in the internal HTTP transmitter used by diagnose tool
+and Push API key validator.

--- a/packages/nodejs/src/diagnose.ts
+++ b/packages/nodejs/src/diagnose.ts
@@ -116,23 +116,25 @@ export class DiagnoseTool {
     const config = this.#config.data
     const url = new URL(`/1/auth`, config["endpoint"])
     const transmitter = new Transmitter(url.toString())
-    let statusCode = null
+    let response: HashMap<any> = {}
 
     await transmitter
       .transmit()
       .then(responseData => {
-        statusCode = responseData["status"]
+        response = responseData
       })
       .catch(responseData => {
-        statusCode = responseData["status"]
+        response = responseData
       })
 
-    if (statusCode == 200) {
+    if (response["status"] == 200) {
       return Promise.resolve("valid")
-    } else if (statusCode == 401) {
+    } else if (response["status"] == 401) {
       return Promise.reject("invalid")
     } else {
-      return Promise.reject(`Failed to validate: status ${statusCode}`)
+      return Promise.reject(
+        `Failed to validate: ${response["error"] || response["body"]}`
+      )
     }
   }
 
@@ -242,19 +244,25 @@ export class DiagnoseTool {
     await transmitter
       .transmit()
       .then(responseData => {
-        const { token } = responseData["body"]
-        console.log(`  Your support token:`, token)
-        console.log(
-          `  View this report:   https://appsignal.com/diagnose/${token}`
-        )
+        if (responseData["status"] == 200) {
+          const { token } = responseData["body"]
+          console.log(`  Your support token:`, token)
+          console.log(
+            `  View this report:   https://appsignal.com/diagnose/${token}`
+          )
+        } else {
+          console.error(
+            "  Error: Something went wrong while submitting the report to AppSignal."
+          )
+          console.error(`  Response code: ${responseData["status"]}`)
+          console.error(
+            `  Response body:\n${JSON.stringify(responseData["body"])}`
+          )
+        }
       })
       .catch(responseData => {
         console.error(
-          "  Error: Something went wrong while submitting the report to AppSignal."
-        )
-        console.error(`  Response code: ${responseData["status"]}`)
-        console.error(
-          `  Response body:\n${JSON.stringify(responseData["body"])}`
+          `  Error submitting the report: ${responseData["error"].message}`
         )
       })
   }

--- a/packages/nodejs/src/transmitter.ts
+++ b/packages/nodejs/src/transmitter.ts
@@ -49,12 +49,12 @@ export class Transmitter {
               parsedResponse = {}
             }
 
-            if (responseStatus == 200) {
-              resolve({ status: responseStatus, body: parsedResponse })
-            } else {
-              reject({ status: responseStatus, body: parsedResponse })
-            }
+            resolve({ status: responseStatus, body: parsedResponse })
           })
+      })
+
+      request.on("error", error => {
+        reject({ error: error })
       })
 
       request.write(this.#data)


### PR DESCRIPTION
Request errors are now handled on diagnose HTTP external calls (Push API
key validation and report sending).

The promise returned by `Transmitter#transmit` will only reject if
there's some kind of error during the request. Non-200 response codes
are not considered an error anymore.

Output example:

```
Error submitting the report: getaddrinfo ENOTFOUND appsignal.com
```

Closes: https://github.com/appsignal/appsignal-nodejs/issues/535