### PR TITLE
Add and implement sendSessionData config option

### DIFF
--- a/packages/nodejs/.changesets/skipsessiondata-config-opt-is-now-available.md
+++ b/packages/nodejs/.changesets/skipsessiondata-config-opt-is-now-available.md
@@ -1,0 +1,7 @@
+---
+bump: "patch"
+type: "add"
+---
+
+The `sendSessionData` config option is now available. When set to `false`, it prevents the
+integration from sending session data to AppSignal.

--- a/packages/nodejs/src/__tests__/config.test.ts
+++ b/packages/nodejs/src/__tests__/config.test.ts
@@ -40,6 +40,7 @@ describe("Configuration", () => {
     ],
     sendEnvironmentMetadata: true,
     sendParams: true,
+    sendSessionData: true,
     transactionDebugMode: false
   }
 

--- a/packages/nodejs/src/__tests__/span.test.ts
+++ b/packages/nodejs/src/__tests__/span.test.ts
@@ -192,7 +192,7 @@ describe(".setSampleData()", () => {
     jest.clearAllMocks()
   })
 
-  it("calls the extension with the desired data if sendParams is active", () => {
+  it("calls the extension with the desired params data if sendParams is active", () => {
     new BaseClient({ ...DEFAULT_OPTS })
 
     const rootSpan = new RootSpan()
@@ -209,7 +209,7 @@ describe(".setSampleData()", () => {
     )
   })
 
-  it("does not call the extension with the desired data if sendParams is inactive", () => {
+  it("does not call the extension with the desired params data if sendParams is inactive", () => {
     new BaseClient({ ...DEFAULT_OPTS, sendParams: false })
 
     const rootSpan = new RootSpan()
@@ -218,6 +218,34 @@ describe(".setSampleData()", () => {
       .mockImplementation(() => {})
 
     rootSpan.setSampleData("params", sampleData)
+
+    expect(spanMock).not.toHaveBeenCalled()
+  })
+
+  it("calls the extension with the desired session data if sendSessionData is active", () => {
+    new BaseClient({ ...DEFAULT_OPTS })
+
+    const rootSpan = new RootSpan()
+    const spanMock = jest
+      .spyOn(span, "setSpanSampleData")
+      .mockImplementation(() => {})
+
+    rootSpan.setSampleData("session_data", sampleData)
+
+    expect(spanMock).toHaveBeenCalledWith(
+      {},
+      "session_data",
+      Data.generate(sampleData)
+    )
+  })
+
+  it("does not call the extension with the desired session data if sendSessionData is inactive", () => {
+    new BaseClient({ ...DEFAULT_OPTS, sendSessionData: false })
+
+    const rootSpan = new RootSpan()
+    const spanMock = jest.spyOn(span, "setSpanSampleData")
+
+    rootSpan.setSampleData("session_data", sampleData)
 
     expect(spanMock).not.toHaveBeenCalled()
   })

--- a/packages/nodejs/src/config.ts
+++ b/packages/nodejs/src/config.ts
@@ -140,6 +140,7 @@ export class Configuration {
       ],
       sendEnvironmentMetadata: true,
       sendParams: true,
+      sendSessionData: true,
       transactionDebugMode: false
     }
   }

--- a/packages/nodejs/src/config/configmap.ts
+++ b/packages/nodejs/src/config/configmap.ts
@@ -26,7 +26,7 @@ export const ENV_TO_KEY_MAPPING: { [key: string]: string } = {
   APPSIGNAL_RUNNING_IN_CONTAINER: "runningInContainer",
   APPSIGNAL_SEND_ENVIRONMENT_METADATA: "sendEnvironmentMetadata",
   APPSIGNAL_SEND_PARAMS: "sendParams",
-  APPSIGNAL_SKIP_SESSION_DATA: "skipSessionData",
+  APPSIGNAL_SEND_SESSION_DATA: "sendSessionData",
   APPSIGNAL_TRANSACTION_DEBUG_MODE: "transactionDebugMode",
   APPSIGNAL_WORKING_DIRECTORY_PATH: "workingDirectoryPath",
   APPSIGNAL_WORKING_DIR_PATH: "workingDirPath",
@@ -89,6 +89,7 @@ export const JS_TO_RUBY_MAPPING: { [key: string]: string } = {
   runningInContainer: "running_in_container",
   sendEnvironmentMetadata: "send_environment_metadata",
   sendParams: "send_params",
+  sendSessionData: "send_session_data",
   transactionDebugMode: "transaction_debug_mode",
   workingDirPath: "working_dir_path",
   workingDirectoryPath: "working_directory_path"

--- a/packages/nodejs/src/span.ts
+++ b/packages/nodejs/src/span.ts
@@ -125,8 +125,10 @@ export class BaseSpan implements Span {
           HashMapValue | Array<HashMapValue> | HashMap<HashMapValue> | undefined
         >
   ): this {
+    const clientConfig = BaseClient.config.data
     if (!key || !data) return this
-    if (key == "params" && !BaseClient.config.data.sendParams) return this
+    if (key == "params" && !clientConfig.sendParams) return this
+    if (key == "session_data" && !clientConfig.sendSessionData) return this
 
     try {
       span.setSpanSampleData(this._ref, key, Data.generate(data))


### PR DESCRIPTION
## Add sendSessionData config option

The `sendSessionData` config option is now available and its default
value is `true`. It'll be used to globally determine if the users want
to send session data in the spans or not.

## Implement sendSessionData config option

The `sendSessionData` config option allows the user to decide if they
want to send session data to AppSignal. Its default value is `true`.

`Span#setSampleData()` now checks if the `sendSessionData` option is
enabled when sending `session_data` to decide if they're going to be
sent to AppSignal or not.

Closes: #516