### PR TITLE
Add hostname tag to V8 probe gauges

### DIFF
--- a/packages/nodejs/.changesets/add-hostname-tag-to-v8-probe-gauges.md
+++ b/packages/nodejs/.changesets/add-hostname-tag-to-v8-probe-gauges.md
@@ -1,0 +1,7 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Add a hostname tag to V8 probe metrics. This fixes an issue where metrics' values
+would be overriden between different hosts.

--- a/packages/nodejs/src/__tests__/probes.test.ts
+++ b/packages/nodejs/src/__tests__/probes.test.ts
@@ -1,4 +1,8 @@
+import { Metrics } from "../interfaces"
 import { BaseProbes as Probes } from "../probes"
+import * as v8 from "../probes/v8"
+import os from "os"
+import { BaseClient } from "../client"
 
 describe("Probes", () => {
   let probes: Probes
@@ -17,5 +21,61 @@ describe("Probes", () => {
     probes.register("test_metric", fn)
     jest.runOnlyPendingTimers()
     expect(fn).toHaveBeenCalled()
+  })
+
+  describe("v8 probe", () => {
+    let meterMock: Metrics
+    let setGaugeMock: jest.Mock
+
+    beforeEach(() => {
+      setGaugeMock = jest.fn()
+
+      meterMock = ({
+        setGauge: setGaugeMock
+      } as unknown) as Metrics
+    })
+
+    function registerV8Probe(hostname?: string) {
+      new BaseClient({ hostname: hostname })
+
+      let { PROBE_NAME, init } = v8
+      probes.register(PROBE_NAME, init(meterMock))
+    }
+
+    it("reports v8 heap statistics with hostnames", () => {
+      registerV8Probe("MyHostname")
+
+      jest.runOnlyPendingTimers()
+
+      let gaugeNames = [
+        "nodejs_total_heap_size",
+        "nodejs_total_heap_size_executable",
+        "nodejs_total_physical_size",
+        "nodejs_used_heap_size",
+        "nodejs_malloced_memory",
+        "nodejs_number_of_native_contexts",
+        "nodejs_number_of_detached_contexts"
+      ]
+
+      gaugeNames.forEach(gaugeName => {
+        expect(setGaugeMock).toBeCalledWith(gaugeName, expect.any(Number), {
+          hostname: "MyHostname"
+        })
+      })
+    })
+
+    it("uses the system hostname if none is provided", () => {
+      registerV8Probe()
+
+      jest.runOnlyPendingTimers()
+
+      expect(setGaugeMock).toBeCalledWith(
+        expect.any(String),
+        expect.any(Number),
+        {
+          hostname: os.hostname()
+        }
+      )
+    })
   })
 })

--- a/packages/nodejs/src/probes/v8/index.ts
+++ b/packages/nodejs/src/probes/v8/index.ts
@@ -1,9 +1,16 @@
 import { Metrics } from "../../interfaces"
 import v8 from "v8"
+import os from "os"
+import { BaseClient } from "../../client"
 
 export const PROBE_NAME = "v8_stats"
 
 export function init(meter: Metrics) {
+  function setGauge(key: string, value: number) {
+    let hostname = BaseClient.config.data.hostname || os.hostname()
+    meter.setGauge(key, value, { hostname })
+  }
+
   return function () {
     const {
       total_heap_size,
@@ -15,16 +22,12 @@ export function init(meter: Metrics) {
       number_of_detached_contexts
     } = v8.getHeapStatistics()
 
-    meter
-      .setGauge("nodejs_total_heap_size", total_heap_size)
-      .setGauge("nodejs_total_heap_size_executable", total_heap_size_executable)
-      .setGauge("nodejs_total_physical_size", total_physical_size)
-      .setGauge("nodejs_used_heap_size", used_heap_size)
-      .setGauge("nodejs_malloced_memory", malloced_memory)
-      .setGauge("nodejs_number_of_native_contexts", number_of_native_contexts)
-      .setGauge(
-        "nodejs_number_of_detached_contexts",
-        number_of_detached_contexts
-      )
+    setGauge("nodejs_total_heap_size", total_heap_size)
+    setGauge("nodejs_total_heap_size_executable", total_heap_size_executable)
+    setGauge("nodejs_total_physical_size", total_physical_size)
+    setGauge("nodejs_used_heap_size", used_heap_size)
+    setGauge("nodejs_malloced_memory", malloced_memory)
+    setGauge("nodejs_number_of_native_contexts", number_of_native_contexts)
+    setGauge("nodejs_number_of_detached_contexts", number_of_detached_contexts)
   }
 }


### PR DESCRIPTION
Add a tag containing the hostname to the V8 probe gauges. Before this change, hosts would override each others' values. Now each of the hosts' values is given for its own hostname.

This PR completes the first task in #540.