### PR TITLE
Fix `enableMinutelyProbes` behaviour

### DIFF
--- a/packages/nodejs/.changesets/fix-enableminutelyprobes-behaviour.md
+++ b/packages/nodejs/.changesets/fix-enableminutelyprobes-behaviour.md
@@ -1,0 +1,21 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Setting `enableMinutelyProbes` to `false` now disables the minutely probes
+system. Custom probes will not be called when the minutely probes are
+disabled. In addition, the `APPSIGNAL_ENABLE_MINUTELY_PROBES` environment
+variable can now be used to enable or disable the minutely probes.
+
+Before this change, setting `enableMinutelyProbes` to `false` would not
+register the default Node.js heap statistics minutely probe, but custom
+probes would still be called. To opt in for the previous behaviour,
+disabling only the Node.js heap statistics minutely probe without disabling
+custom probes, you can use the `probes.unregister()` method to unregister
+the default probe:
+
+```js
+const probes = appsignal.metrics().probes();
+probes.unregister("v8_stats");
+```

--- a/packages/nodejs/.changesets/implement-unregister-method-for-probes.md
+++ b/packages/nodejs/.changesets/implement-unregister-method-for-probes.md
@@ -1,0 +1,7 @@
+---
+bump: "patch"
+type: "add"
+---
+
+Implement unregister method for probes. You can now call the
+`probes.unregister(name)` method to unregister a probe by name.

--- a/packages/nodejs/src/__tests__/bootstrap.test.ts
+++ b/packages/nodejs/src/__tests__/bootstrap.test.ts
@@ -41,13 +41,8 @@ describe("Bootstrap", () => {
     })
 
     it("bootstraps the core probes", () => {
-      initCoreProbes(mock, { enableMinutelyProbes: true })
+      initCoreProbes(mock)
       expect(registerMock).toHaveBeenCalledTimes(1)
-    })
-
-    it("doesn't bootstrap the core probes if enableMinutelyProbes is false", () => {
-      initCoreProbes(mock, { enableMinutelyProbes: false })
-      expect(registerMock).toHaveBeenCalledTimes(0)
     })
   })
 })

--- a/packages/nodejs/src/__tests__/metrics.test.ts
+++ b/packages/nodejs/src/__tests__/metrics.test.ts
@@ -1,10 +1,24 @@
+import { BaseClient } from "../client"
 import { BaseMetrics as Metrics } from "../metrics"
+import { NoopProbes } from "../noops"
+import { BaseProbes } from "../probes"
 
 describe("Metrics", () => {
   let metrics: Metrics
 
   beforeEach(() => {
+    new BaseClient()
     metrics = new Metrics()
+  })
+
+  it("has `Probes` when minutely probes are on", () => {
+    expect(metrics.probes()).toBeInstanceOf(BaseProbes)
+  })
+
+  it("has `NoopProbes` when minutely probes are off", () => {
+    new BaseClient({ enableMinutelyProbes: false })
+    metrics = new Metrics()
+    expect(metrics.probes()).toBeInstanceOf(NoopProbes)
   })
 
   it("sets a gauge", () => {

--- a/packages/nodejs/src/__tests__/probes.test.ts
+++ b/packages/nodejs/src/__tests__/probes.test.ts
@@ -21,6 +21,16 @@ describe("Probes", () => {
     probes.register("test_metric", fn)
     jest.runOnlyPendingTimers()
     expect(fn).toHaveBeenCalled()
+    expect(probes.count).toEqual(1)
+  })
+
+  it("unregisters a probe", () => {
+    const fn = jest.fn()
+    probes.register("test_metric", fn)
+    probes.unregister("test_metric")
+    jest.runOnlyPendingTimers()
+    expect(fn).not.toHaveBeenCalled()
+    expect(probes.count).toEqual(0)
   })
 
   describe("v8 probe", () => {

--- a/packages/nodejs/src/__tests__/probes.test.ts
+++ b/packages/nodejs/src/__tests__/probes.test.ts
@@ -30,6 +30,14 @@ describe("Probes", () => {
     expect(probes.count).toEqual(1)
   })
 
+  it("does not call a probe after it has been overwritten", () => {
+    const first = registerMockProbe()
+    const second = registerMockProbe()
+    jest.runOnlyPendingTimers()
+    expect(first).not.toHaveBeenCalled()
+    expect(second).toHaveBeenCalled()
+  })
+
   it("unregisters a probe", () => {
     const fn = registerMockProbe()
     probes.unregister("test_metric")

--- a/packages/nodejs/src/bootstrap.ts
+++ b/packages/nodejs/src/bootstrap.ts
@@ -3,7 +3,6 @@ import { Instrumentation } from "./instrument"
 import { httpPlugin, httpsPlugin } from "./instrumentation/http"
 import * as pgPlugin from "./instrumentation/pg"
 import * as redisPlugin from "./instrumentation/redis"
-
 import * as gcProbe from "./probes/v8"
 
 /**
@@ -39,15 +38,8 @@ export function initCorePlugins(
 /**
  * Initialises all the available probes to attach automatically at runtime.
  */
-export function initCoreProbes(
-  meter: Metrics,
-  { enableMinutelyProbes }: { enableMinutelyProbes?: boolean }
-) {
+export function initCoreProbes(meter: Metrics) {
   let probes: any[] = [gcProbe]
-
-  if (!enableMinutelyProbes) {
-    return
-  }
 
   // load probes
   probes.forEach(({ PROBE_NAME, init }) =>

--- a/packages/nodejs/src/interfaces/probes.ts
+++ b/packages/nodejs/src/interfaces/probes.ts
@@ -14,6 +14,11 @@ export interface Probes {
   register(name: string, fn: () => void): this
 
   /**
+   * Unregisters an existing minutely probe.
+   */
+  unregister(name: string): this
+
+  /**
    * Unregisters all probes and clears the timers.
    */
   clear(): this

--- a/packages/nodejs/src/metrics.ts
+++ b/packages/nodejs/src/metrics.ts
@@ -1,7 +1,9 @@
 import { Metrics, Probes } from "./interfaces"
 import { BaseProbes } from "./probes"
+import { NoopProbes } from "./noops"
 import { metrics } from "./extension_wrapper"
 import { Data } from "./internal/data"
+import { BaseClient } from "./client"
 
 /**
  * The metrics object.
@@ -9,7 +11,17 @@ import { Data } from "./internal/data"
  * @class
  */
 export class BaseMetrics implements Metrics {
-  #probes = new BaseProbes()
+  #probes: Probes
+
+  constructor() {
+    let enableMinutelyProbes = BaseClient.config.data.enableMinutelyProbes
+
+    if (enableMinutelyProbes) {
+      this.#probes = new BaseProbes()
+    } else {
+      this.#probes = new NoopProbes()
+    }
+  }
 
   /**
    * A gauge is a metric value at a specific time. If you set more

--- a/packages/nodejs/src/noops/index.ts
+++ b/packages/nodejs/src/noops/index.ts
@@ -1,3 +1,4 @@
 export * from "./span"
 export * from "./tracer"
 export * from "./metrics"
+export * from "./probes"

--- a/packages/nodejs/src/noops/metrics.ts
+++ b/packages/nodejs/src/noops/metrics.ts
@@ -1,8 +1,8 @@
 import { Metrics, Probes } from "../interfaces"
-import { BaseProbes } from "../probes"
+import { NoopProbes } from "../noops"
 
 export class NoopMetrics implements Metrics {
-  #probes = new BaseProbes()
+  #probes = new NoopProbes()
 
   public setGauge(
     key: string,

--- a/packages/nodejs/src/noops/probes.ts
+++ b/packages/nodejs/src/noops/probes.ts
@@ -1,0 +1,19 @@
+import { Probes } from "../interfaces"
+
+export class NoopProbes implements Probes {
+  public get count(): number {
+    return 0
+  }
+
+  public register(name: string, fn: () => void): this {
+    return this
+  }
+
+  public unregister(name: string): this {
+    return this
+  }
+
+  public clear(): this {
+    return this
+  }
+}

--- a/packages/nodejs/src/probes/index.ts
+++ b/packages/nodejs/src/probes/index.ts
@@ -31,12 +31,25 @@ export class BaseProbes extends EventEmitter implements Probes {
     return this.on(name, fn)
   }
 
+  public unregister(name: string): this {
+    const timer = this.#timers.get(name)
+
+    if (typeof timer !== "undefined") {
+      clearInterval(timer)
+      this.#timers.delete(name)
+      this.removeAllListeners(name)
+    }
+
+    return this
+  }
+
   /**
    * Unregisters all probes and clears the timers.
    */
   public clear(): this {
     this.#timers.forEach(t => clearInterval(t))
     this.#timers = new Map()
+    this.removeAllListeners()
     return this
   }
 }

--- a/packages/nodejs/src/probes/index.ts
+++ b/packages/nodejs/src/probes/index.ts
@@ -28,6 +28,7 @@ export class BaseProbes extends EventEmitter implements Probes {
       setInterval(() => this.emit(name), 60 * 1000)
     )
 
+    this.removeAllListeners(name)
     return this.on(name, fn)
   }
 


### PR DESCRIPTION
Fixes #544.

### Implement unregister method for probes

Before this change, it was possible to disable a probe by registering an empty probe with the same name, but this is neither
obvious nor documented. This commit adds a `probes.unregister()` method that removes a probe in a more explicit manner.

[This will help in improving the docs relating to the minutely probes, as outlined in appsignal/appsignal-docs#532.]

### Fix enableMinutelyProbes behaviour

Before this change, setting `enableMinutelyProbes` to `false` would not disable the minutely probes system, it merely does not register the default minutely probe.

The flag's behaviour has been changed so that the minutely probes system is disabled in its entirety when it is set to `false`. The `Probes` object within `Metrics` is replaced by a `NoopProbes` object, which does nothing when a probe is registered.

[This also fixes the issue with the `APPSIGNAL_ENABLE_MINUTELY_PROBES` environment variable being effectively ignored, as described in #546]

### Fix probes not being overwritten

In the documentation for other integrations, we describe probes as being overwritten if a different probe with the same name is registered. While this was not documented as such for the Node.js integration in our user-facing documentation, our internal documentation for the `register` method describes its behaviour as such.

However, since the `EventEmitter` listeners were not being removed, when a new probe function was registered under the same name as an existing probe function, both probe functions would be called every minute. This commit fixes this, so that the behaviour matches the other integrations and the internal documentation.