### PR TITLE
Use APPSIGNAL_ACTIVE environment value

### DIFF
--- a/packages/nodejs/.changesets/use-appsignal_active-environment-variable.md
+++ b/packages/nodejs/.changesets/use-appsignal_active-environment-variable.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Use the APPSIGNAL_ACTIVE environment variable to determine whether AppSignal is active.

--- a/packages/nodejs/src/__tests__/config.test.ts
+++ b/packages/nodejs/src/__tests__/config.test.ts
@@ -13,6 +13,7 @@ describe("Configuration", () => {
   let initialEnv: { [key: string]: any }
 
   const expectedDefaultConfig = {
+    active: false,
     caFilePath: path.join(__dirname, "../../cert/cacert.pem"),
     debug: false,
     dnsServers: [],

--- a/packages/nodejs/src/__tests__/diagnose.test.ts
+++ b/packages/nodejs/src/__tests__/diagnose.test.ts
@@ -8,7 +8,7 @@ describe("DiagnoseTool", () => {
   const fsAccessSpy = jest.spyOn(fs, "accessSync").mockImplementation(() => {})
 
   beforeEach(() => {
-    tool = new DiagnoseTool({})
+    tool = new DiagnoseTool()
     jest.clearAllMocks()
   })
 
@@ -64,7 +64,7 @@ describe("DiagnoseTool", () => {
   describe("when to log path is configured as a full path", () => {
     beforeEach(() => {
       process.env["APPSIGNAL_LOG_PATH"] = "/path/to/appsignal.log"
-      tool = new DiagnoseTool({})
+      tool = new DiagnoseTool()
     })
 
     it("returns the log_dir_path", async () => {

--- a/packages/nodejs/src/cli/diagnose.ts
+++ b/packages/nodejs/src/cli/diagnose.ts
@@ -11,7 +11,7 @@ export class Diagnose {
   #diagnose: typeof DiagnoseTool
 
   constructor() {
-    this.#diagnose = new DiagnoseTool({})
+    this.#diagnose = new DiagnoseTool()
   }
 
   public async run() {

--- a/packages/nodejs/src/client.ts
+++ b/packages/nodejs/src/client.ts
@@ -43,12 +43,12 @@ export class BaseClient implements Client {
    * Creates a new instance of the `Appsignal` object
    */
   constructor(options: Partial<AppsignalOptions> = {}) {
-    const {
-      active = false, // Agent is not started by default
-      ignoreInstrumentation
-    } = options
+    const { ignoreInstrumentation } = options
 
     this.config = new Configuration(options)
+
+    const active = this.config.data.active!
+
     this.extension = new Extension({ active })
 
     this.storeInGlobal()

--- a/packages/nodejs/src/config.ts
+++ b/packages/nodejs/src/config.ts
@@ -113,6 +113,7 @@ export class Configuration {
    */
   private _defaultValues(): { [key: string]: any } {
     return {
+      active: false,
       caFilePath: path.join(__dirname, "../cert/cacert.pem"),
       debug: false,
       dnsServers: [],

--- a/packages/nodejs/src/diagnose.ts
+++ b/packages/nodejs/src/diagnose.ts
@@ -37,9 +37,9 @@ export class DiagnoseTool {
   #config: Configuration
   #extension: Extension
 
-  constructor({ active = true }) {
-    this.#config = new Configuration({ active })
-    this.#extension = new Extension({ active })
+  constructor() {
+    this.#config = new Configuration({})
+    this.#extension = new Extension({ active: true })
   }
 
   /**


### PR DESCRIPTION
Before this change, the value of the `APPSIGNAL_ACTIVE` environment variable would never be read, as the `active` config option was read directly from the `BaseClient` constructor. After this change, the option is read from the `Config` object, after it has been initialised in the constructor.

Fixes #546.