### PR TITLE
Allow expected process name to be a path

### DIFF
--- a/packages/nodejs/src/__tests__/config.test.ts
+++ b/packages/nodejs/src/__tests__/config.test.ts
@@ -282,7 +282,7 @@ describe("Configuration", () => {
 
     it("writes private constants to the environment", () => {
       expect(env("_APPSIGNAL_AGENT_PATH")).toMatch(/nodejs\/ext$/)
-      expect(env("_APPSIGNAL_PROCESS_NAME")).toEqual("node")
+      expect(env("_APPSIGNAL_PROCESS_NAME")).toMatch(/node$/)
       expect(env("_APPSIGNAL_LANGUAGE_INTEGRATION_VERSION")).toEqual(
         `nodejs-${VERSION}`
       )


### PR DESCRIPTION
This change allows the tests to pass locally when Node.js is invoked via tools like `asdf`, which keep the binary at a specific path outside the `$PATH` and invoke it with a shell shim.

[skip changeset]