### PR TITLE
Update install report path

### DIFF
--- a/packages/nodejs/.changesets/fix-install-report-path-name-generation.md
+++ b/packages/nodejs/.changesets/fix-install-report-path-name-generation.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Fix install report path name generation. This fixes the diagnose report not being able to find the path where the install report is stored.

--- a/packages/nodejs/.changesets/fix-install-report-path-name-generation.md
+++ b/packages/nodejs/.changesets/fix-install-report-path-name-generation.md
@@ -1,6 +1,0 @@
----
-bump: "patch"
-type: "fix"
----
-
-Fix install report path name generation. This fixes the diagnose report not being able to find the path where the install report is stored.

--- a/packages/nodejs/.changesets/update-install-report-path.md
+++ b/packages/nodejs/.changesets/update-install-report-path.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "change"
+---
+
+Update install report path location. The "nodejs" package now stores the install report in its own package path, with the rest of the extension files. This makes it easier to access by the diagnose report.

--- a/packages/nodejs/.gitignore
+++ b/packages/nodejs/.gitignore
@@ -79,3 +79,4 @@ build/
 /ext/appsignal.version
 /ext/libappsignal.a
 /ext/libappsignal.dylib
+/ext/*.report

--- a/packages/nodejs/scripts/extension/report.js
+++ b/packages/nodejs/scripts/extension/report.js
@@ -82,7 +82,7 @@ function createDownloadReport(report) {
 function reportPath() {
   // Navigate up to the app dir. Move up the scripts dir, package dir,
   // @appsignal dir and node_modules dir.
-  const appPath = path.join(__dirname, "../../../../")
+  const appPath = path.join(__dirname, "../../../../../")
   const hash = crypto.createHash("sha256")
   hash.update(appPath)
   const reportPathDigest = hash.digest("hex")

--- a/packages/nodejs/scripts/extension/report.js
+++ b/packages/nodejs/scripts/extension/report.js
@@ -80,13 +80,7 @@ function createDownloadReport(report) {
 // This implementation should match the `packages/nodejs/src/diagnose.ts`
 // implementation to generate the same path.
 function reportPath() {
-  // Navigate up to the app dir. Move up the scripts dir, package dir,
-  // @appsignal dir and node_modules dir.
-  const appPath = path.join(__dirname, "../../../../../")
-  const hash = crypto.createHash("sha256")
-  hash.update(appPath)
-  const reportPathDigest = hash.digest("hex")
-  return path.join(`/tmp/appsignal-${reportPathDigest}-install.report`)
+  return path.join(__dirname, "../../ext/install.report")
 }
 
 module.exports = {

--- a/packages/nodejs/src/__tests__/diagnose.test.ts
+++ b/packages/nodejs/src/__tests__/diagnose.test.ts
@@ -30,6 +30,20 @@ describe("DiagnoseTool", () => {
     expect(output.process.uid).toEqual(process.getuid())
   })
 
+  describe("install report", () => {
+    it("fetches the install report", async () => {
+      const output = await tool.generate()
+
+      const install = output.installation
+      expect(install).not.toHaveProperty("parsing_error")
+      expect(install).toHaveProperty("build")
+      expect(install).toHaveProperty("download")
+      expect(install).toHaveProperty("host")
+      expect(install).toHaveProperty("language")
+      expect(install).toHaveProperty("result")
+    })
+  })
+
   it("returns the log_dir_path", async () => {
     const report = await tool.generate()
     expect(report.paths.log_dir_path.path).toEqual("/tmp")

--- a/packages/nodejs/src/__tests__/diagnose.test.ts
+++ b/packages/nodejs/src/__tests__/diagnose.test.ts
@@ -42,6 +42,49 @@ describe("DiagnoseTool", () => {
       expect(install).toHaveProperty("language")
       expect(install).toHaveProperty("result")
     })
+
+    it("returns an error report on failure to read the install report", async () => {
+      const fsReadSpy = jest
+        .spyOn(fs, "readFileSync")
+        .mockImplementation(() => {
+          throw new Error("uh oh")
+        })
+      const output = await tool.generate()
+
+      const install = output.installation
+      expect(install).toMatchObject({
+        parsing_error: {
+          error: expect.any(String),
+          backtrace: expect.any(Array)
+        }
+      })
+      expect(install).not.toHaveProperty("build")
+      expect(install).not.toHaveProperty("download")
+      expect(install).not.toHaveProperty("host")
+      expect(install).not.toHaveProperty("language")
+      expect(install).not.toHaveProperty("result")
+    })
+
+    it("returns an error report on failure to parse the install report", async () => {
+      const fsReadSpy = jest
+        .spyOn(fs, "readFileSync")
+        .mockImplementation(() => "not JSON")
+      const output = await tool.generate()
+
+      const install = output.installation
+      expect(install).toMatchObject({
+        parsing_error: {
+          error: expect.any(String),
+          backtrace: expect.any(Array),
+          raw: "not JSON"
+        }
+      })
+      expect(install).not.toHaveProperty("build")
+      expect(install).not.toHaveProperty("download")
+      expect(install).not.toHaveProperty("host")
+      expect(install).not.toHaveProperty("language")
+      expect(install).not.toHaveProperty("result")
+    })
   })
 
   it("returns the log_dir_path", async () => {

--- a/packages/nodejs/src/diagnose.ts
+++ b/packages/nodejs/src/diagnose.ts
@@ -268,13 +268,7 @@ export class DiagnoseTool {
 // This implementation should match the `scripts/extension/report.js`
 // implementation to generate the same path.
 function reportPath(): string {
-  // Navigate up to the app dir. Move up the src dir, package dir, @appsignal
-  // dir and node_modules dir.
-  const appPath = path.join(__dirname, "../../../../")
-  const hash = createHash("sha256")
-  hash.update(appPath)
-  const reportPathDigest = hash.digest("hex")
-  return path.join(`/tmp/appsignal-${reportPathDigest}-install.report`)
+  return path.join(__dirname, "../ext/install.report")
 }
 
 function getPathType(stats: fs.Stats) {


### PR DESCRIPTION
## Update report path to match new package structure

In PR #545 we've merged the nodejs-ext package into the nodejs package.
This change moved some files around, and moved the extension install
scripts one level deeper into the `extension` subdirectory. Update the
report path name generation to match the new depth of the file.

Previously: `packages/nodejs-ext/scripts/extension.js`
New: `packages/nodejs/scripts/extension/extension.js`

It's interesting that no tests failed because of this. I think it's not
caught in the diagnose_tests, because we stub the install report.

I've now added a simple test to test the presence of the report, and not
a parsing error that occurs when no file could be read or there was a
problem reading the file. I'm struggling with Jest's mock system to
write a test for this and I'd rather look at it when addressing issue
#550 that updates the path location, which makes it easier to stub I
hope.

## Update install report location to ext directory

In PR #545 we've merged the nodejs-ext package into the nodejs package.
It no longer fails the package install on extension installation
failure, which means the ext directory remains after a installation
failure.

We can now store the install report file in the package's `ext`
directory, like we do in all the other integrations. This means we no
longer need to generate a filename for the install report to store it in
the system tmp directory.

Closes #550
