### PR TITLE
Fix extension function fallbacks

### DIFF
--- a/packages/nodejs/.changesets/fix-extension-fallback-functions.md
+++ b/packages/nodejs/.changesets/fix-extension-fallback-functions.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Fix the extension function fallbacks on installation failure. When the extension fails to install and calls are made to the unloaded functions, it will no longer throw an error.

--- a/packages/nodejs/.changesets/fix-extension-fallback-functions.md
+++ b/packages/nodejs/.changesets/fix-extension-fallback-functions.md
@@ -3,4 +3,4 @@ bump: "patch"
 type: "fix"
 ---
 
-Fix the extension function fallbacks on installation failure. When the extension fails to install and calls are made to the unloaded functions, it will no longer throw an error.
+Fix the extension function fallbacks on installation failure. When the extension fails to install and calls are made to the not loaded functions, it will no longer throw an error.

--- a/packages/nodejs/src/__tests__/extension.failure.test.ts
+++ b/packages/nodejs/src/__tests__/extension.failure.test.ts
@@ -30,4 +30,15 @@ describe("Extension", () => {
       ext.stop()
     }).not.toThrow()
   })
+
+  it("does not error on diagnoseRaw", () => {
+    expect(ext.diagnose()).toMatchObject({
+      error: expect.any(Error),
+      output: [""]
+    })
+  })
+
+  it("does not error on runningInContainer", () => {
+    expect(ext.runningInContainer()).toBeUndefined()
+  })
 })

--- a/packages/nodejs/src/extension.ts
+++ b/packages/nodejs/src/extension.ts
@@ -48,7 +48,7 @@ export class Extension {
     } catch (error) {
       return {
         error: error,
-        output: diagnostics_report_string.split("\n")
+        output: (diagnostics_report_string || "").split("\n")
       }
     }
   }

--- a/packages/nodejs/src/extension_wrapper.ts
+++ b/packages/nodejs/src/extension_wrapper.ts
@@ -12,9 +12,9 @@ try {
       start() {
         throw new Error("Extension module not loaded")
       },
-      stop() {
-        return
-      }
+      stop() {},
+      diagnoseRaw() {},
+      runningInContainer() {}
     }
   } as ExtensionWrapper
 }


### PR DESCRIPTION
As reported in #556, when the extension is not installed or fails to
load, calls to certain extension functions will fail. The issue mentions
the `runningInContainer` broken being broken on the main branch.

PR #554 also removes some safety checks that cause the same issue for
the `diagnoseRaw` function. Those safety checks were removed because
they did not what expected, tracking if the extension was running or
not.

For both functions I've implemented a no-operations function. This will
fix any errors on calls to these functions. Other functions that call
these functions need to handle receiving no return value.

Part of #556, but doesn't fix it entirely. We should call more function
calls. These ones were the most obvious ones.

Based on PR #554.