### PR TITLE
Fix the CI build to include intentional failures

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -111,6 +111,7 @@ blocks:
     - name: "@appsignal/nodejs - nodejs"
       commands:
       - mono test --package=@appsignal/nodejs
+      - mono run --package @appsignal/nodejs -- npm run test:failure
     - name: "@appsignal/nodejs - nodejs - diagnose"
       commands:
       - git submodule init
@@ -206,6 +207,7 @@ blocks:
     - name: "@appsignal/nodejs - nodejs"
       commands:
       - mono test --package=@appsignal/nodejs
+      - mono run --package @appsignal/nodejs -- npm run test:failure
     - name: "@appsignal/nodejs - nodejs - diagnose"
       commands:
       - git submodule init
@@ -299,6 +301,7 @@ blocks:
     - name: "@appsignal/nodejs - nodejs"
       commands:
       - mono test --package=@appsignal/nodejs
+      - mono run --package @appsignal/nodejs -- npm run test:failure
     - name: "@appsignal/nodejs - nodejs - diagnose"
       commands:
       - git submodule init
@@ -392,6 +395,7 @@ blocks:
     - name: "@appsignal/nodejs - nodejs"
       commands:
       - mono test --package=@appsignal/nodejs
+      - mono run --package @appsignal/nodejs -- npm run test:failure
     - name: "@appsignal/nodejs - nodejs - diagnose"
       commands:
       - git submodule init

--- a/build_matrix.yml
+++ b/build_matrix.yml
@@ -98,12 +98,8 @@ matrix:
           - git submodule init
           - git submodule update
           - LANGUAGE=nodejs test/integration/diagnose/bin/test
-    - package: "@appsignal/nodejs-ext"
-      path: "packages/nodejs-ext"
-      variations:
-        - name: "nodejs-ext"
       extra_commands:
-        - mono run --package @appsignal/nodejs-ext -- npm run test:failure
+        - mono run --package @appsignal/nodejs -- npm run test:failure
     # Library integrations
     - package: "@appsignal/apollo-server"
       path: "packages/apollo-server"

--- a/packages/nodejs/jest.config.js
+++ b/packages/nodejs/jest.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   preset: "ts-jest",
   testEnvironment: "node",
-  roots: ["<rootDir>/src"],
+  roots: ["<rootDir>/src", "<rootDir>/scripts"],
   transform: {
     "^.+\\.tsx?$": "ts-jest"
   }

--- a/packages/nodejs/package.json
+++ b/packages/nodejs/package.json
@@ -27,13 +27,14 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "build:watch": "tsc -p tsconfig.json -w --preserveWatchOutput",
-    "clean": "rimraf dist coverage && rimraf ext/appsignal-agent ext/libappsignal.a ext/appsignal.* ext/*.tar.gz",
+    "clean": "rimraf dist coverage build && rimraf ext/appsignal-agent ext/libappsignal.a ext/appsignal.* ext/*.tar.gz ext/*.report",
     "install": "node scripts/extension/extension.js",
     "link:npm": "npm link",
     "link:yarn": "yarn link",
     "test": "jest --filter=./test/filter.js",
-    "test:ext:failure": "_TEST_APPSIGNAL_EXTENSION_FAILURE=true _APPSIGNAL_EXTENSION_INSTALL=true npm run install; _TEST_APPSIGNAL_EXTENSION_FAILURE=true jest --filter=./test/filter.js",
-    "test:watch": "jest --filter=./test/filter.js --watch"
+    "test:watch": "jest --filter=./test/filter.js --watch",
+    "pretest:failure": "npm run clean",
+    "test:failure": "_TEST_APPSIGNAL_EXTENSION_FAILURE=true _APPSIGNAL_EXTENSION_INSTALL=true npm run install; _TEST_APPSIGNAL_EXTENSION_FAILURE=true jest --filter=./test/filter.js"
   },
   "os": [
     "linux",


### PR DESCRIPTION
In the package mergers of PR #545, we merged the `nodejs-ext` package in
the `nodejs` package.

The tests that belong to the `nodejs-ext` package that tested the
behavior when the extension failed to install were not run after merging
that PR.

I've updated the build matrix to run those tests for the `nodejs`
package now.

For Jest I also had to configure a new root directory. In the
`nodejs-ext` package this was not configure, so I assume it previously
searched in all subdirectories.

For the clean command I also had to add the `build` directory be cleaned
up, otherwise it would continue to load the loaded extension without
problem.

[skip changeset]
