### PR TITLE
Remove cpu and os fields from package.json

### DIFF
--- a/packages/nodejs/.changesets/remove-package-json-os-and-cpu-fields.md
+++ b/packages/nodejs/.changesets/remove-package-json-os-and-cpu-fields.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "change"
+---
+
+Remove the `os` and `cpu` fields from the `package.json`. This will prevent installations from failing on unlisted CPU architectures and Operating Systems. Our extension installer script will do this check instead. The package should not fail to install when it encounters an unsupported CPU architecture or Operating System.

--- a/packages/nodejs/package.json
+++ b/packages/nodejs/package.json
@@ -36,16 +36,6 @@
     "pretest:failure": "npm run clean",
     "test:failure": "_TEST_APPSIGNAL_EXTENSION_FAILURE=true _APPSIGNAL_EXTENSION_INSTALL=true npm run install; _TEST_APPSIGNAL_EXTENSION_FAILURE=true jest --filter=./test/filter.js"
   },
-  "os": [
-    "linux",
-    "darwin",
-    "freebsd"
-  ],
-  "cpu": [
-    "x64",
-    "x86",
-    "arm"
-  ],
   "engines": {
     "node": ">= 12"
   },


### PR DESCRIPTION
When the `cpu` or `os` fields are configured npm will not install the
package if the host CPU architecture or Operating System does not match
any of the configured values.

This previously meant the `nodejs-ext` package would not install and be
removed from the file system, which it also did if the extension
installation failed later on in the process. (It doesn't do that
anymore.) Since we merged the `nodejs-ext` package in the `nodejs`
package, these fields will cause serious problems with the integration.

If the nodejs package would fail to install the whole integration would
break. The app and other packages would try to call parts of the package
that is not present.

Remove the `os` and `cpu` fields to not restrict installation to any of
the configured CPU architectures or Operating Systems. Our extension
installer script figures out for which it can install the extension, and
write a report on failure. The `nodejs` package should always install
without issue.

Closes #560