### PR TITLE
Update CI with new install report location

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -81,14 +81,12 @@ blocks:
     epilogue: &2
       on_fail:
         commands:
-        - cat /tmp/appsignal-*-install.report
+        - cat packages/nodejs/ext/install.report
     jobs:
     - name: Build
       commands:
       - mono build
       - cache store $_PACKAGES_CACHE-packages-$SEMAPHORE_GIT_SHA-v$NODE_VERSION packages
-      - cache store $_PACKAGES_CACHE-install-report-$SEMAPHORE_GIT_SHA-v$NODE_VERSION
-        /tmp/appsignal-*-install.report
 - name: Node.js 17 - Tests
   dependencies:
   - Node.js 17 - Build
@@ -104,7 +102,6 @@ blocks:
       - sem-version c 8
       - cache restore
       - cache restore $_PACKAGES_CACHE-packages-$SEMAPHORE_GIT_SHA-v$NODE_VERSION
-      - cache restore $_PACKAGES_CACHE-install-report-$SEMAPHORE_GIT_SHA-v$NODE_VERSION
       - mono bootstrap --ci
     epilogue: *2
     jobs:
@@ -184,8 +181,6 @@ blocks:
       commands:
       - mono build
       - cache store $_PACKAGES_CACHE-packages-$SEMAPHORE_GIT_SHA-v$NODE_VERSION packages
-      - cache store $_PACKAGES_CACHE-install-report-$SEMAPHORE_GIT_SHA-v$NODE_VERSION
-        /tmp/appsignal-*-install.report
 - name: Node.js 16 - Tests
   dependencies:
   - Node.js 16 - Build
@@ -200,7 +195,6 @@ blocks:
       - sem-version c 8
       - cache restore
       - cache restore $_PACKAGES_CACHE-packages-$SEMAPHORE_GIT_SHA-v$NODE_VERSION
-      - cache restore $_PACKAGES_CACHE-install-report-$SEMAPHORE_GIT_SHA-v$NODE_VERSION
       - mono bootstrap --ci
     epilogue: *2
     jobs:
@@ -279,8 +273,6 @@ blocks:
       commands:
       - mono build
       - cache store $_PACKAGES_CACHE-packages-$SEMAPHORE_GIT_SHA-v$NODE_VERSION packages
-      - cache store $_PACKAGES_CACHE-install-report-$SEMAPHORE_GIT_SHA-v$NODE_VERSION
-        /tmp/appsignal-*-install.report
 - name: Node.js 14 - Tests
   dependencies:
   - Node.js 14 - Build
@@ -294,7 +286,6 @@ blocks:
       commands:
       - cache restore
       - cache restore $_PACKAGES_CACHE-packages-$SEMAPHORE_GIT_SHA-v$NODE_VERSION
-      - cache restore $_PACKAGES_CACHE-install-report-$SEMAPHORE_GIT_SHA-v$NODE_VERSION
       - mono bootstrap --ci
     epilogue: *2
     jobs:
@@ -373,8 +364,6 @@ blocks:
       commands:
       - mono build
       - cache store $_PACKAGES_CACHE-packages-$SEMAPHORE_GIT_SHA-v$NODE_VERSION packages
-      - cache store $_PACKAGES_CACHE-install-report-$SEMAPHORE_GIT_SHA-v$NODE_VERSION
-        /tmp/appsignal-*-install.report
 - name: Node.js 12 - Tests
   dependencies:
   - Node.js 12 - Build
@@ -388,7 +377,6 @@ blocks:
       commands:
       - cache restore
       - cache restore $_PACKAGES_CACHE-packages-$SEMAPHORE_GIT_SHA-v$NODE_VERSION
-      - cache restore $_PACKAGES_CACHE-install-report-$SEMAPHORE_GIT_SHA-v$NODE_VERSION
       - mono bootstrap --ci
     epilogue: *2
     jobs:

--- a/Rakefile
+++ b/Rakefile
@@ -41,9 +41,7 @@ namespace :build_matrix do
                 "commands" => [
                   "mono build",
                   "cache store $_PACKAGES_CACHE-packages-$SEMAPHORE_GIT_SHA-v$NODE_VERSION " \
-                    "packages",
-                  "cache store $_PACKAGES_CACHE-install-report-$SEMAPHORE_GIT_SHA-v$NODE_VERSION " \
-                    "/tmp/appsignal-*-install.report"
+                    "packages"
                 ]
               )
             ]
@@ -119,7 +117,6 @@ namespace :build_matrix do
                 "commands" => setup + [
                   "cache restore",
                   "cache restore $_PACKAGES_CACHE-packages-$SEMAPHORE_GIT_SHA-v$NODE_VERSION",
-                  "cache restore $_PACKAGES_CACHE-install-report-$SEMAPHORE_GIT_SHA-v$NODE_VERSION",
                   "mono bootstrap --ci"
                 ]
               },

--- a/build_matrix.yml
+++ b/build_matrix.yml
@@ -67,7 +67,7 @@ matrix:
   epilogue: # Shared for all jobs in the build matrix
     on_fail:
       commands:
-        - "cat /tmp/appsignal-*-install.report"
+        - "cat packages/nodejs/ext/install.report"
 
   nodejs:
     - nodejs: "17"


### PR DESCRIPTION
In PR #553 I moved the install report location from the global system
tmp path, to the `ext` dir in the nodejs package. Update the CI failure
commands to match.

I removed the separate cache store, because it's included in the
"packages" cache already.

[skip changeset]
[skip review]