### PR TITLE
Lock Redis supported version to 3.x.x

### DIFF
--- a/packages/nodejs/.changesets/lock-redis-version-to-3.md
+++ b/packages/nodejs/.changesets/lock-redis-version-to-3.md
@@ -1,0 +1,7 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+The supported Redis version is now locked to 3.x.x. This will prevent app startup failures for users
+with Redis 4.x.x.

--- a/packages/nodejs/src/instrumentation/redis/index.ts
+++ b/packages/nodejs/src/instrumentation/redis/index.ts
@@ -82,7 +82,7 @@ export const instrument = (
   mod: RedisModule,
   tracer: Tracer
 ): Plugin<RedisModule> => ({
-  version: ">= 3.0.0",
+  version: "~3",
   install(): RedisModule {
     shimmer.wrap(
       mod.RedisClient.prototype,


### PR DESCRIPTION
The supported Redis version is now locked to 3.x.x. This will prevent app startup failures for users
with Redis 4.x.x.

Support issue: https://github.com/appsignal/support/issues/184