### PR TITLE
Check if the correct package version is installed

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -66,7 +66,7 @@ namespace :build_matrix do
                   "#{name}@#{version}"
                 end.join(" ")
                 [
-                  "cd #{package["path"]} && npm install #{packages} --save-dev",
+                  "script/install_packages #{packages}",
                   "script/install_test_example_packages " \
                     "#{File.basename package["path"]} #{packages}"
                 ]

--- a/script/install_packages
+++ b/script/install_packages
@@ -2,27 +2,6 @@
 
 set -eu
 
-package=$1
-shift
-
-if [ "$package" == "" ]; then
-  echo "No package specified!"
-  echo "Usage: install_test_example_packages <package dir> <dependencies>"
-  echo "Example: install_test_example_packages koa koa@1.2.3"
-  exit 1
-fi
-
-example_path="packages/$package/test/example"
-
-if [ ! -d "$example_path" ]; then
-  echo "No test example directory for package $package in $example_path"
-  echo "Please check if the directory exists in the packages/ directory"
-  exit 1
-fi
-
-echo "Navigate to test app directory"
-cd "$example_path"
-
 echo "$ npm install"
 npm install "$@"
 

--- a/script/install_packages
+++ b/script/install_packages
@@ -6,7 +6,7 @@ echo "$ npm install"
 npm install "$@"
 
 echo "Check installed packages"
-installed_packages=$(npm list)
+installed_packages=$(npm list --long --parseable | cut -d ':' -f 2)
 successfully_installed=true
 for package_item in "$@"; do
   if echo "$package_item" | grep "@latest"; then

--- a/script/install_test_example_packages
+++ b/script/install_test_example_packages
@@ -14,15 +14,17 @@ fi
 
 example_path="packages/$package/test/example"
 
-if [ ! -d $example_path ]; then
-  echo "No test example directory for package $package in $package_path"
+if [ ! -d "$example_path" ]; then
+  echo "No test example directory for package $package in $example_path"
   echo "Please check if the directory exists in the packages/ directory"
   exit 1
 fi
 
-cd $example_path
+echo "Navigate to test app directory"
+cd "$example_path"
+
 echo "$ npm install"
-npm install $@
+npm install "$@"
 
 echo "$ npm list"
 npm list

--- a/script/install_test_example_packages
+++ b/script/install_test_example_packages
@@ -27,7 +27,7 @@ echo "$ npm install"
 npm install "$@"
 
 echo "Check installed packages"
-installed_packages=$(npm list)
+installed_packages=$(npm list --long --parseable | cut -d ':' -f 2)
 successfully_installed=true
 for package_item in "$@"; do
   if echo "$package_item" | grep "@latest"; then


### PR DESCRIPTION
## Run shellcheck linter over install script

Fix some issues reported by shellcheck such as variable escaping.

## Check if the correct package version is installed

In the `install_test_example_packages` script, check the output
of `npm list` if the installed packages are actually installed.
I've added this check, because running `npm install` won't fail if it
can't install a specific version if it already has installed something
(listing the package in the `package.json`).

It skips the `latest` version, because it won't know what version will
actually be installed.

Note that the `install_packages` script is not actually used at the
moment, because we don't run the unit tests against specific versions of
packages. Only the integration tests. There are no unit tests for
specific integration packages. If we decide to run future unit tests
against different versions, at least we won't run into the same issue
again.

Fixes #584
[skip changeset]

## Better check installed package versions

Use the suggested command by Noemi to check if the package is installed
or not.

It outputs a plain list of packages and their versions, without the tree
type output to make it easier to read for humans.
