### PR TITLE
Update span tests

### DIFF
--- a/packages/nodejs/src/__tests__/span.test.ts
+++ b/packages/nodejs/src/__tests__/span.test.ts
@@ -11,6 +11,7 @@ type SpanData = {
   span_id?: string
   start_time?: number
   trace_id?: string
+  attributes?: { [key: string]: string }
 }
 
 describe("RootSpan", () => {
@@ -77,6 +78,15 @@ describe("RootSpan", () => {
     expect(internal.name).toEqual(name)
   })
 
+  it("sets the category", () => {
+    const category = "test_category"
+
+    const span = new RootSpan().setCategory(category)
+    const internal = JSON.parse(span.toJSON())
+
+    expect(internal.attributes["appsignal:category"]).toEqual(category)
+  })
+
   it("closes a span", () => {
     span = new RootSpan().close()
     internal = JSON.parse(span.toJSON())
@@ -141,17 +151,16 @@ describe("ChildSpan", () => {
     expect(child).toBeInstanceOf(ChildSpan)
   })
 
-  it("sets the name", () => {
-    const name = "test_span"
+  it("sets the category", () => {
+    const category = "test_category"
 
     span = new ChildSpan({
       traceId: "test_trace_id",
       spanId: "parent_span_id"
-    }).setName(name)
-
+    }).setCategory(category)
     internal = JSON.parse(span.toJSON())
 
-    expect(internal.name).toEqual(name)
+    expect(internal.attributes!["appsignal:category"]).toEqual(category)
   })
 
   it("closes a span", () => {

--- a/packages/nodejs/src/__tests__/span.test.ts
+++ b/packages/nodejs/src/__tests__/span.test.ts
@@ -52,14 +52,6 @@ describe("RootSpan", () => {
     expect(traceId).toEqual(internal.trace_id)
   })
 
-  it("exposes a start time", () => {
-    const { traceId } = span
-
-    expect(traceId).toBeDefined()
-    expect(internal.trace_id).toBeDefined()
-    expect(traceId).toEqual(internal.trace_id)
-  })
-
   it("creates a new ChildSpan", () => {
     const child = span.child()
 
@@ -135,14 +127,6 @@ describe("ChildSpan", () => {
   })
 
   it("exposes a traceId", () => {
-    const { traceId } = span
-
-    expect(traceId).toBeDefined()
-    expect(internal.trace_id).toBeDefined()
-    expect(traceId).toEqual(internal.trace_id)
-  })
-
-  it("exposes a start time", () => {
     const { traceId } = span
 
     expect(traceId).toBeDefined()


### PR DESCRIPTION
This is a small extraction of an attempt at a larger refactor to try something out for https://github.com/appsignal/appsignal-nodejs/issues/556
[skip changeset]

## Remove duplicate test for trace_id

This test asserts if the internal object's `trace_id` is set. This is
tested in the "exposes a traceId" test already.

The description of what the test says it does is covered under the
"creates a Root/ChildSpan with a timestamp" test.

## Add unit tests for setCategory

The span tests didn't have a case for the `setCategory` helper.

I've reused the `setName` test for the `ChildSpan`. It's possible to set
a "name" on a ChildSpan, but the value is ignored. It's not relevant to
test this scenario.
