### PR TITLE
Fix the extension path for local install detection

### DIFF
--- a/packages/nodejs/scripts/extension/support/helpers.js
+++ b/packages/nodejs/scripts/extension/support/helpers.js
@@ -11,7 +11,7 @@ function hasLocalBuild() {
   const filenames = ["appsignal-agent", "libappsignal.a", "appsignal.h"]
 
   return filenames.every(file =>
-    fs.existsSync(path.join(__dirname, "/../../ext/", file))
+    fs.existsSync(path.join(__dirname, "/../../../ext/", file))
   )
 }
 


### PR DESCRIPTION
The local install detection broke after the changes in PR #545. The
extension directory moved. This local install detection needs to be
updated to account for the additional subdirectory this `helpers.js`
file is now in.

This is why the agent CI didn't seem to pick up the local agent for the
Node.js tests.

[skip changeset] because it affects none of our users. It's only an
internal function.