### PR TITLE
Test the Transmitter class

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5527,6 +5527,12 @@
       "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
       "dev": true
     },
+    "node_modules/lodash.set": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
+      "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=",
+      "dev": true
+    },
     "node_modules/lodash.sortby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
@@ -5968,6 +5974,44 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+      "dev": true
+    },
+    "node_modules/nock": {
+      "version": "13.2.2",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-13.2.2.tgz",
+      "integrity": "sha512-PcBHuvl9i6zfaJ50A7LS55oU+nFLv8htXIhffJO+FxyfibdZ4jEvd9kTuvkrJireBFIGMZ+oUIRpMK5gU9h//g==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.1.0",
+        "json-stringify-safe": "^5.0.1",
+        "lodash.set": "^4.3.2",
+        "propagate": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.13"
+      }
+    },
+    "node_modules/nock/node_modules/debug": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/nock/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
     "node_modules/node-addon-api": {
@@ -6970,6 +7014,15 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/propagate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
+      "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/proxy-addr": {
@@ -9274,6 +9327,7 @@
         "@types/pg": "*",
         "@types/redis": "*",
         "@types/semver": "*",
+        "nock": "^13.2.2",
         "pg": "*",
         "redis": "*"
       },
@@ -9445,6 +9499,7 @@
         "@types/pg": "*",
         "@types/redis": "*",
         "@types/semver": "*",
+        "nock": "^13.2.2",
         "node-addon-api": "^3.1.0",
         "node-gyp": "^7.1.2",
         "pg": "*",
@@ -13906,6 +13961,12 @@
       "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
       "dev": true
     },
+    "lodash.set": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
+      "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=",
+      "dev": true
+    },
     "lodash.sortby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
@@ -14235,6 +14296,35 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
+    },
+    "nock": {
+      "version": "13.2.2",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-13.2.2.tgz",
+      "integrity": "sha512-PcBHuvl9i6zfaJ50A7LS55oU+nFLv8htXIhffJO+FxyfibdZ4jEvd9kTuvkrJireBFIGMZ+oUIRpMK5gU9h//g==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.0",
+        "json-stringify-safe": "^5.0.1",
+        "lodash.set": "^4.3.2",
+        "propagate": "^2.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+          "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
+      }
     },
     "node-addon-api": {
       "version": "3.1.0",
@@ -14994,6 +15084,12 @@
         "kleur": "^3.0.3",
         "sisteransi": "^1.0.5"
       }
+    },
+    "propagate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
+      "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
+      "dev": true
     },
     "proxy-addr": {
       "version": "2.0.6",

--- a/packages/nodejs/package.json
+++ b/packages/nodejs/package.json
@@ -23,10 +23,11 @@
     "tslib": "^2.0.3"
   },
   "devDependencies": {
-    "@types/semver": "*",
     "@types/pg": "*",
-    "pg": "*",
     "@types/redis": "*",
+    "@types/semver": "*",
+    "nock": "^13.2.2",
+    "pg": "*",
     "redis": "*"
   },
   "scripts": {

--- a/packages/nodejs/src/__tests__/transmitter.test.ts
+++ b/packages/nodejs/src/__tests__/transmitter.test.ts
@@ -1,0 +1,170 @@
+import { Transmitter } from "../transmitter"
+import nock from "nock"
+import https from "https"
+import fs from "fs"
+import { ClientRequest, IncomingMessage } from "http"
+
+describe("Transmitter", () => {
+  let originalEnv: any = undefined
+
+  beforeEach(() => {
+    if (!nock.isActive()) {
+      nock.activate()
+    }
+
+    nock.disableNetConnect()
+
+    originalEnv = { ...process.env }
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+
+    process.env = originalEnv
+  })
+
+  afterAll(() => {
+    nock.restore()
+  })
+
+  describe(".transmit", () => {
+    function sampleTransmitter(): Transmitter {
+      return new Transmitter("https://example.com/foo", "request body")
+    }
+
+    function mockSampleRequest(responseBody: object | string, query = {}) {
+      nock("https://example.com")
+        .post("/foo", "request body")
+        .query({
+          api_key: "",
+          name: "",
+          environment: "test",
+          hostname: "",
+          ...query
+        })
+        .reply(200, responseBody)
+    }
+
+    async function expectResponse(
+      response: Promise<any>,
+      expectedBody: object
+    ) {
+      await expect(response).resolves.toEqual({
+        status: 200,
+        body: expectedBody
+      })
+    }
+
+    function mockHTTPSRequest() {
+      return jest.spyOn(https, "request").mockImplementation(() => {
+        const clientRequestMock = {
+          on: () => {},
+          write: () => {},
+          end: () => {}
+        }
+
+        return (clientRequestMock as unknown) as ClientRequest
+      })
+    }
+
+    it("resolves to a response on success", async () => {
+      const transmitter = sampleTransmitter()
+
+      mockSampleRequest({ json: "response" })
+
+      await expectResponse(transmitter.transmit(), { json: "response" })
+    })
+
+    it("resolves to an empty object if the response is not JSON", async () => {
+      const transmitter = sampleTransmitter()
+
+      mockSampleRequest("not JSON")
+
+      await expectResponse(transmitter.transmit(), {})
+    })
+
+    it("rejects on error", async () => {
+      const transmitter = sampleTransmitter()
+
+      // do not mock the request -- beforeEach uses nock to disable network
+      // requests, so any request to a non-mocked host will throw an error
+
+      await expect(transmitter.transmit()).rejects.toMatchObject({
+        error: expect.any(Error)
+      })
+    })
+
+    it("uses config values in the query string", async () => {
+      process.env.APPSIGNAL_PUSH_API_KEY = "some_api_key"
+      process.env.APPSIGNAL_APP_NAME = "myApp"
+      ;(process.env as any).NODE_ENV = "development"
+      process.env.APPSIGNAL_HOSTNAME = "myHostname"
+
+      const transmitter = sampleTransmitter()
+
+      mockSampleRequest(
+        {},
+        {
+          api_key: "some_api_key",
+          name: "myApp",
+          environment: "development",
+          hostname: "myHostname"
+        }
+      )
+
+      await expectResponse(transmitter.transmit(), {})
+    })
+
+    it("uses the CA file from the config", async () => {
+      // disable nock, so we can mock the https library ourselves
+      nock.restore()
+
+      process.env.APPSIGNAL_CA_FILE_PATH = "/foo/bar"
+
+      jest.spyOn(fs, "accessSync").mockImplementation(() => {})
+
+      const fsReadFileSyncMock = jest
+        .spyOn(fs, "readFileSync")
+        .mockImplementation(() => "ca file contents")
+
+      const httpsRequestMock = mockHTTPSRequest()
+
+      sampleTransmitter().transmit()
+
+      expect(fsReadFileSyncMock).toHaveBeenCalledWith("/foo/bar", "utf-8")
+
+      expect(httpsRequestMock).toHaveBeenCalledWith(
+        expect.objectContaining({ ca: "ca file contents" }),
+        expect.anything()
+      )
+    })
+
+    it("doesn't configure the CA if the CA file is not readable", () => {
+      // disable nock, so we can mock the https library ourselves
+      nock.restore()
+
+      process.env.APPSIGNAL_CA_FILE_PATH = "/foo/bar"
+
+      jest.spyOn(fs, "accessSync").mockImplementation(path => {
+        if (path == "/foo/bar") {
+          throw new Error("No CA for you!")
+        }
+      })
+
+      const consoleWarnSpy = jest.spyOn(console, "warn")
+
+      const httpsRequestMock = mockHTTPSRequest()
+
+      sampleTransmitter().transmit()
+
+      expect(httpsRequestMock).toHaveBeenCalledWith(
+        expect.not.objectContaining({ ca: expect.anything() }),
+        expect.anything()
+      )
+
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        "Provided caFilePath: '/foo/bar' is not readable."
+      )
+    })
+  })
+})


### PR DESCRIPTION
Adds tests for the existing functionality of the `Transmitter` class. It checks that the query parameters are added to the URL, using values from the config, that the promise is resolved with a status code and body, or rejected with an error, that the body is parsed as JSON or replaced with an empty object, and that it uses the CA file defined in the config in HTTPS requests.

Fixes an issue with the Transmitter where the full URL was used in place of the path -- that is, `GET http://foo.com/bar` was sent over the wire, instead of `GET /bar`.

Removes the unused `active` parameter from the Transmitter class, and no longer passes it as `true` to the Config. Using the Transmitter should not initialise the extension.

Changes the Transmitter implementation so that, when a CA file could not be read, the `ca` property of the HTTPS options object is unset, instead of being set to an empty string.

This is a first step towards #532. 

[skip changeset]