### PR TITLE
Add more tests for Span type

### DIFF
--- a/packages/nodejs/.changesets/remove-span-tojson-function.md
+++ b/packages/nodejs/.changesets/remove-span-tojson-function.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "remove"
+---
+
+Remove the private function `Span.toJSON`. This wasn't previously marked as private, but it was.

--- a/packages/nodejs/src/__tests__/scope.test.ts
+++ b/packages/nodejs/src/__tests__/scope.test.ts
@@ -98,12 +98,12 @@ describe("ScopeManager", () => {
         const span = scopeManager.active()
 
         expect(span).toBeDefined()
-        expect(span?.toJSON()).toMatch(/modified/)
+        expect(span?.toObject().name).toEqual("modified")
       }
 
       scopeManager.withContext(test, span => {
         span.setName("default")
-        expect(span.toJSON()).toMatch(/default/)
+        expect(span.toObject().name).toEqual("default")
       })
 
       scopeManager.withContext(test, span => {
@@ -115,5 +115,6 @@ describe("ScopeManager", () => {
     })
   })
 
+  // TODO: Add tests
   describe(".emitWithContext()", () => {})
 })

--- a/packages/nodejs/src/__tests__/tracer.test.ts
+++ b/packages/nodejs/src/__tests__/tracer.test.ts
@@ -13,14 +13,14 @@ describe("Tracer", () => {
   describe(".createSpan()", () => {
     it("assigns the spans properly", () => {
       const rootSpan = tracer.createSpan().setName("rootSpan")
-      const rootSpanData = JSON.parse(rootSpan.toJSON())
+      const rootSpanData = rootSpan.toObject()
 
       expect(rootSpan).toBeInstanceOf(RootSpan)
       expect(rootSpanData.parent_span_id).toEqual("")
       expect(rootSpanData.name).toEqual("rootSpan")
 
       const childSpan = tracer.createSpan().setName("childSpan")
-      const childSpanData = JSON.parse(childSpan.toJSON())
+      const childSpanData = childSpan.toObject()
 
       expect(childSpan).toBeInstanceOf(ChildSpan)
       expect(childSpanData.parent_span_id).toEqual(rootSpanData.span_id)
@@ -29,7 +29,7 @@ describe("Tracer", () => {
       const spanFromSpan = tracer
         .createSpan(undefined, childSpan)
         .setName("spanFromSpan")
-      const spanFromSpanData = JSON.parse(spanFromSpan.toJSON())
+      const spanFromSpanData = spanFromSpan.toObject()
 
       expect(spanFromSpan).toBeInstanceOf(ChildSpan)
       expect(spanFromSpanData.parent_span_id).toEqual(childSpanData.span_id)
@@ -58,11 +58,11 @@ describe("Tracer", () => {
         rootSpan.setCategory("bar")
         rootSpan.set("pod", 42)
 
-        const rootSpanData = JSON.parse(rootSpan.toJSON())
+        const rootSpanData = rootSpan.toObject()
 
         expect(rootSpanData.name).toEqual("foo")
-        expect(rootSpanData.attributes["appsignal:category"]).toEqual("bar")
-        expect(rootSpanData.attributes.pod).toEqual(42)
+        expect(rootSpanData.attributes!["appsignal:category"]).toEqual("bar")
+        expect(rootSpanData.attributes!.pod).toEqual(42)
 
         return done()
       })
@@ -70,9 +70,9 @@ describe("Tracer", () => {
 
     it("adds the given error to the span", done => {
       tracer.sendError(err, rootSpan => {
-        const rootSpanData = JSON.parse(rootSpan.toJSON())
+        const rootSpanData = rootSpan.toObject()
 
-        expect(rootSpanData.error.message).toEqual("FooBarError")
+        expect(rootSpanData.error!.message).toEqual("FooBarError")
 
         return done()
       })
@@ -84,7 +84,7 @@ describe("Tracer", () => {
       const rootSpan = tracer.createSpan().setName(name)
 
       await tracer.withSpan(rootSpan, async span => {
-        const internal = JSON.parse(span.toJSON())
+        const internal = span.toObject()
         expect(internal.name).toEqual(name)
 
         span.close()

--- a/packages/nodejs/src/interfaces/span.ts
+++ b/packages/nodejs/src/interfaces/span.ts
@@ -116,7 +116,24 @@ export interface Span {
   close(endTime?: number): this
 
   /**
-   * Returns a JSON string representing the internal Span in the agent.
+   * Returns a SpanData object representing the internal Span in the extension.
+   *
+   * @private
    */
-  toJSON(): string
+  toObject(): SpanData
+}
+
+/**
+ * The internal data structure of a `Span` inside the AppSignal Extension.
+ */
+export type SpanData = {
+  closed?: boolean
+  name?: string
+  namespace?: string
+  parent_span_id?: string
+  span_id?: string
+  start_time?: number
+  trace_id?: string
+  error?: { name: string; message: string; backtrace: Array<String> }
+  attributes?: { [key: string]: string }
 }

--- a/packages/nodejs/src/noops/span.ts
+++ b/packages/nodejs/src/noops/span.ts
@@ -1,5 +1,5 @@
 import { HashMap } from "@appsignal/types"
-import { Span } from "../interfaces"
+import { Span, SpanData } from "../interfaces"
 
 export class NoopSpan implements Span {
   public get traceId(): string {
@@ -52,7 +52,7 @@ export class NoopSpan implements Span {
     return this
   }
 
-  public toJSON(): string {
-    return "{}"
+  public toObject(): SpanData {
+    return {}
   }
 }

--- a/packages/nodejs/src/span.ts
+++ b/packages/nodejs/src/span.ts
@@ -1,6 +1,5 @@
 import { HashMap, HashMapValue } from "@appsignal/types"
-
-import { Span, SpanOptions, SpanContext } from "./interfaces"
+import { Span, SpanOptions, SpanContext, SpanData } from "./interfaces"
 
 import { span } from "./extension_wrapper"
 import { Data } from "./internal/data"
@@ -190,19 +189,21 @@ export class BaseSpan implements Span {
   }
 
   /**
-   * Returns a JSON string representing the internal Span in the agent.
+   * Returns a SpanData object representing the internal Span in the extension.
+   *
+   * @private
    */
-  public toJSON(): string {
+  public toObject(): SpanData {
     const json = span.spanToJSON(this._ref)
 
     // if this is true, then the span has been garbage collected
     // @TODO: i feel that this could have better ergonomics on the agent
     // side. come up with something better here later.
     if (json.trim() === "") {
-      return JSON.stringify({ closed: true })
+      return { closed: true }
     }
 
-    return json
+    return JSON.parse(json)
   }
 }
 


### PR DESCRIPTION
Some functions were not directly unit tested. Add some tests to cover
the basics.

I didn't repeat the same tests for the ChildSpan, because they're
calling the identical functions through inheritance. We should revisit
how this is tested, only testing it once.

[skip changeset]