### PR TITLE
Make noop object initialization consistent

### DIFF
--- a/packages/nodejs/.changesets/improve-memory-usage-when-extension-is-not-initialized.md
+++ b/packages/nodejs/.changesets/improve-memory-usage-when-extension-is-not-initialized.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "change"
+---
+
+Improve memory usage when extension is not initialized. It will no longer initialize a new empty Tracer object when the extension is not loaded or AppSignal is not active.

--- a/packages/nodejs/src/client.ts
+++ b/packages/nodejs/src/client.ts
@@ -25,7 +25,7 @@ export class BaseClient implements Client {
   extension: Extension
   instrumentation: Instrumentation
 
-  #tracer: Tracer = new BaseTracer()
+  #tracer: Tracer
   #metrics: Metrics
 
   /**
@@ -52,8 +52,10 @@ export class BaseClient implements Client {
     if (this.isActive) {
       this.extension.start()
       this.#metrics = new BaseMetrics()
+      this.#tracer = new BaseTracer()
     } else {
       this.#metrics = new NoopMetrics()
+      this.#tracer = new NoopTracer()
     }
 
     this.instrumentation = new Instrumentation(this.tracer(), this.metrics())
@@ -110,10 +112,6 @@ export class BaseClient implements Client {
    * returns a `NoopTracer`, which will do nothing.
    */
   public tracer(): Tracer {
-    if (!this.isActive) {
-      return new NoopTracer()
-    }
-
     return this.#tracer
   }
 


### PR DESCRIPTION
Move the `NoopTracer` initialization to the initializer. That way it's
only initialized once and not every time the tracer is called.