### PR TITLE
Reuse client getter helper

### DIFF
--- a/packages/nodejs/src/client.ts
+++ b/packages/nodejs/src/client.ts
@@ -29,14 +29,17 @@ export class BaseClient implements Client {
   #metrics: Metrics
 
   /**
-   * Global accessors to Client and Config
+   * Global accessors for the AppSignal client
    */
   static get client(): Client {
     return global.__APPSIGNAL__
   }
 
+  /**
+   * Global accessors for the AppSignal Config
+   */
   static get config(): Configuration {
-    return global.__APPSIGNAL__?.config
+    return this.client.config
   }
 
   /**


### PR DESCRIPTION
Call the client getter from the config getter. That way we only have to
maintain the global field naming in one function.

Update docs to document both functions.

[skip changeset] because it's only an internal refactor users won't
notice.