### PR TITLE
Support arm64 host for tests

### DIFF
--- a/packages/nodejs/scripts/extension/report.test.js
+++ b/packages/nodejs/scripts/extension/report.test.js
@@ -106,7 +106,7 @@ describe("muslOverride", () => {
   })
 
   describe("with APPSIGNAL_BUILD_FOR_LINUX_ARM empty", () => {
-    test("returns linux-musl platform with musl_override === false", () => {
+    test("returns host's platform and linux_arm_override === false", () => {
       setPlatform("linux")
       setEnv("APPSIGNAL_BUILD_FOR_LINUX_ARM", "")
 
@@ -119,7 +119,7 @@ describe("muslOverride", () => {
   })
 
   describe("with APPSIGNAL_BUILD_FOR_LINUX_ARM=1", () => {
-    test("returns linux-musl platform with musl_override === true", () => {
+    test("returns arm64 linux platform and linux_arm_override === true", () => {
       setEnv("APPSIGNAL_BUILD_FOR_LINUX_ARM", "1")
 
       expect(createBuildReport({})).toMatchObject({
@@ -131,7 +131,7 @@ describe("muslOverride", () => {
   })
 
   describe("with APPSIGNAL_BUILD_FOR_LINUX_ARM=true", () => {
-    test("returns linux-musl platform with musl_override === true", () => {
+    test("returns arm64 linux platform with linux_arm_override === true", () => {
       setEnv("APPSIGNAL_BUILD_FOR_LINUX_ARM", "true")
 
       expect(createBuildReport({})).toMatchObject({

--- a/packages/nodejs/scripts/extension/report.test.js
+++ b/packages/nodejs/scripts/extension/report.test.js
@@ -111,7 +111,7 @@ describe("muslOverride", () => {
       setEnv("APPSIGNAL_BUILD_FOR_LINUX_ARM", "")
 
       expect(createBuildReport({})).toMatchObject({
-        architecture: "x64",
+        architecture: process.arch, // Defaults to the host architecture
         target: "linux",
         linux_arm_override: false
       })


### PR DESCRIPTION
## Update test names to match the actual assertions

The test names were copy-pasted and not updated afterward.

[skip changelog]

## Support arm64 host for tests

When I run the test suite on an arm64 host, support that architecture as
well in the test suite. I had to update on test that always assumed an
x64 architecture for the test suite.

[skip changeset]