### PR TITLE
Add tests for http outgoing integration

### DIFF
--- a/packages/nodejs/src/instrumentation/http/lifecycle/__tests__/outgoing.test.ts
+++ b/packages/nodejs/src/instrumentation/http/lifecycle/__tests__/outgoing.test.ts
@@ -61,8 +61,8 @@ describe("HTTP outgoing requests", () => {
       attributes: { "appsignal:category": "request.http", method: "GET" },
       error: null,
       name: "GET http://localhost",
-      sample_data: {}
+      sample_data: {},
+      closed: true
     })
-    expect(SpanTestRegistry.closedSpans).toContain(lastSpan)
   })
 })

--- a/packages/nodejs/src/instrumentation/http/lifecycle/__tests__/outgoing.test.ts
+++ b/packages/nodejs/src/instrumentation/http/lifecycle/__tests__/outgoing.test.ts
@@ -1,0 +1,68 @@
+import { SpanTestRegistry } from "../../../../../test/registry"
+import nock from "nock"
+import { HashMap } from "@appsignal/types"
+import { BaseClient as Client } from "../../../../client"
+import { BaseTracer as Tracer } from "../../../../tracer"
+import { instrument } from "../../http"
+import { ChildSpan } from "../../../../span"
+
+describe("HTTP outgoing requests", () => {
+  const name = "TEST APP"
+  const pushApiKey = "TEST_API_KEY"
+
+  let http: any
+  let client: Client
+  let tracer: Tracer
+
+  // enableMinutelyProbes is set to false so we don't leak timers
+  const DEFAULT_OPTS = {
+    active: true,
+    name,
+    pushApiKey,
+    enableMinutelyProbes: false
+  }
+
+  beforeEach(() => {
+    SpanTestRegistry.clear()
+    client = new Client({ ...DEFAULT_OPTS })
+    tracer = new Tracer()
+    http = require("http")
+    instrument(http, tracer).install()
+  })
+
+  async function performRequest() {
+    return new Promise<HashMap<any>>((resolve, reject) => {
+      const options = {
+        host: "example.com",
+        path: "/foo",
+        method: "GET"
+      }
+      const request = http.request(options, (stream: any) => {
+        stream.on("data", () => {}).on("end", resolve)
+      })
+      request.on("error", (error: Error) => {
+        reject({ error: error })
+      })
+      request.end()
+    })
+  }
+
+  it("creates a span for the outgoing HTTP request", async () => {
+    nock("http://example.com").get("/foo").reply(200, "response body")
+    const span = tracer.createSpan() // Create any root span
+    expect(SpanTestRegistry.spans).toHaveLength(1)
+
+    await performRequest()
+
+    expect(SpanTestRegistry.spans).toHaveLength(2)
+    const lastSpan = SpanTestRegistry.lastSpan()
+    expect(lastSpan).toEqual(expect.any(ChildSpan))
+    expect(lastSpan.toObject()).toMatchObject({
+      attributes: { "appsignal:category": "request.http", method: "GET" },
+      error: null,
+      name: "GET http://localhost",
+      sample_data: {}
+    })
+    expect(SpanTestRegistry.closedSpans).toContain(lastSpan)
+  })
+})

--- a/packages/nodejs/test/registry.ts
+++ b/packages/nodejs/test/registry.ts
@@ -1,0 +1,72 @@
+import { Span, SpanOptions, SpanContext } from "../src/interfaces"
+import { RootSpan, ChildSpan } from "../src/span"
+
+export class SpanTestRegistry {
+  static spans: Span[] = []
+  static closedSpans: Span[] = []
+
+  static addSpan(span: Span) {
+    this.spans.push(span)
+  }
+
+  static addClosedSpan(span: Span) {
+    this.closedSpans.push(span)
+  }
+
+  static lastSpan(): Span {
+    const length = this.spans.length
+    return this.spans[length - 1]
+  }
+
+  static clear() {
+    this.spans = []
+    this.closedSpans = []
+  }
+}
+
+jest.mock("../src/span", () => {
+  const originalModule = jest.requireActual("../src/span")
+
+  // Wrapper classes that registers each created Span classes on the
+  // SpanTestRegistry so we can access the created spans later in the test.
+  class TrackedRootSpan extends originalModule.RootSpan {
+    constructor(spanOptions: Partial<SpanOptions> = {}) {
+      super(spanOptions)
+      SpanTestRegistry.addSpan((this as unknown) as Span)
+    }
+
+    // Mock out the `close` functions so that `Span.toObject` will return the
+    // Span object from the extension. If `close` is called it will return an
+    // empty object.
+    // A list of closed Spans can be accessed with
+    // `SpanTestRegistry.closedSpans`
+    close() {
+      SpanTestRegistry.addClosedSpan((this as unknown) as Span)
+    }
+  }
+
+  class TrackedChildSpan extends originalModule.ChildSpan {
+    constructor(
+      spanOrContext: Span | SpanContext,
+      spanOptions: Partial<SpanOptions> = {}
+    ) {
+      super(spanOrContext, spanOptions)
+      SpanTestRegistry.addSpan((this as unknown) as Span)
+    }
+
+    // Mock out the `close` functions so that `Span.toObject` will return the
+    // Span object from the extension. If `close` is called it will return an
+    // empty object.
+    // A list of closed Spans can be accessed with
+    // `SpanTestRegistry.closedSpans`
+    close() {
+      SpanTestRegistry.addClosedSpan((this as unknown) as Span)
+    }
+  }
+
+  return {
+    ...originalModule,
+    RootSpan: TrackedRootSpan,
+    ChildSpan: TrackedChildSpan
+  }
+})


### PR DESCRIPTION
Add a TestRegistry (name suggestions welcome!) to store Spans that are
created during the test. This registry will be accessible after the test
to fetch all created spans. It also mocks out the `Span.close` function
so we can call `toObject` on them later, and the Extension doesn't
return an empty String for the Span.

It currently only tests `ChildSpan`s, but this can be updated the same
way for RootSpans.

## About this implementation

This implementation is much the same as the Ruby gem and does not rely
on mock objects (`MockTracer`, `MockSpan`) that may or may not mimic
their real world behavior.

To avoid all the hassle of this Span creation tracking, because this was
not easy to figure out in Node.js, I'm thinking adding a test mode to
the extension where we can just ask which spans it created during the
test. That way we also only have to implement this once for all
integrations.
https://github.com/appsignal/appsignal-agent/issues/744

[skip changeset]