### PR TITLE
Ignore script test files in published package

### DIFF
--- a/packages/nodejs/.changesets/do-not-ship-test-files.md
+++ b/packages/nodejs/.changesets/do-not-ship-test-files.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "remove"
+---
+
+Do not ship the extension install script test files in the published package. Reduces the package size a tiny bit.

--- a/packages/nodejs/.npmignore
+++ b/packages/nodejs/.npmignore
@@ -1,6 +1,7 @@
 *
 !/dist/**/*
 !/scripts/**/*
+scripts/**/*.test.js
 !/ext/appsignal_extension.cpp
 !/cert/**/*
 !binding.gyp

--- a/packages/nodejs/scripts/extension/__tests__/extension.failure.test.js
+++ b/packages/nodejs/scripts/extension/__tests__/extension.failure.test.js
@@ -1,6 +1,6 @@
 const fs = require("fs")
 const path = require("path")
-const { reportPath } = require("./report")
+const { reportPath } = require("../report")
 
 function hasExtensionFailure() {
   if (process.env._TEST_APPSIGNAL_EXTENSION_FAILURE !== "true") {

--- a/packages/nodejs/scripts/extension/__tests__/extension.test.js
+++ b/packages/nodejs/scripts/extension/__tests__/extension.test.js
@@ -1,9 +1,9 @@
 const fs = require("fs")
-const { reportPath } = require("./report")
-const { downloadFromMirror } = require("./extension")
+const { reportPath } = require("../report")
+const { downloadFromMirror } = require("../extension")
 const nock = require("nock")
 const { Writable, EventEmitter } = require("stream")
-const { AGENT_VERSION } = require("./support/constants")
+const { AGENT_VERSION } = require("../support/constants")
 
 describe("Extension install success", () => {
   test("writes success result to diagnose installation report", () => {

--- a/packages/nodejs/scripts/extension/__tests__/report.test.js
+++ b/packages/nodejs/scripts/extension/__tests__/report.test.js
@@ -2,9 +2,9 @@ const originalProcess = process
 const originalProcessEnv = process.env
 const mockHelpers = { hasMusl: jest.fn() }
 
-jest.doMock("./support/helpers", () => mockHelpers)
+jest.doMock("../support/helpers", () => mockHelpers)
 
-const { createBuildReport } = require("./report")
+const { createBuildReport } = require("../report")
 
 describe("muslOverride", () => {
   beforeEach(() => {


### PR DESCRIPTION
## Move extension install script files to `__tests__`

Move the extension install script files to the `__tests__` sub directory
like we do for all our other test files. This is only a rename, no other
changes were make.

## Ignore script test files in published package

When we publish a new version of the `@appsignal/nodejs` package the
test files for the extension install script were also included.
Some time ago there were no tests for this so it wasn't an issue, but
now that we have tests we need to explicitly ignore them in `.npmignore`
to not package them in the new published versions.

The output of `npm pack` before this change:

```
822B    scripts/extension/__tests__/extension.failure.test.js
3.9kB   scripts/extension/__tests__/extension.test.js
3.8kB   scripts/extension/__tests__/report.test.js
7.1kB   scripts/extension/extension.js
2.0kB   scripts/extension/report.js
2.5kB   scripts/extension/support/constants.js
1.3kB   scripts/extension/support/helpers.js
```

The output of `npm pack` after this change:

```
7.1kB   scripts/extension/extension.js
2.0kB   scripts/extension/report.js
2.5kB   scripts/extension/support/constants.js
1.3kB   scripts/extension/support/helpers.js
```

Fixes #596
