### PR TITLE
Remove experimental module

### DIFF
--- a/packages/nodejs/.changesets/remove-unused-experimental-module.md
+++ b/packages/nodejs/.changesets/remove-unused-experimental-module.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "remove"
+---
+
+Remove the unused experimental module.

--- a/packages/nodejs/src/experimental.ts
+++ b/packages/nodejs/src/experimental.ts
@@ -1,6 +1,0 @@
-/**
- * Experimental add-ons and overrides. Use with caution!
- *
- * @constant
- */
-export const EXPERIMENTAL = {}

--- a/packages/nodejs/src/index.ts
+++ b/packages/nodejs/src/index.ts
@@ -7,4 +7,3 @@
 
 export { BaseClient as Appsignal } from "./client"
 export * from "./interfaces"
-export { EXPERIMENTAL } from "./experimental"


### PR DESCRIPTION
The experimental module is unused in the `@appsignal/nodejs` package.
Let's remove it.

Closes #602