### PR TITLE
Update `@appsignal/types` dependency to 3.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "packages/*"
       ],
       "devDependencies": {
-        "@appsignal/types": "^2.1.5",
+        "@appsignal/types": "^3.0.0",
         "@types/jest": "^26.0.19",
         "husky": "^4.3.6",
         "jest": "^26.6.3",
@@ -74,6 +74,11 @@
         "tslib": "^2.0.3"
       }
     },
+    "node_modules/@appsignal/core/node_modules/@appsignal/types": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@appsignal/types/-/types-2.1.7.tgz",
+      "integrity": "sha512-a1xs27N7KVMxjdiIgnCsPZP95mjsZym82bCsYzir8C+kh1dpa72uY3e2uO7AK2amKLWaQK34uQQS4ouVo1PIbA=="
+    },
     "node_modules/@appsignal/core/node_modules/tslib": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
@@ -96,9 +101,9 @@
       "link": true
     },
     "node_modules/@appsignal/types": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/@appsignal/types/-/types-2.1.5.tgz",
-      "integrity": "sha512-LtxfqACzS10PYxAqe2YgT9k/pPFyzAwyXvi48QddWyBj7ROleAXrEKJjjgqxOYszIGCm14cbCLSDmEDvIVnDbw=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@appsignal/types/-/types-3.0.0.tgz",
+      "integrity": "sha512-L0OAKaro7209Du39UF2ZWU8CzUJxeeKaW6Zyu2FA2SGdW3HK0PoJxY7A8R52KdZiXzMlCAlrOjvoDvT/ct0RIg=="
     },
     "node_modules/@babel/code-frame": {
       "version": "7.12.11",
@@ -9266,7 +9271,7 @@
       "license": "MIT",
       "dependencies": {
         "@appsignal/nodejs": "=2.3.1",
-        "@appsignal/types": "^2.1.5",
+        "@appsignal/types": "^3.0.0",
         "shimmer": "^1.2.1",
         "tslib": "^2.0.3"
       },
@@ -9312,7 +9317,7 @@
       "license": "MIT",
       "dependencies": {
         "@appsignal/core": "^1.1.4",
-        "@appsignal/types": "^2.1.5",
+        "@appsignal/types": "^3.0.0",
         "node-addon-api": "^3.1.0",
         "node-gyp": "^7.1.2",
         "require-in-the-middle": "^5.1.0",
@@ -9433,6 +9438,11 @@
         "tslib": "^2.0.3"
       },
       "dependencies": {
+        "@appsignal/types": {
+          "version": "2.1.7",
+          "resolved": "https://registry.npmjs.org/@appsignal/types/-/types-2.1.7.tgz",
+          "integrity": "sha512-a1xs27N7KVMxjdiIgnCsPZP95mjsZym82bCsYzir8C+kh1dpa72uY3e2uO7AK2amKLWaQK34uQQS4ouVo1PIbA=="
+        },
         "tslib": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
@@ -9460,7 +9470,7 @@
       "version": "file:packages/koa",
       "requires": {
         "@appsignal/nodejs": "=2.3.1",
-        "@appsignal/types": "^2.1.5",
+        "@appsignal/types": "^3.0.0",
         "@types/koa": "*",
         "@types/koa__router": "*",
         "@types/shimmer": "*",
@@ -9495,7 +9505,7 @@
       "version": "file:packages/nodejs",
       "requires": {
         "@appsignal/core": "^1.1.4",
-        "@appsignal/types": "^2.1.5",
+        "@appsignal/types": "^3.0.0",
         "@types/pg": "*",
         "@types/redis": "*",
         "@types/semver": "*",
@@ -9526,9 +9536,9 @@
       }
     },
     "@appsignal/types": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/@appsignal/types/-/types-2.1.5.tgz",
-      "integrity": "sha512-LtxfqACzS10PYxAqe2YgT9k/pPFyzAwyXvi48QddWyBj7ROleAXrEKJjjgqxOYszIGCm14cbCLSDmEDvIVnDbw=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@appsignal/types/-/types-3.0.0.tgz",
+      "integrity": "sha512-L0OAKaro7209Du39UF2ZWU8CzUJxeeKaW6Zyu2FA2SGdW3HK0PoJxY7A8R52KdZiXzMlCAlrOjvoDvT/ct0RIg=="
     },
     "@babel/code-frame": {
       "version": "7.12.11",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "packages/*"
   ],
   "devDependencies": {
-    "@appsignal/types": "^2.1.5",
+    "@appsignal/types": "^3.0.0",
     "@types/jest": "^26.0.19",
     "husky": "^4.3.6",
     "jest": "^26.6.3",

--- a/packages/koa/.changesets/update-appsignal-types-dependency-to-3-0-0-.md
+++ b/packages/koa/.changesets/update-appsignal-types-dependency-to-3-0-0-.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "change"
+---
+
+Update @appsignal/types dependency to 3.0.0.

--- a/packages/koa/package.json
+++ b/packages/koa/package.json
@@ -10,7 +10,7 @@
     "directory": "packages/koa"
   },
   "dependencies": {
-    "@appsignal/types": "^2.1.5",
+    "@appsignal/types": "^3.0.0",
     "@appsignal/nodejs": "=2.3.1",
     "shimmer": "^1.2.1",
     "tslib": "^2.0.3"

--- a/packages/nodejs/.changesets/update-appsignal-types-dependency-to-3-0-0-.md
+++ b/packages/nodejs/.changesets/update-appsignal-types-dependency-to-3-0-0-.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "change"
+---
+
+Update @appsignal/types dependency to 3.0.0.

--- a/packages/nodejs/package.json
+++ b/packages/nodejs/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@appsignal/core": "^1.1.4",
-    "@appsignal/types": "^2.1.5",
+    "@appsignal/types": "^3.0.0",
     "node-addon-api": "^3.1.0",
     "node-gyp": "^7.1.2",
     "require-in-the-middle": "^5.1.0",


### PR DESCRIPTION
Update the types package to the version without Node.js types. They're
all part of the Node.js package itself now since PR #451.

This avoids confusion about the availability of Node.js types in the
types package.

Fixes #590