### PR TITLE
Restore, reset and clear mocks between tests

### DIFF
--- a/packages/nodejs/jest.config.js
+++ b/packages/nodejs/jest.config.js
@@ -4,5 +4,8 @@ module.exports = {
   roots: ["<rootDir>/src", "<rootDir>/scripts"],
   transform: {
     "^.+\\.tsx?$": "ts-jest"
-  }
+  },
+  restoreMocks: true,
+  resetMocks: true,
+  clearMocks: true
 }

--- a/packages/nodejs/scripts/extension/__tests__/extension.test.js
+++ b/packages/nodejs/scripts/extension/__tests__/extension.test.js
@@ -22,10 +22,6 @@ describe(".downloadFromMirror", () => {
     nock.disableNetConnect()
   })
 
-  afterEach(() => {
-    jest.restoreAllMocks()
-  })
-
   afterAll(() => {
     nock.restore()
   })

--- a/packages/nodejs/src/__tests__/bootstrap.test.ts
+++ b/packages/nodejs/src/__tests__/bootstrap.test.ts
@@ -8,10 +8,6 @@ describe("Bootstrap", () => {
       load: jest.fn()
     } as unknown) as Instrumentation
 
-    beforeEach(() => {
-      jest.clearAllMocks()
-    })
-
     it("bootstraps the core instumentation plugins", () => {
       initCorePlugins(mock, { ignoreInstrumentation: undefined })
       expect(mock.load).toHaveBeenCalledTimes(4)
@@ -29,15 +25,14 @@ describe("Bootstrap", () => {
 
   describe("Probes", () => {
     const registerMock = jest.fn()
-
-    const mock = ({
-      probes: jest.fn().mockImplementation(() => ({
-        register: registerMock
-      }))
-    } as unknown) as Metrics
+    let mock: Metrics
 
     beforeEach(() => {
-      jest.clearAllMocks()
+      mock = ({
+        probes: jest.fn().mockImplementation(() => ({
+          register: registerMock
+        }))
+      } as unknown) as Metrics
     })
 
     it("bootstraps the core probes", () => {

--- a/packages/nodejs/src/__tests__/client.test.ts
+++ b/packages/nodejs/src/__tests__/client.test.ts
@@ -20,7 +20,6 @@ describe("BaseClient", () => {
 
   afterEach(() => {
     client.stop()
-    jest.restoreAllMocks()
   })
 
   it("starts the client", () => {

--- a/packages/nodejs/src/__tests__/config.test.ts
+++ b/packages/nodejs/src/__tests__/config.test.ts
@@ -59,7 +59,6 @@ describe("Configuration", () => {
 
   beforeAll(() => {
     initialEnv = Object.assign({}, process.env)
-    jest.clearAllMocks()
   })
 
   afterAll(() => {
@@ -292,6 +291,8 @@ describe("Configuration", () => {
 
     describe("with config options set to non-default values", () => {
       beforeEach(() => {
+        jest.spyOn(fs, "accessSync").mockImplementation(() => {})
+
         new Configuration({
           name,
           active: true,

--- a/packages/nodejs/src/__tests__/diagnose.test.ts
+++ b/packages/nodejs/src/__tests__/diagnose.test.ts
@@ -5,11 +5,9 @@ import { VERSION, AGENT_VERSION } from "../version"
 describe("DiagnoseTool", () => {
   let tool: DiagnoseTool
 
-  const fsAccessSpy = jest.spyOn(fs, "accessSync").mockImplementation(() => {})
-
   beforeEach(() => {
     tool = new DiagnoseTool()
-    jest.clearAllMocks()
+    jest.spyOn(fs, "accessSync").mockImplementation(() => {})
   })
 
   it("generates a configuration", async () => {

--- a/packages/nodejs/src/__tests__/span.test.ts
+++ b/packages/nodejs/src/__tests__/span.test.ts
@@ -226,10 +226,6 @@ describe(".setSampleData()", () => {
   const DEFAULT_OPTS = { name, pushApiKey, enableMinutelyProbes: false }
   const sampleData = { foo: "bar" }
 
-  beforeEach(() => {
-    jest.clearAllMocks()
-  })
-
   it("calls the extension with the desired params data if sendParams is active", () => {
     new BaseClient({ ...DEFAULT_OPTS })
 

--- a/packages/nodejs/src/__tests__/transmitter.test.ts
+++ b/packages/nodejs/src/__tests__/transmitter.test.ts
@@ -21,8 +21,6 @@ describe("Transmitter", () => {
   })
 
   afterEach(() => {
-    jest.restoreAllMocks()
-
     process.env = originalEnv
   })
 


### PR DESCRIPTION
To avoid accidentally reusing mocks between tests, set properties `restoreMocks`, `resetMocks` and `clearMocks` to `true` in the Jest configuration file.

Remove usages of `jest.clearAllMocks`, `jest.resetAllMocks` and `jest.restoreAllMocks` sprinkled across the tests.

Following up on [this Slack conversation that I forgot to create an issue for](https://appsignal.slack.com/archives/CNPP953E2/p1643963180388439).

[skip changeset]