### PR TITLE
Test against latest Next.js versions 12 and 11

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -154,6 +154,10 @@ blocks:
       commands:
       - script/install_test_example_packages nextjs next@latest react@latest react-dom@latest
       - script/test_package_integration nextjs
+    - name: "@appsignal/nextjs - next.js@12.1.0 - integrations"
+      commands:
+      - script/install_test_example_packages nextjs next@12.1.0 react@17.0.2 react-dom@17.0.2
+      - script/test_package_integration nextjs
     - name: "@appsignal/nextjs - next.js@11.1.4 - integrations"
       commands:
       - script/install_test_example_packages nextjs next@11.1.4 react@17.0.2 react-dom@17.0.2
@@ -247,6 +251,10 @@ blocks:
       commands:
       - script/install_test_example_packages nextjs next@latest react@latest react-dom@latest
       - script/test_package_integration nextjs
+    - name: "@appsignal/nextjs - next.js@12.1.0 - integrations"
+      commands:
+      - script/install_test_example_packages nextjs next@12.1.0 react@17.0.2 react-dom@17.0.2
+      - script/test_package_integration nextjs
     - name: "@appsignal/nextjs - next.js@11.1.4 - integrations"
       commands:
       - script/install_test_example_packages nextjs next@11.1.4 react@17.0.2 react-dom@17.0.2
@@ -338,6 +346,10 @@ blocks:
       commands:
       - script/install_test_example_packages nextjs next@latest react@latest react-dom@latest
       - script/test_package_integration nextjs
+    - name: "@appsignal/nextjs - next.js@12.1.0 - integrations"
+      commands:
+      - script/install_test_example_packages nextjs next@12.1.0 react@17.0.2 react-dom@17.0.2
+      - script/test_package_integration nextjs
     - name: "@appsignal/nextjs - next.js@11.1.4 - integrations"
       commands:
       - script/install_test_example_packages nextjs next@11.1.4 react@17.0.2 react-dom@17.0.2
@@ -428,6 +440,10 @@ blocks:
     - name: "@appsignal/nextjs - next.js@latest - integrations"
       commands:
       - script/install_test_example_packages nextjs next@latest react@latest react-dom@latest
+      - script/test_package_integration nextjs
+    - name: "@appsignal/nextjs - next.js@12.1.0 - integrations"
+      commands:
+      - script/install_test_example_packages nextjs next@12.1.0 react@17.0.2 react-dom@17.0.2
       - script/test_package_integration nextjs
     - name: "@appsignal/nextjs - next.js@11.1.4 - integrations"
       commands:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -154,9 +154,9 @@ blocks:
       commands:
       - script/install_test_example_packages nextjs next@latest react@latest react-dom@latest
       - script/test_package_integration nextjs
-    - name: "@appsignal/nextjs - next.js@11.0.1 - integrations"
+    - name: "@appsignal/nextjs - next.js@11.1.4 - integrations"
       commands:
-      - script/install_test_example_packages nextjs next@11.0.1 react@17.0.2 react-dom@17.0.2
+      - script/install_test_example_packages nextjs next@11.1.4 react@17.0.2 react-dom@17.0.2
       - script/test_package_integration nextjs
     - name: "@appsignal/nextjs - next.js@10.2.3 - integrations"
       commands:
@@ -247,9 +247,9 @@ blocks:
       commands:
       - script/install_test_example_packages nextjs next@latest react@latest react-dom@latest
       - script/test_package_integration nextjs
-    - name: "@appsignal/nextjs - next.js@11.0.1 - integrations"
+    - name: "@appsignal/nextjs - next.js@11.1.4 - integrations"
       commands:
-      - script/install_test_example_packages nextjs next@11.0.1 react@17.0.2 react-dom@17.0.2
+      - script/install_test_example_packages nextjs next@11.1.4 react@17.0.2 react-dom@17.0.2
       - script/test_package_integration nextjs
     - name: "@appsignal/nextjs - next.js@10.2.3 - integrations"
       commands:
@@ -338,9 +338,9 @@ blocks:
       commands:
       - script/install_test_example_packages nextjs next@latest react@latest react-dom@latest
       - script/test_package_integration nextjs
-    - name: "@appsignal/nextjs - next.js@11.0.1 - integrations"
+    - name: "@appsignal/nextjs - next.js@11.1.4 - integrations"
       commands:
-      - script/install_test_example_packages nextjs next@11.0.1 react@17.0.2 react-dom@17.0.2
+      - script/install_test_example_packages nextjs next@11.1.4 react@17.0.2 react-dom@17.0.2
       - script/test_package_integration nextjs
     - name: "@appsignal/nextjs - next.js@10.2.3 - integrations"
       commands:
@@ -429,9 +429,9 @@ blocks:
       commands:
       - script/install_test_example_packages nextjs next@latest react@latest react-dom@latest
       - script/test_package_integration nextjs
-    - name: "@appsignal/nextjs - next.js@11.0.1 - integrations"
+    - name: "@appsignal/nextjs - next.js@11.1.4 - integrations"
       commands:
-      - script/install_test_example_packages nextjs next@11.0.1 react@17.0.2 react-dom@17.0.2
+      - script/install_test_example_packages nextjs next@11.1.4 react@17.0.2 react-dom@17.0.2
       - script/test_package_integration nextjs
     - name: "@appsignal/nextjs - next.js@10.2.3 - integrations"
       commands:

--- a/build_matrix.yml
+++ b/build_matrix.yml
@@ -154,6 +154,11 @@ matrix:
             next: "latest"
             react: "latest"
             react-dom: "latest"
+        - name: "next.js@12.1.0"
+          packages:
+            next: "12.1.0"
+            react: "17.0.2"
+            react-dom: "17.0.2"
         - name: "next.js@11.1.4"
           packages:
             next: "11.1.4"

--- a/build_matrix.yml
+++ b/build_matrix.yml
@@ -154,9 +154,9 @@ matrix:
             next: "latest"
             react: "latest"
             react-dom: "latest"
-        - name: "next.js@11.0.1"
+        - name: "next.js@11.1.4"
           packages:
-            next: "11.0.1"
+            next: "11.1.4"
             react: "17.0.2"
             react-dom: "17.0.2"
         - name: "next.js@10.2.3"


### PR DESCRIPTION
## Bump to latest Next.js 11 release

Update the CI to test against the latest version 11 release.

## Test against Next.js version 12

Next.js has released 12.1. We didn't test against version 12 yet, so
I've added it to the CI build.

I can't find the Next.js support policy, which versions they continue to
support. I can only see that version 12 and 11 still have tags in npm,
so that may indicate they only support those two versions. Which means
we could remove version 10 from the build.
