### PR TITLE
Allow nested values in setSampleData

### DIFF
--- a/packages/express/src/middleware/index.ts
+++ b/packages/express/src/middleware/index.ts
@@ -45,11 +45,6 @@ export function expressMiddleware(appsignal: Client): RequestHandler {
           span.setName(`${method} ${baseUrl}${req.route.path}`)
         }
 
-        // defeated the type checker here because i'm pretty sure the error
-        // `tsc` returns is actually a parse error
-        // @TODO: keep an eye on this
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
         span.setSampleData("params", { ...params, ...query })
         span.setSampleData("environment", filteredHeaders)
 

--- a/packages/nodejs/.changesets/allow-nested-values-in-span-setsampledata.md
+++ b/packages/nodejs/.changesets/allow-nested-values-in-span-setsampledata.md
@@ -1,0 +1,9 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Allow nested values in `Span.setSampleData`. This change also allows
+values other than strings, integers and booleans to be passed as values
+within the sample data objects. Note that not all sample data keys allow
+nested values to be passed.

--- a/packages/nodejs/src/interfaces/span.ts
+++ b/packages/nodejs/src/interfaces/span.ts
@@ -1,4 +1,4 @@
-import { HashMap, HashMapValue } from "@appsignal/types"
+import { HashMap } from "@appsignal/types"
 
 /**
  * The state of a `Span` at initialization time.
@@ -87,16 +87,7 @@ export interface Span {
   /**
    * Sets a data collection as sample data on the current `Span`.
    */
-  setSampleData(
-    key: string,
-    data:
-      | Array<
-          HashMapValue | Array<HashMapValue> | HashMap<HashMapValue> | undefined
-        >
-      | HashMap<
-          HashMapValue | Array<HashMapValue> | HashMap<HashMapValue> | undefined
-        >
-  ): this
+  setSampleData(key: string, data: Array<any> | HashMap<any>): this
 
   /**
    * Adds sanitized SQL data as a string to a Span.

--- a/packages/nodejs/src/noops/span.ts
+++ b/packages/nodejs/src/noops/span.ts
@@ -41,10 +41,7 @@ export class NoopSpan implements Span {
     return this
   }
 
-  public setSampleData(
-    _key: string,
-    _data: Array<string | number | boolean> | HashMap<string | number | boolean>
-  ): this {
+  public setSampleData(_key: string, _data: Array<any> | HashMap<any>): this {
     return this
   }
 

--- a/packages/nodejs/src/span.ts
+++ b/packages/nodejs/src/span.ts
@@ -1,4 +1,4 @@
-import { HashMap, HashMapValue } from "@appsignal/types"
+import { HashMap } from "@appsignal/types"
 import { Span, SpanOptions, SpanContext, SpanData } from "./interfaces"
 
 import { span } from "./extension_wrapper"
@@ -114,16 +114,7 @@ export class BaseSpan implements Span {
   /**
    * Sets a data collection as sample data on the current `Span`.
    */
-  public setSampleData(
-    key: string,
-    data:
-      | Array<
-          HashMapValue | Array<HashMapValue> | HashMap<HashMapValue> | undefined
-        >
-      | HashMap<
-          HashMapValue | Array<HashMapValue> | HashMap<HashMapValue> | undefined
-        >
-  ): this {
+  public setSampleData(key: string, data: Array<any> | HashMap<any>): this {
     const clientConfig = BaseClient.config.data
     if (!key || !data) return this
     if (key == "params" && !clientConfig.sendParams) return this


### PR DESCRIPTION
Fixes #624.

Fix the signature of setSampleData so that it accepts any array or object, instead of only arrays or objects with up to two levels of nesting. This allows the user to pass arbitrary objects to sample data properties that accept them, such as `custom_data`.

Note that not all sample data properties accept nested values.

### Notes

I tried to implement only allowing arbitrary nesting for some keys, while enforcing one level of nesting for other keys in the signature, [as discussed in the issue](https://github.com/appsignal/appsignal-nodejs/issues/624#issuecomment-1060437678). In principle, it is possible to do so using function signature overloads:

```typescript
type SampleDataValue = string | number | bigint | boolean | null | undefined

type FlatSampleData = {
  [key: string]: SampleDataValue
} | SampleDataValue[]

type NestedSampleData = {
  [key: string]: SampleDataValue | NestedSampleData
} | (SampleDataValue | NestedSampleData)[]

interface Span {
  public setSampleData(
    key: "environment" | "tags",
    data: FlatSampleData
  ): this
  
  public setSampleData(
    key: "params" | "session_data" | "custom_data",
    data: NestedSampleData
  ): this
}
```

There's a few reasons why I opted for a simpler function signature:

- It is not possible to specify that "non-plain objects" should also be allowed in the `FlatSampleData`. Given our current implementation of `Data.generate`, passing a non-plain object to it will call `.toString` on it. So you should be able to pass those to `FlatSampleData`, but it's not possible, as far as I know, to discriminate between these kinds of objects at the type signature level.
- [Overloads are tricky!](https://www.typescriptlang.org/docs/handbook/2/functions.html#writing-good-overloads) Specifically, each invocation of an overloaded function can only represent a call to one of the possible overloads. That is, you couldn't do something like `{"tags": {}, "params": {}}.entries().forEach(([key, data]) => span.setSampleData(key, data))`, because each invocation inside the loop corresponds to a different overload. The TypeScript handbook itself says: "Always prefer parameters with union types instead of overloads when possible".
- [We have a pending task to replace `setSampleData(key, data)` with functions of the form `setKey(data)`.](https://github.com/appsignal/integration-guide/issues/80) That seems like a much less surprising way to enforce different signatures for different sample data values.