### PR TITLE
Use NPM 7 with Node 14 or lower

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -274,6 +274,7 @@ blocks:
       value: '14'
     prologue:
       commands:
+      - npm i -g npm@7
       - cache restore
       - mono bootstrap --ci
       - cache store
@@ -295,6 +296,7 @@ blocks:
       value: 'false'
     prologue:
       commands:
+      - npm i -g npm@7
       - cache restore
       - cache restore $_PACKAGES_CACHE-packages-$SEMAPHORE_GIT_SHA-v$NODE_VERSION
       - mono bootstrap --ci
@@ -370,6 +372,7 @@ blocks:
       value: '12'
     prologue:
       commands:
+      - npm i -g npm@7
       - cache restore
       - mono bootstrap --ci
       - cache store
@@ -391,6 +394,7 @@ blocks:
       value: 'false'
     prologue:
       commands:
+      - npm i -g npm@7
       - cache restore
       - cache restore $_PACKAGES_CACHE-packages-$SEMAPHORE_GIT_SHA-v$NODE_VERSION
       - mono bootstrap --ci

--- a/build_matrix.yml
+++ b/build_matrix.yml
@@ -87,7 +87,13 @@ matrix:
     - nodejs: "16"
       setup: *gcc8
     - nodejs: "14"
+      setup: &npm7
+        # Use NPM version 7 to work around a bug when using NPM 8 and Node 14
+        # or lower, where commands that are ran at the root of the workspace
+        # do not trigger lifecycle hooks for the workspace packages.
+        - npm i -g npm@7
     - nodejs: "12"
+      setup: *npm7
   packages:
     - package: "@appsignal/nodejs"
       path: "packages/nodejs"


### PR DESCRIPTION
To work around a bug where NPM 8 does not trigger lifecycle hooks for workspace packages when a command is ran from the workspace root, use NPM 7 for Node 14 and Node 12.