### PR TITLE
Delete job specific cache in CI jobs

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -87,6 +87,7 @@ blocks:
     - name: Build
       commands:
       - mono build
+      - cache delete $_PACKAGES_CACHE-packages-$SEMAPHORE_GIT_SHA-v$NODE_VERSION
       - cache store $_PACKAGES_CACHE-packages-$SEMAPHORE_GIT_SHA-v$NODE_VERSION packages
       - cat packages/nodejs/ext/install.report
 - name: Node.js 17 - Tests
@@ -188,6 +189,7 @@ blocks:
     - name: Build
       commands:
       - mono build
+      - cache delete $_PACKAGES_CACHE-packages-$SEMAPHORE_GIT_SHA-v$NODE_VERSION
       - cache store $_PACKAGES_CACHE-packages-$SEMAPHORE_GIT_SHA-v$NODE_VERSION packages
       - cat packages/nodejs/ext/install.report
 - name: Node.js 16 - Tests
@@ -287,6 +289,7 @@ blocks:
     - name: Build
       commands:
       - mono build
+      - cache delete $_PACKAGES_CACHE-packages-$SEMAPHORE_GIT_SHA-v$NODE_VERSION
       - cache store $_PACKAGES_CACHE-packages-$SEMAPHORE_GIT_SHA-v$NODE_VERSION packages
       - cat packages/nodejs/ext/install.report
 - name: Node.js 14 - Tests
@@ -385,6 +388,7 @@ blocks:
     - name: Build
       commands:
       - mono build
+      - cache delete $_PACKAGES_CACHE-packages-$SEMAPHORE_GIT_SHA-v$NODE_VERSION
       - cache store $_PACKAGES_CACHE-packages-$SEMAPHORE_GIT_SHA-v$NODE_VERSION packages
       - cat packages/nodejs/ext/install.report
 - name: Node.js 12 - Tests

--- a/Rakefile
+++ b/Rakefile
@@ -40,6 +40,7 @@ namespace :build_matrix do
                 "name" => "Build",
                 "commands" => [
                   "mono build",
+                  "cache delete $_PACKAGES_CACHE-packages-$SEMAPHORE_GIT_SHA-v$NODE_VERSION",
                   "cache store $_PACKAGES_CACHE-packages-$SEMAPHORE_GIT_SHA-v$NODE_VERSION " \
                     "packages",
                   "cat packages/nodejs/ext/install.report"


### PR DESCRIPTION
To move build artifacts around from job to job in the same workflow,
make sure it uses the artifacts generated by this workflow's run.

Caches are not overwritten if it already exists. Make sure to always
remove the cache if it exists. Otherwise a retry of a build may to
continue to use the cache from the first time the workflow was run,
which is not what we want and may introduce silent bugs.

I did not choose to use artifacts here as artifacts may incur an
addition charge later on. By deleting the cache we get the same
behavior.

Closes #631
[skip changeset]