### PR TITLE
Follow redirects on transmitter requests

### DIFF
--- a/packages/nodejs/.changesets/follow-redirects-when-downloading-the-appsignal-agent.md
+++ b/packages/nodejs/.changesets/follow-redirects-when-downloading-the-appsignal-agent.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Follow redirects when downloading the AppSignal agent. This fixes an issue where the redirect page would be downloaded instead of the agent, causing the agent installation to fail.


### PR DESCRIPTION
Implement following redirects for `Transmitter` requests. As per the HTTP spec and common browser behavior, redirects using status codes 301, 302 and 303 have the method changed to `GET`, and redirection loops are detected.

Fixes #505.