### PR TITLE
Fix Apollo Server error reporting

### DIFF
--- a/packages/apollo-server/.changesets/fix-error-reporting.md
+++ b/packages/apollo-server/.changesets/fix-error-reporting.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Fix error reporting. Due to a bug in the scope management logic, errors emitted by Apollo Server were not being reported by the integration.

--- a/packages/apollo-server/test/example/index.js
+++ b/packages/apollo-server/test/example/index.js
@@ -1,6 +1,6 @@
 const { Appsignal } = require("../../../nodejs")
 
-new Appsignal({
+const appsignal = new Appsignal({
   active: true,
   name: "<YOUR APPLICATION NAME>",
   pushApiKey: "<YOUR API KEY>"
@@ -47,9 +47,13 @@ const resolvers = {
   }
 }
 
+const { createApolloPlugin } = require("../../../apollo-server")
+
+const plugins = [createApolloPlugin(appsignal)]
+
 // The ApolloServer constructor requires two parameters: your schema
 // definition and your set of resolvers.
-const server = new ApolloServer({ typeDefs, resolvers })
+const server = new ApolloServer({ typeDefs, resolvers, plugins })
 
 // The `listen` method launches a web server.
 server.listen({ port: 4010 }).then(({ url }) => {

--- a/packages/apollo-server/test/spec/integration_spec.rb
+++ b/packages/apollo-server/test/spec/integration_spec.rb
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
 
 require "net/http"
+require "json"
 
 EXAMPLE_APP_DIR = File.expand_path(File.join("..", "example"), __dir__)
 
-RSpec.describe "Next.js" do
+RSpec.describe "Apollo Server" do
   before(:context) do
     @app = AppRunner.new("npm run start", EXAMPLE_APP_DIR)
     @app.run
@@ -13,22 +14,112 @@ RSpec.describe "Next.js" do
   after(:context) { @app.stop }
   after { @app.cleanup }
 
-  describe "POST /" do
-    before do
-      uri = URI("http://localhost:4010/")
-      http = Net::HTTP.new(uri.host, uri.port)
-      request = Net::HTTP::Post.new(uri.request_uri)
-      request["Content-Type"] = "application/json"
-      request.body = '{"query":"query { __typename }"}'
-      @response = http.request(request).body
-    end
+  def request_query(query)
+    uri = URI("http://localhost:4010/")
+    http = Net::HTTP.new(uri.host, uri.port)
+    request = Net::HTTP::Post.new(uri.request_uri)
+    request["Content-Type"] = "application/json"
+    request.body = { "query" => query }.to_json
+    http.request(request)
+  end
 
-    it "sets the root span's name" do
-      expect(@response).to match('{"data":{"__typename":"Query"}}')
+  it("reports a successful query") do
+    query = "query AllTheBooks { books { title } }"
+    response = request_query(query)
+    expect(response.code).to eq("200")
 
-      log = @app.logs
-      span_id = fetch_root_span_id(log)
-      expect(log).to include("Set name 'POST /' for span '#{span_id}'")
-    end
+    log = @app.logs
+
+    root_span_id = fetch_root_span_id(log)
+    expect(log).to include("Set name 'AllTheBooks' for span '#{root_span_id}'")
+
+    child_span_ids = fetch_child_span_ids(log, root_span_id)
+    expect(child_span_ids.length).to be(3)
+
+    parse_span_id, validate_span_id, execute_span_id = child_span_ids
+
+    expect(log).to include(
+      "Set attribute for key 'appsignal:category' " \
+        "with value 'parse.graphql' to span '#{parse_span_id}'"
+    )
+    expect(log).to include(
+      "Set attribute for key 'appsignal:category' " \
+        "with value 'validate.graphql' to span '#{validate_span_id}'"
+    )
+    expect(log).to include(
+      "Set attribute for key 'appsignal:category' " \
+        "with value 'execute.graphql' to span '#{execute_span_id}'"
+    )
+    expect(log).to include(
+      "Set attribute for key 'appsignal:body' " \
+        "with value '#{query}' to span '#{execute_span_id}'"
+    )
+  end
+
+  it("reports an error when a query fails to parse") do
+    query = "gibberish"
+    response = request_query(query)
+    expect(response.code).to eq("400")
+
+    log = @app.logs
+
+    root_span_id = fetch_root_span_id(log)
+    expect(log).to include("Set name '[unknown graphql query]' for span '#{root_span_id}'")
+
+    expect(log).to include(
+      "Add error 'GraphQLError' to span '#{root_span_id}' with message " \
+        "'Syntax Error: Unexpected Name \"gibberish\".' with a backtrace"
+    )
+
+    child_span_ids = fetch_child_span_ids(log, root_span_id)
+    expect(child_span_ids.length).to be(1)
+
+    parse_span_id = child_span_ids.first
+
+    expect(log).to include(
+      "Set attribute for key 'appsignal:category' " \
+        "with value 'parse.graphql' to span '#{parse_span_id}'"
+    )
+
+    expect(log).not_to include(
+      "Set attribute for key 'appsignal:category' with value 'validate.graphql'"
+    )
+    expect(log).not_to include(
+      "Set attribute for key 'appsignal:category' with value 'execute.graphql'"
+    )
+  end
+
+  it("reports an error when a query fails to validate") do
+    query = "query { books { cover } }"
+    response = request_query(query)
+    expect(response.code).to eq("400")
+
+    log = @app.logs
+
+    root_span_id = fetch_root_span_id(log)
+    expect(log).to include("Set name '[unknown graphql query]' for span '#{root_span_id}'")
+
+    expect(log).to include(
+      "Add error 'GraphQLError' to span '#{root_span_id}' with message " \
+        "'Cannot query field \"cover\" on type \"Book\".' with a backtrace"
+    )
+
+    child_span_ids = fetch_child_span_ids(log, root_span_id)
+    expect(child_span_ids.length).to be(2)
+
+    parse_span_id, validate_span_id = child_span_ids
+
+    expect(log).to include(
+      "Set attribute for key 'appsignal:category' " \
+        "with value 'parse.graphql' to span '#{parse_span_id}'"
+    )
+    expect(log).to include(
+      "Set attribute for key 'appsignal:category' " \
+        "with value 'validate.graphql' to span '#{validate_span_id}'"
+    )
+
+    expect(log).not_to include(
+      "Set attribute for key 'appsignal:category' with value 'execute.graphql'"
+    )
   end
 end

--- a/packages/nodejs/.changesets/ensure-the-root-span-is-preserved-across-scopes.md
+++ b/packages/nodejs/.changesets/ensure-the-root-span-is-preserved-across-scopes.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Ensure the root span is preserved across scopes. Due to a bug in the scope management logic, calling `tracer.withSpan` could cause the root span for a given scope to be forgotten.

--- a/packages/nodejs/src/__tests__/scope.test.ts
+++ b/packages/nodejs/src/__tests__/scope.test.ts
@@ -32,6 +32,29 @@ describe("ScopeManager", () => {
     })
   })
 
+  describe(".setRoot()", () => {
+    it("sets the root span and active span for the current process", () => {
+      const span = new RootSpan()
+
+      scopeManager.setRoot(span)
+
+      expect(scopeManager.root()).toStrictEqual(span)
+      expect(scopeManager.active()).toStrictEqual(span)
+    })
+
+    describe("when there is an active span", () => {
+      it("does not set the active span for the current process", () => {
+        const rootSpan = new RootSpan()
+        const childSpan = new ChildSpan(rootSpan)
+
+        scopeManager.withContext(childSpan, () => {
+          scopeManager.setRoot(rootSpan)
+          expect(scopeManager.active()).toStrictEqual(childSpan)
+        })
+      })
+    })
+  })
+
   describe(".withContext()", () => {
     it("should run the callback (object as target)", () => {
       const fn = jest.fn(() => {

--- a/packages/nodejs/src/__tests__/scope.test.ts
+++ b/packages/nodejs/src/__tests__/scope.test.ts
@@ -1,5 +1,6 @@
 import { ScopeManager } from "../scope"
 import { RootSpan, ChildSpan } from "../span"
+import { Span } from "../interfaces/span"
 
 describe("ScopeManager", () => {
   let scopeManager: ScopeManager
@@ -13,22 +14,73 @@ describe("ScopeManager", () => {
     scopeManager.disable()
   })
 
+  // Returns a promise for the return value of a function, to be
+  // ran in a process spawned with `process.nextTick`
+  function asyncTask<T>(fn: () => T): Promise<T> {
+    return new Promise(resolve => process.nextTick(() => resolve(fn())))
+  }
+
+  function asyncTaskWithContext<T>(
+    scopeManager: ScopeManager,
+    span: Span,
+    fn: () => T
+  ): Promise<T> {
+    let asyncTaskPromise
+
+    scopeManager.withContext(span, () => {
+      asyncTaskPromise = asyncTask(fn)
+    })
+
+    // `scopeManager.withContext` executes the function given to it
+    // immediately, so `asyncTaskPromise` is always assigned -- but
+    // the TypeScript compiler doesn't know that, so we ask it to
+    // trust us that it's not `undefined`.
+    return (asyncTaskPromise as unknown) as Promise<T>
+  }
+
+  describe("new ScopeManager()", () => {
+    it("has a disabled async hook", async () => {
+      scopeManager = new ScopeManager()
+      const span = new RootSpan()
+
+      await expect(
+        asyncTaskWithContext(scopeManager, span, () => scopeManager.active())
+      ).resolves.toBe(undefined)
+    })
+  })
+
   describe(".enable()", () => {
-    it("should work", () => {
-      expect(() => {
-        scopeManager = new ScopeManager()
-        expect(scopeManager.enable()).toEqual(scopeManager)
-      }).not.toThrow()
+    it("enables the async hook", async () => {
+      scopeManager = new ScopeManager()
+      const span = new RootSpan()
+
+      scopeManager.enable()
+
+      await expect(
+        asyncTaskWithContext(scopeManager, span, () => scopeManager.active())
+      ).resolves.toBe(span)
     })
   })
 
   describe(".disable()", () => {
-    it("should work", () => {
-      expect(() => {
-        expect(scopeManager.disable()).toEqual(scopeManager)
-      }).not.toThrow()
+    it("disables the async hook", async () => {
+      const span = new RootSpan()
 
-      scopeManager.enable()
+      scopeManager.disable()
+
+      await expect(
+        asyncTaskWithContext(scopeManager, span, () => scopeManager.active())
+      ).resolves.toBe(undefined)
+    })
+
+    it("forgets all active spans", () => {
+      const span = new RootSpan()
+
+      scopeManager.withContext(span, () => {
+        expect(scopeManager.active()).toBe(span)
+        scopeManager.disable()
+        expect(scopeManager.active()).toBe(undefined)
+      })
     })
   })
 
@@ -38,8 +90,8 @@ describe("ScopeManager", () => {
 
       scopeManager.setRoot(span)
 
-      expect(scopeManager.root()).toStrictEqual(span)
-      expect(scopeManager.active()).toStrictEqual(span)
+      expect(scopeManager.root()).toBe(span)
+      expect(scopeManager.active()).toBe(span)
     })
 
     describe("when there is an active span", () => {
@@ -49,30 +101,27 @@ describe("ScopeManager", () => {
 
         scopeManager.withContext(childSpan, () => {
           scopeManager.setRoot(rootSpan)
-          expect(scopeManager.active()).toStrictEqual(childSpan)
+          expect(scopeManager.active()).toBe(childSpan)
         })
       })
     })
   })
 
   describe(".withContext()", () => {
-    it("should run the callback (object as target)", () => {
-      const fn = jest.fn(() => {
-        expect(scopeManager.active()).toStrictEqual(test)
-      })
-      const test = new RootSpan({ namespace: "test" })
-      scopeManager.withContext(test, fn)
+    it("runs the callback", () => {
+      const fn = jest.fn()
+      scopeManager.withContext(new RootSpan(), fn)
       expect(fn).toBeCalled()
     })
 
-    it("should run the callback (when disabled)", () => {
+    it("runs the callback when disabled", () => {
       const fn = jest.fn()
       scopeManager.disable()
       scopeManager.withContext(new RootSpan(), fn)
       expect(fn).toBeCalled()
     })
 
-    it("should rethrow errors", () => {
+    it("rethrows errors", () => {
       const err = new Error("This should be rethrown")
 
       expect(() =>
@@ -82,22 +131,33 @@ describe("ScopeManager", () => {
       ).toThrow(err)
     })
 
-    it("should finally restore an old scope", () => {
-      const rootSpan = new RootSpan()
-      const scope1 = new ChildSpan(rootSpan)
-      const scope2 = new ChildSpan(rootSpan)
+    it("sets the given span as the active span", () => {
+      const span = new RootSpan()
 
-      scopeManager.withContext(scope1, () => {
-        expect(scopeManager.active()).toStrictEqual(scope1)
+      scopeManager.withContext(span, () => {
+        expect(scopeManager.active()).toBe(span)
+      })
+    })
 
-        scopeManager.withContext(scope2, () => {
-          expect(scopeManager.active()).toStrictEqual(scope2)
+    it("restores the previous active span and root span", () => {
+      const outerRootSpan = new RootSpan()
+      const outerChildSpan = new ChildSpan(outerRootSpan)
+      const innerChildSpan = new ChildSpan(outerChildSpan)
+      const innerRootSpan = new RootSpan()
+
+      scopeManager.setRoot(outerRootSpan)
+
+      scopeManager.withContext(outerChildSpan, () => {
+        scopeManager.withContext(innerChildSpan, () => {
+          scopeManager.setRoot(innerRootSpan)
         })
 
-        expect(scopeManager.active()).toStrictEqual(scope1)
+        expect(scopeManager.active()).toBe(outerChildSpan)
+        expect(scopeManager.root()).toBe(outerRootSpan)
       })
 
-      expect(scopeManager.active()).toStrictEqual(scopeManager.root())
+      expect(scopeManager.active()).toBe(outerRootSpan)
+      expect(scopeManager.root()).toBe(outerRootSpan)
     })
   })
 

--- a/packages/nodejs/src/instrumentation/http/lifecycle/outgoing.ts
+++ b/packages/nodejs/src/instrumentation/http/lifecycle/outgoing.ts
@@ -4,11 +4,9 @@
  * Copyright 2019, OpenTelemetry Authors
  */
 
-import { Tracer, Span } from "../../../interfaces"
+import { Tracer } from "../../../interfaces"
 import url from "url"
 import { IncomingMessage, ClientRequest, RequestOptions } from "http"
-
-import { NoopSpan } from "../../../noops"
 
 type HttpRequestArgs = Array<
   (
@@ -72,7 +70,6 @@ function outgoingRequestFunction(
     urlOrOptions: string | url.URL | RequestOptions,
     ...args: unknown[]
   ): ClientRequest {
-    let span: Span
     let origin: string
     let method: string
 
@@ -91,14 +88,8 @@ function outgoingRequestFunction(
       return original.apply(this, [urlOrOptions, ...args])
     }
 
-    if (tracer.currentSpan() instanceof NoopSpan) {
-      // create a new `RootSpan` if there isn't one already in progress
-      span = tracer.createSpan()
-    } else {
-      span = tracer.currentSpan().child()
-    }
-
-    span
+    const span = tracer
+      .createSpan()
       .setName(`${method} ${origin}`)
       .setCategory("request.http")
       .set("method", method)

--- a/packages/nodejs/src/scope.ts
+++ b/packages/nodejs/src/scope.ts
@@ -117,6 +117,9 @@ export class ScopeManager {
   public setRoot(rootSpan: Span) {
     const uid = asyncHooks.executionAsyncId()
     this.#roots.set(uid, rootSpan)
+    if (!this.#scopes.has(uid)) {
+      this.#scopes.set(uid, rootSpan)
+    }
   }
 
   /*

--- a/test/integration/support/integration_helper.rb
+++ b/test/integration/support/integration_helper.rb
@@ -7,4 +7,8 @@ module IntegrationHelper
 
     span_id
   end
+
+  def fetch_child_span_ids(log, root_span_id)
+    log.scan(/Start child span '(\w+)' with parent '#{root_span_id}'/).map(&:first)
+  end
 end


### PR DESCRIPTION
Fixes #623 and closes #626.

[Fix Apollo server error reporting](https://github.com/appsignal/appsignal-nodejs/commit/26b7b7d6e2315183f6d2c4d852787bbf744a4c42)

Ensure `setRoot` sets an active scope. If there is no active scope, calling `scopeManager.setRoot` will set the given root span as both the active span and the root span for the current process. This fixes a bug where processes lose track of their root span after `tracer.withSpan` is called.

Remove a check in the HTTP outgoing instrumentation that checks if there is a current span before creating a root span.

Add integration tests for the current behaviour of the Apollo Server integration. It can report a successful query, including the query body, and report errors that take place during the parsing and validation stages.

The error reporting was previously not working due to the bug described above regarding `scopeManager.setRoot`.

[Improve ScopeManager tests](https://github.com/appsignal/appsignal-nodejs/commit/8e241f19cae4e7a9a923e032106b17005fb4c0be)

Test ScopeManager's enable/disable methods. These methods were not being tested, other than their implementation not throwing an error when called. The tests now check that the underlying async hook is enabled/disabled.

Fix the `withContext` test for restoring the scopes. Before, it was checking that the active span and the root span were equal -- which was true, but only because they were both `undefined`. The equivalent test now makes assertions about the behaviour of the method as a whole, checking that both active and root spans are restored.

Always use `toBe` to compare spans. Spans are identified by a reference empty object which the AppSignal agent keeps track of. These empty objects are always strict equal to each other, so Span objects should be compared to each other with identity equality (`Object.is`).