### PR TITLE
Fix `http://localhost` outgoing HTTP request

### DIFF
--- a/packages/nodejs/.changesets/read-host-property-in-outgoing-http-requests.md
+++ b/packages/nodejs/.changesets/read-host-property-in-outgoing-http-requests.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+When instrumenting an outgoing HTTP request, read the `host` property from the request options if the `hostname` property is not present. This fixes a bug where outgoing HTTP request hosts would be shown as `http://localhost`. 

--- a/packages/nodejs/src/instrumentation/http/lifecycle/__tests__/outgoing.test.ts
+++ b/packages/nodejs/src/instrumentation/http/lifecycle/__tests__/outgoing.test.ts
@@ -62,7 +62,7 @@ describe("HTTP outgoing requests", () => {
     expect(lastSpan.toObject()).toMatchObject({
       attributes: { "appsignal:category": "request.http", method: "GET" },
       error: null,
-      name: "GET http://localhost",
+      name: "GET http://example.com",
       sample_data: {},
       closed: true
     })

--- a/packages/nodejs/src/instrumentation/http/lifecycle/outgoing.ts
+++ b/packages/nodejs/src/instrumentation/http/lifecycle/outgoing.ts
@@ -40,7 +40,7 @@ function optionsToOriginString(
   } else {
     // is a `RequestOptions` object
     protocol = options.protocol ?? protocol
-    hostname = options.hostname ?? hostname
+    hostname = options.hostname ?? options.host ?? hostname
   }
 
   return `${protocol}//${hostname}`


### PR DESCRIPTION
This fixes a bug reported [in an Intercom conversation](https://app.intercom.com/a/apps/yzor8gyw/inbox/inbox/5246522/conversations/16410700091085), where outgoing HTTP requests show up as `http://localhost`.

### Use `host` if `hostname` is undefined

When processing request options in our outgoing HTTP request instrumentation, if `hostname` is undefined, use `host` as the host name instead.

Note that the meanings for `hostname` and `host` differ between the request options object in the Node.js `http` library and the `url.URL` object from the standard WHATWG URL API.

In `url.URL` objects, `hostname` is the host name ("google.com") and `host` is the host name and port ("google.com:80").

In the `http` library, `host` is expected to be the host name, without the port. However, for compatibility with `url.parse()` from the `url.URL` API, `hostname` is supported as an alias for `host`, overriding it if both are present.