### PR TITLE
Check if extension installed successfully on CI

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -89,7 +89,8 @@ blocks:
       - mono build
       - cache delete $_PACKAGES_CACHE-packages-$SEMAPHORE_GIT_SHA-v$NODE_VERSION
       - cache store $_PACKAGES_CACHE-packages-$SEMAPHORE_GIT_SHA-v$NODE_VERSION packages
-      - cat packages/nodejs/ext/install.report
+      - 'cat packages/nodejs/ext/install.report; cat packages/nodejs/ext/install.report
+        | grep ''"status": "success"'''
 - name: Node.js 17 - Tests
   dependencies:
   - Node.js 17 - Build
@@ -191,7 +192,8 @@ blocks:
       - mono build
       - cache delete $_PACKAGES_CACHE-packages-$SEMAPHORE_GIT_SHA-v$NODE_VERSION
       - cache store $_PACKAGES_CACHE-packages-$SEMAPHORE_GIT_SHA-v$NODE_VERSION packages
-      - cat packages/nodejs/ext/install.report
+      - 'cat packages/nodejs/ext/install.report; cat packages/nodejs/ext/install.report
+        | grep ''"status": "success"'''
 - name: Node.js 16 - Tests
   dependencies:
   - Node.js 16 - Build
@@ -291,7 +293,8 @@ blocks:
       - mono build
       - cache delete $_PACKAGES_CACHE-packages-$SEMAPHORE_GIT_SHA-v$NODE_VERSION
       - cache store $_PACKAGES_CACHE-packages-$SEMAPHORE_GIT_SHA-v$NODE_VERSION packages
-      - cat packages/nodejs/ext/install.report
+      - 'cat packages/nodejs/ext/install.report; cat packages/nodejs/ext/install.report
+        | grep ''"status": "success"'''
 - name: Node.js 14 - Tests
   dependencies:
   - Node.js 14 - Build
@@ -390,7 +393,8 @@ blocks:
       - mono build
       - cache delete $_PACKAGES_CACHE-packages-$SEMAPHORE_GIT_SHA-v$NODE_VERSION
       - cache store $_PACKAGES_CACHE-packages-$SEMAPHORE_GIT_SHA-v$NODE_VERSION packages
-      - cat packages/nodejs/ext/install.report
+      - 'cat packages/nodejs/ext/install.report; cat packages/nodejs/ext/install.report
+        | grep ''"status": "success"'''
 - name: Node.js 12 - Tests
   dependencies:
   - Node.js 12 - Build

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,6 +23,7 @@ GEM
     unicode-display_width (2.0.0)
 
 PLATFORMS
+  arm64-darwin-21
   x86_64-darwin-20
 
 DEPENDENCIES

--- a/Rakefile
+++ b/Rakefile
@@ -43,7 +43,8 @@ namespace :build_matrix do
                   "cache delete $_PACKAGES_CACHE-packages-$SEMAPHORE_GIT_SHA-v$NODE_VERSION",
                   "cache store $_PACKAGES_CACHE-packages-$SEMAPHORE_GIT_SHA-v$NODE_VERSION " \
                     "packages",
-                  "cat packages/nodejs/ext/install.report"
+                  "cat packages/nodejs/ext/install.report; " \
+                    "cat packages/nodejs/ext/install.report | grep '\"status\": \"success\"'"
                 ]
               )
             ]


### PR DESCRIPTION
We printed the contents of the install report, but did not check if it
the result status was successful or not. This then lead to all the
specific tests to be run in an integration without an extension.

This will halt the CI on the build step rather than the tests for all
the supported libraries. Saves time and energy for us and the CI, and
gives a clearer picture in the CI overview what went wrong.

[skip changeset]