### PR TITLE
Move condition to build the package to a script

### DIFF
--- a/packages/nodejs/.changesets/fix-error-on-windows-machines-on-install-.md
+++ b/packages/nodejs/.changesets/fix-error-on-windows-machines-on-install-.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Fix error on Microsoft Windows machines on install. The AppSignal extension still won't install on Windows, but now it won't cause an error while checking a development mode condition if it should build the TypeScript package.

--- a/packages/nodejs/package.json
+++ b/packages/nodejs/package.json
@@ -37,7 +37,7 @@
     "postclean": "npm run clean:ext",
     "clean": "rimraf dist coverage build",
     "clean:ext": "rimraf ext/appsignal-agent ext/libappsignal.a ext/appsignal.* ext/*.tar.gz ext/*.report",
-    "preinstall": "if test -d src; then npm run build; fi",
+    "preinstall": "node scripts/extension/prebuild.js",
     "install": "node scripts/extension/extension.js",
     "link:npm": "npm link",
     "link:yarn": "yarn link",

--- a/packages/nodejs/scripts/extension/prebuild.js
+++ b/packages/nodejs/scripts/extension/prebuild.js
@@ -1,0 +1,30 @@
+const fs = require("fs")
+const childProcess = require("child_process")
+
+function build() {
+  return new Promise((resolve, reject) => {
+    childProcess.exec("npm run build", error => {
+      if (error) {
+        return reject(error)
+      } else {
+        return resolve()
+      }
+    })
+  })
+}
+
+function run() {
+  // Build the package if it is the local development version that still has
+  // the `src` directory. It won't run in the shipped version where the `src`
+  // directory is not available.
+  if (fs.existsSync("src")) {
+    return build().catch(error => {
+      console.error(
+        "Something went wrong while building the @appsignal/nodejs package: ",
+        error
+      )
+    })
+  }
+}
+
+run()


### PR DESCRIPTION
For local development we want to build the package before running
install, this will save hassle with fresh clones of the repository and
on `mono clean`/`npm run clean`.

The check we did was a Unix only check within the if-statement with
`test`. Move the check and execution of `npm run build` to a new Node.js
file so it runs on any Operating System.

Fixes #646