### PR TITLE
Add Node 18 to build matrix

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -8,7 +8,7 @@ name: AppSignal for Node.js
 agent:
   machine:
     type: e1-standard-2
-    os_image: ubuntu1804
+    os_image: ubuntu2004
 auto_cancel:
   running:
     when: branch != 'main' AND branch != 'develop'
@@ -54,7 +54,6 @@ blocks:
       - name: NODE_VERSION
         value: '16'
       commands:
-      - sem-version c 8
       - cache restore
       - mono bootstrap --ci
       - cache store
@@ -62,7 +61,7 @@ blocks:
     - name: Git Lint (Lintje)
       commands:
       - script/lint_git
-- name: Node.js 17 - Build
+- name: Node.js 18 - Build
   dependencies:
   - Validation
   task:
@@ -71,10 +70,9 @@ blocks:
       name: NODE_OPTIONS
       value: "--openssl-legacy-provider"
     - name: NODE_VERSION
-      value: '17'
+      value: '18'
     prologue:
       commands:
-      - sem-version c 8
       - npm i -g npm@8.5.3
       - cache restore
       - mono bootstrap --ci
@@ -91,19 +89,122 @@ blocks:
       - cache store $_PACKAGES_CACHE-packages-$SEMAPHORE_GIT_SHA-v$NODE_VERSION packages
       - 'cat packages/nodejs/ext/install.report; cat packages/nodejs/ext/install.report
         | grep ''"status": "success"'''
+- name: Node.js 18 - Tests
+  dependencies:
+  - Node.js 18 - Build
+  task:
+    env_vars:
+    - *1
+    - name: NODE_VERSION
+      value: '18'
+    - name: _APPSIGNAL_EXTENSION_INSTALL
+      value: 'false'
+    prologue:
+      commands:
+      - npm i -g npm@8.5.3
+      - cache restore
+      - cache restore $_PACKAGES_CACHE-packages-$SEMAPHORE_GIT_SHA-v$NODE_VERSION
+      - mono bootstrap --ci
+    epilogue: *2
+    jobs:
+    - name: "@appsignal/nodejs - nodejs"
+      commands:
+      - mono test --package=@appsignal/nodejs
+      - mono run --package @appsignal/nodejs -- npm run test:failure
+    - name: "@appsignal/nodejs - nodejs - diagnose"
+      commands:
+      - git submodule init
+      - git submodule update
+      - LANGUAGE=nodejs test/integration/diagnose/bin/test
+    - name: "@appsignal/apollo-server - apollo-server@latest - integrations"
+      commands:
+      - script/install_test_example_packages apollo-server apollo-server-plugin-base@latest
+      - script/test_package_integration apollo-server
+    - name: "@appsignal/apollo-server - apollo-server@0.13.0 - integrations"
+      commands:
+      - script/install_test_example_packages apollo-server apollo-server-plugin-base@0.13.0
+      - script/test_package_integration apollo-server
+    - name: "@appsignal/apollo-server - apollo-server@0.12.0 - integrations"
+      commands:
+      - script/install_test_example_packages apollo-server apollo-server-plugin-base@0.12.0
+      - script/test_package_integration apollo-server
+    - name: "@appsignal/apollo-server - apollo-server@0.11.0 - integrations"
+      commands:
+      - script/install_test_example_packages apollo-server apollo-server-plugin-base@0.11.0
+      - script/test_package_integration apollo-server
+    - name: "@appsignal/express - express@latest - integrations"
+      commands:
+      - script/install_test_example_packages express express@latest
+      - script/test_package_integration express
+    - name: "@appsignal/express - express@4.17.1 - integrations"
+      commands:
+      - script/install_test_example_packages express express@4.17.1
+      - script/test_package_integration express
+    - name: "@appsignal/koa - koa@latest - integrations"
+      commands:
+      - script/install_test_example_packages koa koa@latest
+      - script/test_package_integration koa
+    - name: "@appsignal/koa - koa@2.13.1 - integrations"
+      commands:
+      - script/install_test_example_packages koa koa@2.13.1
+      - script/test_package_integration koa
+    - name: "@appsignal/koa - koa@2.12.1 - integrations"
+      commands:
+      - script/install_test_example_packages koa koa@2.12.1
+      - script/test_package_integration koa
+    - name: "@appsignal/nextjs - next.js@latest - integrations"
+      commands:
+      - script/install_test_example_packages nextjs next@latest react@latest react-dom@latest
+      - script/test_package_integration nextjs
+    - name: "@appsignal/nextjs - next.js@12.1.0 - integrations"
+      commands:
+      - script/install_test_example_packages nextjs next@12.1.0 react@17.0.2 react-dom@17.0.2
+      - script/test_package_integration nextjs
+    - name: "@appsignal/nextjs - next.js@11.1.4 - integrations"
+      commands:
+      - script/install_test_example_packages nextjs next@11.1.4 react@17.0.2 react-dom@17.0.2
+      - script/test_package_integration nextjs
+    - name: "@appsignal/nextjs - next.js@10.2.3 - integrations"
+      commands:
+      - script/install_test_example_packages nextjs next@10.2.3 react@16.14.0 react-dom@16.14.0
+      - script/test_package_integration nextjs
+- name: Node.js 17 - Build
+  dependencies:
+  - Validation
+  task:
+    env_vars:
+    - &3
+      name: NODE_OPTIONS
+      value: "--openssl-legacy-provider"
+    - name: NODE_VERSION
+      value: '17'
+    prologue:
+      commands:
+      - npm i -g npm@8.5.3
+      - cache restore
+      - mono bootstrap --ci
+      - cache store
+    epilogue: *2
+    jobs:
+    - name: Build
+      commands:
+      - mono build
+      - cache delete $_PACKAGES_CACHE-packages-$SEMAPHORE_GIT_SHA-v$NODE_VERSION
+      - cache store $_PACKAGES_CACHE-packages-$SEMAPHORE_GIT_SHA-v$NODE_VERSION packages
+      - 'cat packages/nodejs/ext/install.report; cat packages/nodejs/ext/install.report
+        | grep ''"status": "success"'''
 - name: Node.js 17 - Tests
   dependencies:
   - Node.js 17 - Build
   task:
     env_vars:
-    - *1
+    - *3
     - name: NODE_VERSION
       value: '17'
     - name: _APPSIGNAL_EXTENSION_INSTALL
       value: 'false'
     prologue:
       commands:
-      - sem-version c 8
       - npm i -g npm@8.5.3
       - cache restore
       - cache restore $_PACKAGES_CACHE-packages-$SEMAPHORE_GIT_SHA-v$NODE_VERSION
@@ -180,7 +281,6 @@ blocks:
       value: '16'
     prologue:
       commands:
-      - sem-version c 8
       - npm i -g npm@8.5.3
       - cache restore
       - mono bootstrap --ci
@@ -205,7 +305,6 @@ blocks:
       value: 'false'
     prologue:
       commands:
-      - sem-version c 8
       - npm i -g npm@8.5.3
       - cache restore
       - cache restore $_PACKAGES_CACHE-packages-$SEMAPHORE_GIT_SHA-v$NODE_VERSION
@@ -302,106 +401,6 @@ blocks:
     env_vars:
     - name: NODE_VERSION
       value: '14'
-    - name: _APPSIGNAL_EXTENSION_INSTALL
-      value: 'false'
-    prologue:
-      commands:
-      - npm i -g npm@8.5.3
-      - cache restore
-      - cache restore $_PACKAGES_CACHE-packages-$SEMAPHORE_GIT_SHA-v$NODE_VERSION
-      - mono bootstrap --ci
-    epilogue: *2
-    jobs:
-    - name: "@appsignal/nodejs - nodejs"
-      commands:
-      - mono test --package=@appsignal/nodejs
-      - mono run --package @appsignal/nodejs -- npm run test:failure
-    - name: "@appsignal/nodejs - nodejs - diagnose"
-      commands:
-      - git submodule init
-      - git submodule update
-      - LANGUAGE=nodejs test/integration/diagnose/bin/test
-    - name: "@appsignal/apollo-server - apollo-server@latest - integrations"
-      commands:
-      - script/install_test_example_packages apollo-server apollo-server-plugin-base@latest
-      - script/test_package_integration apollo-server
-    - name: "@appsignal/apollo-server - apollo-server@0.13.0 - integrations"
-      commands:
-      - script/install_test_example_packages apollo-server apollo-server-plugin-base@0.13.0
-      - script/test_package_integration apollo-server
-    - name: "@appsignal/apollo-server - apollo-server@0.12.0 - integrations"
-      commands:
-      - script/install_test_example_packages apollo-server apollo-server-plugin-base@0.12.0
-      - script/test_package_integration apollo-server
-    - name: "@appsignal/apollo-server - apollo-server@0.11.0 - integrations"
-      commands:
-      - script/install_test_example_packages apollo-server apollo-server-plugin-base@0.11.0
-      - script/test_package_integration apollo-server
-    - name: "@appsignal/express - express@latest - integrations"
-      commands:
-      - script/install_test_example_packages express express@latest
-      - script/test_package_integration express
-    - name: "@appsignal/express - express@4.17.1 - integrations"
-      commands:
-      - script/install_test_example_packages express express@4.17.1
-      - script/test_package_integration express
-    - name: "@appsignal/koa - koa@latest - integrations"
-      commands:
-      - script/install_test_example_packages koa koa@latest
-      - script/test_package_integration koa
-    - name: "@appsignal/koa - koa@2.13.1 - integrations"
-      commands:
-      - script/install_test_example_packages koa koa@2.13.1
-      - script/test_package_integration koa
-    - name: "@appsignal/koa - koa@2.12.1 - integrations"
-      commands:
-      - script/install_test_example_packages koa koa@2.12.1
-      - script/test_package_integration koa
-    - name: "@appsignal/nextjs - next.js@latest - integrations"
-      commands:
-      - script/install_test_example_packages nextjs next@latest react@latest react-dom@latest
-      - script/test_package_integration nextjs
-    - name: "@appsignal/nextjs - next.js@12.1.0 - integrations"
-      commands:
-      - script/install_test_example_packages nextjs next@12.1.0 react@17.0.2 react-dom@17.0.2
-      - script/test_package_integration nextjs
-    - name: "@appsignal/nextjs - next.js@11.1.4 - integrations"
-      commands:
-      - script/install_test_example_packages nextjs next@11.1.4 react@17.0.2 react-dom@17.0.2
-      - script/test_package_integration nextjs
-    - name: "@appsignal/nextjs - next.js@10.2.3 - integrations"
-      commands:
-      - script/install_test_example_packages nextjs next@10.2.3 react@16.14.0 react-dom@16.14.0
-      - script/test_package_integration nextjs
-- name: Node.js 12 - Build
-  dependencies:
-  - Validation
-  task:
-    env_vars:
-    - name: NODE_VERSION
-      value: '12'
-    prologue:
-      commands:
-      - npm i -g npm@8.5.3
-      - cache restore
-      - mono bootstrap --ci
-      - cache store
-    epilogue: *2
-    jobs:
-    - name: Build
-      commands:
-      - mono build
-      - cache delete $_PACKAGES_CACHE-packages-$SEMAPHORE_GIT_SHA-v$NODE_VERSION
-      - cache store $_PACKAGES_CACHE-packages-$SEMAPHORE_GIT_SHA-v$NODE_VERSION packages
-      - 'cat packages/nodejs/ext/install.report; cat packages/nodejs/ext/install.report
-        | grep ''"status": "success"'''
-- name: Node.js 12 - Tests
-  dependencies:
-  - Node.js 12 - Build
-  task:
-    env_vars:
-    - name: NODE_VERSION
-      value: '12'
     - name: _APPSIGNAL_EXTENSION_INSTALL
       value: 'false'
     prologue:

--- a/build_matrix.yml
+++ b/build_matrix.yml
@@ -4,7 +4,7 @@ semaphore: # Default `.semaphore/semaphore.yml` contents
   agent:
     machine:
       type: e1-standard-2
-      os_image: ubuntu1804
+      os_image: ubuntu2004
   auto_cancel:
     running:
       when: branch != 'main' AND branch != 'develop'
@@ -51,10 +51,6 @@ semaphore: # Default `.semaphore/semaphore.yml` contents
             - name: NODE_VERSION
               value: "16"
           commands:
-            # Configure the host to use GCC 8.3 for Node.js 16. This is the minimal
-            # required version for Node.js 16, and the extension won't compile
-            # without it.
-            - sem-version c 8
             - cache restore
             - mono bootstrap --ci
             - cache store
@@ -70,12 +66,8 @@ matrix:
         - ""
 
   nodejs:
-    - nodejs: "17"
-      setup: 
-        # Configure the host to use GCC 8.3 for Node.js 16 and above. This
-        # is the minimal required version for Node.js 16 and above, and the
-        # extension won't compile without it.
-        - &gcc8 sem-version c 8
+    - nodejs: "18"
+      setup:
         # Use NPM version 8.5.3 to work around a bug when using NPM 8.5.4 or
         # higher, where commands that are ran at the root of the workspace
         # do not trigger lifecycle hooks for the workspace packages.
@@ -89,14 +81,21 @@ matrix:
         # https://github.com/nodejs/node/issues/40455
         - name: NODE_OPTIONS
           value: "--openssl-legacy-provider"
+    - nodejs: "17"
+      setup:
+        - *npm853
+      env_vars:
+        # Set `NODE_OPTIONS` to `--openssl-legacy-provider`, as a workaround
+        # for this `webpack` bug affecting the `@appsignal/nextjs` tests
+        # when running on Node 17:
+        # https://github.com/webpack/webpack/issues/14532
+        # https://github.com/nodejs/node/issues/40455
+        - name: NODE_OPTIONS
+          value: "--openssl-legacy-provider"
     - nodejs: "16"
       setup:
-        - *gcc8
         - *npm853
     - nodejs: "14"
-      setup:
-        - *npm853
-    - nodejs: "12"
       setup:
         - *npm853
   packages:


### PR DESCRIPTION
Node 18 is now available and Node 12 is in EOL. This commits adds Node
18 to the build matrix and removes Node 12.

As Node 18 requires glibc 2.28 or newer, the matrix needs to run on at
least Ubuntu 20.04, so it's been updated.

We don't need to specify C 8 anymore for any build as all versions work
by default with the version included in the new OS image.

Closes: #649 

[skip changeset]