### PR TITLE
Send HTTP Post requests body params for Express

### DIFF
--- a/packages/express/.changesets/send-http-request-body-params-properly.md
+++ b/packages/express/.changesets/send-http-request-body-params-properly.md
@@ -1,0 +1,7 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+HTTP Post requests were not sending the body params to AppSignal. They are now properly sent to the
+application.


### PR DESCRIPTION
Body params were not bein sent to AppSignal in Express' HTTP
transactions. With this change, they're now properly sent.

Fixes: #650 