### PR TITLE
Ignore parent `NoopSpan` in `createSpan`

### DIFF
--- a/packages/nodejs/src/tracer.ts
+++ b/packages/nodejs/src/tracer.ts
@@ -41,7 +41,7 @@ export class BaseTracer implements Tracer {
   ): Span {
     const activeRootSpan = this.rootSpan()
 
-    if (spanOrContext) {
+    if (spanOrContext && !(spanOrContext instanceof NoopSpan)) {
       return new ChildSpan(spanOrContext, options)
     } else if (activeRootSpan instanceof NoopSpan) {
       const rootSpan = new RootSpan(options)


### PR DESCRIPTION
If a `NoopSpan` is passed as the parent span to be used by `tracer.createSpan`, instead of assuming it to be a `SpanContext` and creating a broken child span from it, behave as if no span has been passed.

This edge case can be accidentally triggered by passing the output of `tracer.currentSpan` to `tracer.createSpan`, which is something you might want to do if you want to create a span whose parent is the current span, as opposed to `tracer.createSpan`'s default behaviour of creating a span whose parent is the current **root** span.

Rewrite the tests for `.createSpan` so that it is possible to understand what behaviour is being tested without going back and forth between the tests and the implementation, and add a test for the above behaviour change.