### PR TITLE
Import OpenTelemetry types rather than duplicate

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1329,6 +1329,63 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/@opentelemetry/core": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.2.0.tgz",
+      "integrity": "sha512-QiKp8fBbT9ZhRTP+ZVVMyqH62tD/ZQa4gWPi+GnpNetvK1SWPO/8DmRpaSXHwAhu5FWUDJrbFgpLsrDd1zGPOw==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.2.0"
+      },
+      "engines": {
+        "node": ">=8.12.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.2.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.2.0.tgz",
+      "integrity": "sha512-S5ZlZa2JF+1qhiF7eb3tTtDfKmTODO//pvam9vEyZvr+/At45rIQ7cyznRdMWCppZbholwXWXnrKml29IIG9vQ==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/core": "1.2.0",
+        "@opentelemetry/semantic-conventions": "1.2.0"
+      },
+      "engines": {
+        "node": ">=8.12.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.2.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.2.0.tgz",
+      "integrity": "sha512-eHrG9c9OhoDhUmMe63Qzgpcvlgxr2L7BFBbbj2DdZu3vGstayytTT6TDv6mz727lXBqR1HXMbqTGVafS07r3bg==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/core": "1.2.0",
+        "@opentelemetry/resources": "1.2.0",
+        "@opentelemetry/semantic-conventions": "1.2.0"
+      },
+      "engines": {
+        "node": ">=8.12.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.2.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.2.0.tgz",
+      "integrity": "sha512-BNKB9fiYVghALJzCuWO3eNYfdTExPVK4ykrtmfNfy0A6UWYhOYjGMXifUmkunDJNL8ju9tBobo8jF0WR9zGy1Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.12.0"
+      }
+    },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
@@ -11043,10 +11100,10 @@
     },
     "packages/apollo-server": {
       "name": "@appsignal/apollo-server",
-      "version": "1.0.28",
+      "version": "1.0.29",
       "license": "MIT",
       "dependencies": {
-        "@appsignal/nodejs": "=2.3.5",
+        "@appsignal/nodejs": "=2.3.6",
         "apollo-server-plugin-base": "^0.10.3",
         "tslib": "^2.0.3"
       },
@@ -11061,10 +11118,10 @@
     },
     "packages/express": {
       "name": "@appsignal/express",
-      "version": "1.0.29",
+      "version": "1.0.30",
       "license": "MIT",
       "dependencies": {
-        "@appsignal/nodejs": "=2.3.5",
+        "@appsignal/nodejs": "=2.3.6",
         "tslib": "^2.0.3"
       },
       "devDependencies": {
@@ -11082,10 +11139,10 @@
     },
     "packages/koa": {
       "name": "@appsignal/koa",
-      "version": "1.0.19",
+      "version": "1.0.20",
       "license": "MIT",
       "dependencies": {
-        "@appsignal/nodejs": "=2.3.5",
+        "@appsignal/nodejs": "=2.3.6",
         "@appsignal/types": "^3.0.0",
         "shimmer": "^1.2.1",
         "tslib": "^2.0.3"
@@ -11107,10 +11164,10 @@
     },
     "packages/nextjs": {
       "name": "@appsignal/nextjs",
-      "version": "2.0.17",
+      "version": "2.0.18",
       "license": "MIT",
       "dependencies": {
-        "@appsignal/nodejs": "=2.3.5",
+        "@appsignal/nodejs": "=2.3.6",
         "tslib": "^2.0.3"
       },
       "devDependencies": {
@@ -11127,7 +11184,7 @@
     },
     "packages/nodejs": {
       "name": "@appsignal/nodejs",
-      "version": "2.3.5",
+      "version": "2.3.6",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -11146,6 +11203,7 @@
         "appsignal-diagnose": "bin/diagnose"
       },
       "devDependencies": {
+        "@opentelemetry/sdk-trace-base": "^1.2.0",
         "@types/pg": "*",
         "@types/redis": "*",
         "@types/semver": "*",
@@ -11327,7 +11385,7 @@
     "@appsignal/apollo-server": {
       "version": "file:packages/apollo-server",
       "requires": {
-        "@appsignal/nodejs": "=2.3.5",
+        "@appsignal/nodejs": "=2.3.6",
         "apollo-server-plugin-base": "*",
         "tslib": "^2.0.3"
       },
@@ -11364,7 +11422,7 @@
     "@appsignal/express": {
       "version": "file:packages/express",
       "requires": {
-        "@appsignal/nodejs": "=2.3.5",
+        "@appsignal/nodejs": "=2.3.6",
         "@types/express": "*",
         "express": "*",
         "tslib": "^2.0.3"
@@ -11380,7 +11438,7 @@
     "@appsignal/koa": {
       "version": "file:packages/koa",
       "requires": {
-        "@appsignal/nodejs": "=2.3.5",
+        "@appsignal/nodejs": "=2.3.6",
         "@appsignal/types": "^3.0.0",
         "@types/koa": "*",
         "@types/koa__router": "*",
@@ -11400,7 +11458,7 @@
     "@appsignal/nextjs": {
       "version": "file:packages/nextjs",
       "requires": {
-        "@appsignal/nodejs": "=2.3.5",
+        "@appsignal/nodejs": "=2.3.6",
         "next": "*",
         "tslib": "^2.0.3"
       },
@@ -11418,6 +11476,7 @@
         "@appsignal/core": "^1.1.4",
         "@appsignal/types": "^3.0.0",
         "@opentelemetry/api": "^1.0.4",
+        "@opentelemetry/sdk-trace-base": "^1.2.0",
         "@types/pg": "*",
         "@types/redis": "*",
         "@types/semver": "*",
@@ -12498,6 +12557,42 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.0.4.tgz",
       "integrity": "sha512-BuJuXRSJNQ3QoKA6GWWDyuLpOUck+9hAXNMCnrloc1aWVoy6Xq6t9PUV08aBZ4Lutqq2LEHM486bpZqoViScog=="
+    },
+    "@opentelemetry/core": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.2.0.tgz",
+      "integrity": "sha512-QiKp8fBbT9ZhRTP+ZVVMyqH62tD/ZQa4gWPi+GnpNetvK1SWPO/8DmRpaSXHwAhu5FWUDJrbFgpLsrDd1zGPOw==",
+      "dev": true,
+      "requires": {
+        "@opentelemetry/semantic-conventions": "1.2.0"
+      }
+    },
+    "@opentelemetry/resources": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.2.0.tgz",
+      "integrity": "sha512-S5ZlZa2JF+1qhiF7eb3tTtDfKmTODO//pvam9vEyZvr+/At45rIQ7cyznRdMWCppZbholwXWXnrKml29IIG9vQ==",
+      "dev": true,
+      "requires": {
+        "@opentelemetry/core": "1.2.0",
+        "@opentelemetry/semantic-conventions": "1.2.0"
+      }
+    },
+    "@opentelemetry/sdk-trace-base": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.2.0.tgz",
+      "integrity": "sha512-eHrG9c9OhoDhUmMe63Qzgpcvlgxr2L7BFBbbj2DdZu3vGstayytTT6TDv6mz727lXBqR1HXMbqTGVafS07r3bg==",
+      "dev": true,
+      "requires": {
+        "@opentelemetry/core": "1.2.0",
+        "@opentelemetry/resources": "1.2.0",
+        "@opentelemetry/semantic-conventions": "1.2.0"
+      }
+    },
+    "@opentelemetry/semantic-conventions": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.2.0.tgz",
+      "integrity": "sha512-BNKB9fiYVghALJzCuWO3eNYfdTExPVK4ykrtmfNfy0A6UWYhOYjGMXifUmkunDJNL8ju9tBobo8jF0WR9zGy1Q==",
+      "dev": true
     },
     "@protobufjs/aspromise": {
       "version": "1.1.2",

--- a/packages/nodejs/.changesets/use-opentelemetry-spanprocessor-interface-to-build-our-own-spanprocessor.md
+++ b/packages/nodejs/.changesets/use-opentelemetry-spanprocessor-interface-to-build-our-own-spanprocessor.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "change"
+---
+
+Use the OpenTelemetry SpanProcessor interface to build our own SpanProcessor. We previously copied the SpanProcessor code into our package, but instead we now use the OpenTelemetry interface directly. This should make our processor match the expected type better.

--- a/packages/nodejs/package.json
+++ b/packages/nodejs/package.json
@@ -30,7 +30,8 @@
     "@types/semver": "*",
     "nock": "^13.2.2",
     "pg": "*",
-    "redis": "*"
+    "redis": "*",
+    "@opentelemetry/sdk-trace-base": "^1.2.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",

--- a/packages/nodejs/src/interfaces/span_processor.ts
+++ b/packages/nodejs/src/interfaces/span_processor.ts
@@ -1,44 +1,7 @@
-import { HrTime, Span, SpanAttributes, SpanContext } from "@opentelemetry/api"
+import type {
+  Span,
+  ReadableSpan,
+  SpanProcessor
+} from "@opentelemetry/sdk-trace-base"
 
-/**
- * OpenTelemetrySpanProcessor is based on OpenTelemetry's internal span processor.
- */
-export interface OpenTelemetrySpanProcessor {
-  /**
-   * Forces to export all finished spans
-   */
-  forceFlush(): Promise<void>
-
-  /**
-   * Called when an OpenTelemetry {@link Span} is started, if the
-   * `span.isRecording()` returns true.
-   * @param span the OpenTelemetry Span that just started.
-   */
-  onStart(_span: Span, _parentContext: SpanContext): void
-
-  /**
-   * Called when an OpenTelemetry {@link Span} is ended, if the
-   * `span.isRecording()` returns true.
-   * @param span the Span that just ended.
-   */
-  onEnd(_span: ReadableSpan, _parentContext: SpanContext): void
-
-  /**
-   * Shuts down the processor. Called when the OpenTelemetry SDK is shut down.
-   * This is an opportunity for processor to do any cleanup required.
-   */
-  shutdown(): Promise<void>
-}
-
-/**
- * ReadableSpan is based on a subset of OpenTelemetry's internal "readable"
- * spans, which have readonly attributes for exporting.
- */
-export interface ReadableSpan {
-  readonly name: string
-  readonly spanContext: () => SpanContext
-  readonly startTime: HrTime
-  readonly endTime: HrTime
-  readonly attributes: SpanAttributes
-  readonly instrumentationLibrary: { name: string }
-}
+export type { Span, ReadableSpan, SpanProcessor }

--- a/packages/nodejs/src/span_processor.ts
+++ b/packages/nodejs/src/span_processor.ts
@@ -1,7 +1,8 @@
-import { Span, SpanContext } from "@opentelemetry/api"
+import { Context } from "@opentelemetry/api"
 import {
-  OpenTelemetrySpanProcessor,
-  ReadableSpan
+  Span,
+  ReadableSpan,
+  SpanProcessor as OpenTelemetrySpanProcessor
 } from "./interfaces/span_processor"
 import { BaseClient as Client } from "./client"
 import { NoopSpan } from "./noops"
@@ -18,9 +19,9 @@ export class SpanProcessor implements OpenTelemetrySpanProcessor {
   }
 
   // eslint-disable-next-line @typescript-eslint/no-empty-function
-  onStart(_span: Span, _parentContext: SpanContext): void {}
+  onStart(_span: Span, _parentContext: Context): void {}
 
-  onEnd(span: ReadableSpan, _parentContext: SpanContext): void {
+  onEnd(span: ReadableSpan): void {
     const appsignalSpan = this.client.tracer().currentSpan()
 
     if (!(appsignalSpan instanceof NoopSpan)) {


### PR DESCRIPTION
Use Typescript's `import type` and `export type` to include the
OpenTelemetry types into our package without having to copy the code
into our project directly.

This was suggested by @unflxw in PR https://github.com/appsignal/appsignal-nodejs/pull/651#discussion_r866916531

I'm not sure if this is more or less fragile. If the OpenTelemetry
package changes the interface we'd be shipping an older version that
doesn't work with older versions anymore.

The package from which we import is a dev dependency only, and used
during the compile step, and won't ship as a dependency in the final
release.

I got an issue when using the OpenTelemetry SpanProcessor type for the
`onEnd` function. It doesn't have a second argument.

The `onStart` also needed another type, from `SpanContext` to `Context`.