### PR TITLE
Reenable Next.js flaky test

### DIFF
--- a/packages/nextjs/test/spec/integration_spec.rb
+++ b/packages/nextjs/test/spec/integration_spec.rb
@@ -19,7 +19,6 @@ RSpec.describe "Next.js" do
     end
 
     it "renders the index page" do
-      skip("https://github.com/appsignal/appsignal-nodejs/issues/632")
       expect(@result).to match(/Welcome to .+Next\.js!/)
     end
 


### PR DESCRIPTION
Remove skip clause from the integration test that failed for Node.js
v14 on CI

The most recent changes on the build matrix (Upgrading the base SO image, removing some old hotfixes for CPP) have probably fixed this? The test now works.

Fixes: #632 

[skip changeset]