### PR TITLE
Remove README install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,38 +8,7 @@
 
 ## Installation
 
-First, [sign up][appsignal-sign-up] for an AppSignal account and run our automated install tool, which will install `@appsignal/nodejs` and any relevant integrations to your project:
-
-```bash
-npx @appsignal/cli install
-```
-
-You can also skip the automated tool and add `@appsignal/nodejs` to your `package.json` on the command line with `npm`/`yarn`:
-
-```bash
-yarn add @appsignal/nodejs
-npm install --save @appsignal/nodejs
-```
-
-Alternatively, you can manually add the `@appsignal/nodejs` package to your `package.json`. Then, run `yarn install`/`npm install`.
-
-> Installing the AppSignal for Node.js integration builds a native extension. To compile it, macOS users will need to install the [Xcode Developer Tools](https://osxdaily.com/2014/02/12/install-command-line-tools-mac-os-x/). Linux users will need the dependencies outlined here. Windows is not supported.
-
-You can then import and use the package in your bundle:
-
-```js
-const { Appsignal } = require("@appsignal/nodejs");
-
-const appsignal = new Appsignal({
-  active: true,
-  name: "<YOUR APPLICATION NAME>"
-  pushApiKey: "<YOUR API KEY>"
-});
-
-// ...all the rest of your code goes here!
-```
-
-> To auto-instrument modules, the Appsignal module must be both **required** and **initialized** before any other package.
+Please follow our [installation guide](https://docs.appsignal.com/guides/new-application.html) in our documentation.
 
 ## Development
 


### PR DESCRIPTION
Point to the docs instead. This reduces the places we have to sync our
installation instructions with. That way we can be sure people are
always following the same instructions.

[skip ci]
[skip changeset]