### PR TITLE
Remove NPM 8.5.3 usage from CI matrix

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -27,6 +27,7 @@ global_job_config:
     - checkout
     - '[ -n "$NODE_VERSION" ] && sem-version node $NODE_VERSION || echo Skipping Node.js
       install'
+    - npm i -g npm@latest
     - script/setup
     - source ~/.bashrc
 blocks:
@@ -52,7 +53,7 @@ blocks:
     - name: Node.js Lint (Prettier)
       env_vars:
       - name: NODE_VERSION
-        value: '16'
+        value: '18'
       commands:
       - cache restore
       - mono bootstrap --ci
@@ -73,7 +74,6 @@ blocks:
       value: '18'
     prologue:
       commands:
-      - npm i -g npm@8.5.3
       - cache restore
       - mono bootstrap --ci
       - cache store
@@ -101,7 +101,6 @@ blocks:
       value: 'false'
     prologue:
       commands:
-      - npm i -g npm@8.5.3
       - cache restore
       - cache restore $_PACKAGES_CACHE-packages-$SEMAPHORE_GIT_SHA-v$NODE_VERSION
       - mono bootstrap --ci
@@ -180,7 +179,6 @@ blocks:
       value: '17'
     prologue:
       commands:
-      - npm i -g npm@8.5.3
       - cache restore
       - mono bootstrap --ci
       - cache store
@@ -205,7 +203,6 @@ blocks:
       value: 'false'
     prologue:
       commands:
-      - npm i -g npm@8.5.3
       - cache restore
       - cache restore $_PACKAGES_CACHE-packages-$SEMAPHORE_GIT_SHA-v$NODE_VERSION
       - mono bootstrap --ci
@@ -281,7 +278,6 @@ blocks:
       value: '16'
     prologue:
       commands:
-      - npm i -g npm@8.5.3
       - cache restore
       - mono bootstrap --ci
       - cache store
@@ -305,7 +301,6 @@ blocks:
       value: 'false'
     prologue:
       commands:
-      - npm i -g npm@8.5.3
       - cache restore
       - cache restore $_PACKAGES_CACHE-packages-$SEMAPHORE_GIT_SHA-v$NODE_VERSION
       - mono bootstrap --ci
@@ -381,7 +376,6 @@ blocks:
       value: '14'
     prologue:
       commands:
-      - npm i -g npm@8.5.3
       - cache restore
       - mono bootstrap --ci
       - cache store
@@ -405,7 +399,6 @@ blocks:
       value: 'false'
     prologue:
       commands:
-      - npm i -g npm@8.5.3
       - cache restore
       - cache restore $_PACKAGES_CACHE-packages-$SEMAPHORE_GIT_SHA-v$NODE_VERSION
       - mono bootstrap --ci

--- a/build_matrix.yml
+++ b/build_matrix.yml
@@ -22,6 +22,7 @@ semaphore: # Default `.semaphore/semaphore.yml` contents
       commands:
         - checkout
         - "[ -n \"$NODE_VERSION\" ] && sem-version node $NODE_VERSION || echo Skipping Node.js install"
+        -  npm i -g npm@latest
 
         # Mono setup
         - script/setup
@@ -49,7 +50,7 @@ semaphore: # Default `.semaphore/semaphore.yml` contents
         - name: Node.js Lint (Prettier)
           env_vars:
             - name: NODE_VERSION
-              value: "16"
+              value: "18"
           commands:
             - cache restore
             - mono bootstrap --ci
@@ -67,12 +68,6 @@ matrix:
 
   nodejs:
     - nodejs: "18"
-      setup:
-        # Use NPM version 8.5.3 to work around a bug when using NPM 8.5.4 or
-        # higher, where commands that are ran at the root of the workspace
-        # do not trigger lifecycle hooks for the workspace packages.
-        # https://github.com/npm/cli/issues/4552
-        - &npm853 npm i -g npm@8.5.3
       env_vars:
         # Set `NODE_OPTIONS` to `--openssl-legacy-provider`, as a workaround
         # for this `webpack` bug affecting the `@appsignal/nextjs` tests
@@ -82,8 +77,6 @@ matrix:
         - name: NODE_OPTIONS
           value: "--openssl-legacy-provider"
     - nodejs: "17"
-      setup:
-        - *npm853
       env_vars:
         # Set `NODE_OPTIONS` to `--openssl-legacy-provider`, as a workaround
         # for this `webpack` bug affecting the `@appsignal/nextjs` tests
@@ -93,11 +86,7 @@ matrix:
         - name: NODE_OPTIONS
           value: "--openssl-legacy-provider"
     - nodejs: "16"
-      setup:
-        - *npm853
     - nodejs: "14"
-      setup:
-        - *npm853
   packages:
     - package: "@appsignal/nodejs"
       path: "packages/nodejs"


### PR DESCRIPTION
Due to an issue with workspace commands in NPM 8.5.4, we had to force
usage of NPM 8.5.3 in the builds. They fixed it so we don't need to do
it anymore and safely use latest Node and NPM versions.

[skip changeset]