### PR TITLE
Bump agent to v-0b43802

### DIFF
--- a/packages/nodejs/.changesets/bump-agent-to-v-0b43802.md
+++ b/packages/nodejs/.changesets/bump-agent-to-v-0b43802.md
@@ -1,0 +1,8 @@
+---
+bump: "patch"
+type: "change"
+---
+
+Bump agent to v-0b43802.
+
+- Add redis and ioredis OpenTelemetry instrumentation support.

--- a/packages/nodejs/scripts/extension/support/constants.js
+++ b/packages/nodejs/scripts/extension/support/constants.js
@@ -3,7 +3,7 @@
 // appsignal-agent repository.
 // Modifications to this file will be overwritten with the next agent release.
 
-const AGENT_VERSION = "be3107a"
+const AGENT_VERSION = "0b43802"
 const MIRRORS = [
   "https://appsignal-agent-releases.global.ssl.fastly.net",
   "https://d135dj0rjqvssy.cloudfront.net"
@@ -12,62 +12,62 @@ const MIRRORS = [
 const TRIPLES = {
   "x86_64-darwin": {
     checksum:
-      "31b13af931f26832eb9b5f3283a0dcfc83e327a31570aef47704589de5bd54cc",
+      "229263d5e1b5b305965e36ace1868a6e4e397f35c234d0f28ba342b329b5b95b",
     filename: "appsignal-x86_64-darwin-all-static.tar.gz"
   },
   "universal-darwin": {
     checksum:
-      "31b13af931f26832eb9b5f3283a0dcfc83e327a31570aef47704589de5bd54cc",
+      "229263d5e1b5b305965e36ace1868a6e4e397f35c234d0f28ba342b329b5b95b",
     filename: "appsignal-x86_64-darwin-all-static.tar.gz"
   },
   "aarch64-darwin": {
     checksum:
-      "902649453b5cfe86dee86f053a7dbe7df35bc8bce0b9632bd5619a8c824f02af",
+      "6ecffecea27f0c367afef8d060c30657332ae9fc68748099dbb8ffeca69ab295",
     filename: "appsignal-aarch64-darwin-all-static.tar.gz"
   },
   "arm64-darwin": {
     checksum:
-      "902649453b5cfe86dee86f053a7dbe7df35bc8bce0b9632bd5619a8c824f02af",
+      "6ecffecea27f0c367afef8d060c30657332ae9fc68748099dbb8ffeca69ab295",
     filename: "appsignal-aarch64-darwin-all-static.tar.gz"
   },
   "arm-darwin": {
     checksum:
-      "902649453b5cfe86dee86f053a7dbe7df35bc8bce0b9632bd5619a8c824f02af",
+      "6ecffecea27f0c367afef8d060c30657332ae9fc68748099dbb8ffeca69ab295",
     filename: "appsignal-aarch64-darwin-all-static.tar.gz"
   },
   "aarch64-linux": {
     checksum:
-      "37819d1df9b516d39a3aaf54bcc434f7d77e0067d75a86fff8c89be24cf16c28",
+      "cb9d94d4f81479076d3b8995eb27be4302cbd521a50acefa2373d060877f7872",
     filename: "appsignal-aarch64-linux-all-static.tar.gz"
   },
   "i686-linux": {
     checksum:
-      "c372daebb69e9795c8dcd60f48cad2af66628e1e3c8211f00526bdc8c880fc97",
+      "12268b3412ee76985cccbc8c7f1fe7409379f3cda339cf1c2aee9df7bc976109",
     filename: "appsignal-i686-linux-all-static.tar.gz"
   },
   "x86-linux": {
     checksum:
-      "c372daebb69e9795c8dcd60f48cad2af66628e1e3c8211f00526bdc8c880fc97",
+      "12268b3412ee76985cccbc8c7f1fe7409379f3cda339cf1c2aee9df7bc976109",
     filename: "appsignal-i686-linux-all-static.tar.gz"
   },
   "x86_64-linux": {
     checksum:
-      "972a8b02061d747fbe35f3dd8d3d5b7c34bf7a6a38d0526d0ff55b9e70b67f13",
+      "c79c754057275872bec6191ad977232ffeb4ce6de862d5acf3235e2793d95e09",
     filename: "appsignal-x86_64-linux-all-static.tar.gz"
   },
   "x86_64-linux-musl": {
     checksum:
-      "4821b9d4e9b4501a5002f731b633a64b3991272fb0e6e57a61ce1e2a0b33bcad",
+      "83374043076793ee126d229252e9dbd32e3bbbab0d2f4644adb5b15fc17ccdb8",
     filename: "appsignal-x86_64-linux-musl-all-static.tar.gz"
   },
   "x86_64-freebsd": {
     checksum:
-      "2b8ff925dd40daab892cf66ad3fefb72559cab57433907d8f70ae41722716832",
+      "c2a3c4cd066fd6098ae2ba7cb99db5fc83bb2d0eedcfdd4cd5a0282c344db58d",
     filename: "appsignal-x86_64-freebsd-all-static.tar.gz"
   },
   "amd64-freebsd": {
     checksum:
-      "2b8ff925dd40daab892cf66ad3fefb72559cab57433907d8f70ae41722716832",
+      "c2a3c4cd066fd6098ae2ba7cb99db5fc83bb2d0eedcfdd4cd5a0282c344db58d",
     filename: "appsignal-x86_64-freebsd-all-static.tar.gz"
   }
 }


### PR DESCRIPTION
- Add redis and ioredis OpenTelemetry instrumentation support.

[skip review]