### PR TITLE
Remove AppSignal requirement for SpanProcessor

### DIFF
--- a/packages/nodejs/.changesets/support-opentelemetry-root-spans-in-spanprocessor.md
+++ b/packages/nodejs/.changesets/support-opentelemetry-root-spans-in-spanprocessor.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "change"
+---
+
+Support OpenTelemetry root spans in SpanProcessor. This change makes AppSignal instrumentation (like Express/Koa.js/Next.js) no longer a requirement. In fact you will need to use the OpenTelemetry instrumentation for those libraries from now on.

--- a/packages/nodejs/src/span_processor.ts
+++ b/packages/nodejs/src/span_processor.ts
@@ -5,7 +5,6 @@ import {
   SpanProcessor as OpenTelemetrySpanProcessor
 } from "./interfaces/span_processor"
 import { BaseClient as Client } from "./client"
-import { NoopSpan } from "./noops"
 
 export class SpanProcessor implements OpenTelemetrySpanProcessor {
   client: Client
@@ -22,22 +21,18 @@ export class SpanProcessor implements OpenTelemetrySpanProcessor {
   onStart(_span: Span, _parentContext: Context): void {}
 
   onEnd(span: ReadableSpan): void {
-    const appsignalSpan = this.client.tracer().currentSpan()
-
-    if (!(appsignalSpan instanceof NoopSpan)) {
-      this.client.extension.importOpenTelemetrySpan(
-        span.spanContext().spanId,
-        appsignalSpan.spanId,
-        appsignalSpan.traceId,
-        span.startTime[0],
-        span.startTime[1],
-        span.endTime[0],
-        span.endTime[1],
-        span.name,
-        span.attributes,
-        span.instrumentationLibrary.name
-      )
-    }
+    this.client.extension.importOpenTelemetrySpan(
+      span.spanContext().spanId,
+      span.parentSpanId || "",
+      span.spanContext().traceId,
+      span.startTime[0],
+      span.startTime[1],
+      span.endTime[0],
+      span.endTime[1],
+      span.name,
+      span.attributes,
+      span.instrumentationLibrary.name
+    )
   }
 
   shutdown(): Promise<void> {


### PR DESCRIPTION
Previously the SpanProcessor only worked with AppSignal root spans. With
this change it will use the OpenTelemetry parent span if no currently
active AppSignal span is found.

When not using the AppSignal instrumentations to create root spans,
we'll rely on the OpenTelemetry instrumentations to create root spans
instead.

To test the SpanProcessor, I've copied the OpenTelemetry getReadableSpan
function from their zipkin test.
https://github.com/open-telemetry/opentelemetry-js/blob/82e39c470a8f2767e095624497ed351745ad919e/packages/opentelemetry-exporter-zipkin/test/node/zipkin.test.ts#L34-L61

Part of https://github.com/appsignal/opentelemetry/issues/14
Requires https://github.com/appsignal/appsignal-nodejs/pull/672 to fix
the reported current span by AppSignal to not be a closed span.

---

🚨 This should not be merged before ~https://github.com/appsignal/appsignal-agent/pull/762 and~ the [updates to our docs](https://github.com/appsignal/opentelemetry/issues/24).