### PR TITLE
Lock apollo-server package versions in CI

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -117,19 +117,19 @@ blocks:
       - LANGUAGE=nodejs test/integration/diagnose/bin/test
     - name: "@appsignal/apollo-server - apollo-server@latest - integrations"
       commands:
-      - script/install_test_example_packages apollo-server apollo-server-plugin-base@latest
+      - script/install_test_example_packages apollo-server apollo-server@latest apollo-server-plugin-base@latest
+      - script/test_package_integration apollo-server
+    - name: "@appsignal/apollo-server - apollo-server@3.6.0 - integrations"
+      commands:
+      - script/install_test_example_packages apollo-server apollo-server@3.6.0 apollo-server-plugin-base@3.5.0
+      - script/test_package_integration apollo-server
+    - name: "@appsignal/apollo-server - apollo-server@3.5.0 - integrations"
+      commands:
+      - script/install_test_example_packages apollo-server apollo-server@3.5.0 apollo-server-plugin-base@3.4.0
       - script/test_package_integration apollo-server
     - name: "@appsignal/apollo-server - apollo-server@3.4.0 - integrations"
       commands:
-      - script/install_test_example_packages apollo-server apollo-server-plugin-base@3.4.0
-      - script/test_package_integration apollo-server
-    - name: "@appsignal/apollo-server - apollo-server@3.3.0 - integrations"
-      commands:
-      - script/install_test_example_packages apollo-server apollo-server-plugin-base@3.3.0
-      - script/test_package_integration apollo-server
-    - name: "@appsignal/apollo-server - apollo-server@3.2.0 - integrations"
-      commands:
-      - script/install_test_example_packages apollo-server apollo-server-plugin-base@3.2.0
+      - script/install_test_example_packages apollo-server apollo-server@3.4.0 apollo-server-plugin-base@3.3.0
       - script/test_package_integration apollo-server
     - name: "@appsignal/express - express@latest - integrations"
       commands:
@@ -219,19 +219,19 @@ blocks:
       - LANGUAGE=nodejs test/integration/diagnose/bin/test
     - name: "@appsignal/apollo-server - apollo-server@latest - integrations"
       commands:
-      - script/install_test_example_packages apollo-server apollo-server-plugin-base@latest
+      - script/install_test_example_packages apollo-server apollo-server@latest apollo-server-plugin-base@latest
+      - script/test_package_integration apollo-server
+    - name: "@appsignal/apollo-server - apollo-server@3.6.0 - integrations"
+      commands:
+      - script/install_test_example_packages apollo-server apollo-server@3.6.0 apollo-server-plugin-base@3.5.0
+      - script/test_package_integration apollo-server
+    - name: "@appsignal/apollo-server - apollo-server@3.5.0 - integrations"
+      commands:
+      - script/install_test_example_packages apollo-server apollo-server@3.5.0 apollo-server-plugin-base@3.4.0
       - script/test_package_integration apollo-server
     - name: "@appsignal/apollo-server - apollo-server@3.4.0 - integrations"
       commands:
-      - script/install_test_example_packages apollo-server apollo-server-plugin-base@3.4.0
-      - script/test_package_integration apollo-server
-    - name: "@appsignal/apollo-server - apollo-server@3.3.0 - integrations"
-      commands:
-      - script/install_test_example_packages apollo-server apollo-server-plugin-base@3.3.0
-      - script/test_package_integration apollo-server
-    - name: "@appsignal/apollo-server - apollo-server@3.2.0 - integrations"
-      commands:
-      - script/install_test_example_packages apollo-server apollo-server-plugin-base@3.2.0
+      - script/install_test_example_packages apollo-server apollo-server@3.4.0 apollo-server-plugin-base@3.3.0
       - script/test_package_integration apollo-server
     - name: "@appsignal/express - express@latest - integrations"
       commands:
@@ -317,19 +317,19 @@ blocks:
       - LANGUAGE=nodejs test/integration/diagnose/bin/test
     - name: "@appsignal/apollo-server - apollo-server@latest - integrations"
       commands:
-      - script/install_test_example_packages apollo-server apollo-server-plugin-base@latest
+      - script/install_test_example_packages apollo-server apollo-server@latest apollo-server-plugin-base@latest
+      - script/test_package_integration apollo-server
+    - name: "@appsignal/apollo-server - apollo-server@3.6.0 - integrations"
+      commands:
+      - script/install_test_example_packages apollo-server apollo-server@3.6.0 apollo-server-plugin-base@3.5.0
+      - script/test_package_integration apollo-server
+    - name: "@appsignal/apollo-server - apollo-server@3.5.0 - integrations"
+      commands:
+      - script/install_test_example_packages apollo-server apollo-server@3.5.0 apollo-server-plugin-base@3.4.0
       - script/test_package_integration apollo-server
     - name: "@appsignal/apollo-server - apollo-server@3.4.0 - integrations"
       commands:
-      - script/install_test_example_packages apollo-server apollo-server-plugin-base@3.4.0
-      - script/test_package_integration apollo-server
-    - name: "@appsignal/apollo-server - apollo-server@3.3.0 - integrations"
-      commands:
-      - script/install_test_example_packages apollo-server apollo-server-plugin-base@3.3.0
-      - script/test_package_integration apollo-server
-    - name: "@appsignal/apollo-server - apollo-server@3.2.0 - integrations"
-      commands:
-      - script/install_test_example_packages apollo-server apollo-server-plugin-base@3.2.0
+      - script/install_test_example_packages apollo-server apollo-server@3.4.0 apollo-server-plugin-base@3.3.0
       - script/test_package_integration apollo-server
     - name: "@appsignal/express - express@latest - integrations"
       commands:
@@ -415,19 +415,19 @@ blocks:
       - LANGUAGE=nodejs test/integration/diagnose/bin/test
     - name: "@appsignal/apollo-server - apollo-server@latest - integrations"
       commands:
-      - script/install_test_example_packages apollo-server apollo-server-plugin-base@latest
+      - script/install_test_example_packages apollo-server apollo-server@latest apollo-server-plugin-base@latest
+      - script/test_package_integration apollo-server
+    - name: "@appsignal/apollo-server - apollo-server@3.6.0 - integrations"
+      commands:
+      - script/install_test_example_packages apollo-server apollo-server@3.6.0 apollo-server-plugin-base@3.5.0
+      - script/test_package_integration apollo-server
+    - name: "@appsignal/apollo-server - apollo-server@3.5.0 - integrations"
+      commands:
+      - script/install_test_example_packages apollo-server apollo-server@3.5.0 apollo-server-plugin-base@3.4.0
       - script/test_package_integration apollo-server
     - name: "@appsignal/apollo-server - apollo-server@3.4.0 - integrations"
       commands:
-      - script/install_test_example_packages apollo-server apollo-server-plugin-base@3.4.0
-      - script/test_package_integration apollo-server
-    - name: "@appsignal/apollo-server - apollo-server@3.3.0 - integrations"
-      commands:
-      - script/install_test_example_packages apollo-server apollo-server-plugin-base@3.3.0
-      - script/test_package_integration apollo-server
-    - name: "@appsignal/apollo-server - apollo-server@3.2.0 - integrations"
-      commands:
-      - script/install_test_example_packages apollo-server apollo-server-plugin-base@3.2.0
+      - script/install_test_example_packages apollo-server apollo-server@3.4.0 apollo-server-plugin-base@3.3.0
       - script/test_package_integration apollo-server
     - name: "@appsignal/express - express@latest - integrations"
       commands:

--- a/build_matrix.yml
+++ b/build_matrix.yml
@@ -105,16 +105,20 @@ matrix:
       variations:
         - name: "apollo-server@latest"
           packages:
+            apollo-server: "latest"
             apollo-server-plugin-base: "latest"
+        - name: "apollo-server@3.6.0"
+          packages:
+            apollo-server: "3.6.0"
+            apollo-server-plugin-base: "3.5.0"
+        - name: "apollo-server@3.5.0"
+          packages:
+            apollo-server: "3.5.0"
+            apollo-server-plugin-base: "3.4.0"
         - name: "apollo-server@3.4.0"
           packages:
-            apollo-server-plugin-base: "3.4.0"
-        - name: "apollo-server@3.3.0"
-          packages:
+            apollo-server: "3.4.0"
             apollo-server-plugin-base: "3.3.0"
-        - name: "apollo-server@3.2.0"
-          packages:
-            apollo-server-plugin-base: "3.2.0"
       extra_tests:
         integrations:
           - script/test_package_integration apollo-server


### PR DESCRIPTION
Make sure that the apollo-server package uses the same version as the
apollo-server-plugin-base package.

The apollo-server package is configured as matching any version (`*`) in
the test app's `package.json`. This should install the right version.

The apollo-server and apollo-server-plugin-base packages do not follow
the same release scheme so that's why the versions do not appear to
match.

I've also updated the versions against we test to be the last three
ones, except the 3.8 release (3.7 was skipped).

Related issue https://github.com/apollographql/apollo-server/issues/6469
[skip changeset]