### PR TITLE
Test against apollo-server 3.8

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -119,6 +119,10 @@ blocks:
       commands:
       - script/install_test_example_packages apollo-server apollo-server@latest apollo-server-plugin-base@latest
       - script/test_package_integration apollo-server
+    - name: "@appsignal/apollo-server - apollo-server@3.8.1 - integrations"
+      commands:
+      - script/install_test_example_packages apollo-server apollo-server@3.8.1 apollo-server-plugin-base@3.6.0
+      - script/test_package_integration apollo-server
     - name: "@appsignal/apollo-server - apollo-server@3.6.0 - integrations"
       commands:
       - script/install_test_example_packages apollo-server apollo-server@3.6.0 apollo-server-plugin-base@3.5.0
@@ -126,10 +130,6 @@ blocks:
     - name: "@appsignal/apollo-server - apollo-server@3.5.0 - integrations"
       commands:
       - script/install_test_example_packages apollo-server apollo-server@3.5.0 apollo-server-plugin-base@3.4.0
-      - script/test_package_integration apollo-server
-    - name: "@appsignal/apollo-server - apollo-server@3.4.0 - integrations"
-      commands:
-      - script/install_test_example_packages apollo-server apollo-server@3.4.0 apollo-server-plugin-base@3.3.0
       - script/test_package_integration apollo-server
     - name: "@appsignal/express - express@latest - integrations"
       commands:
@@ -221,6 +221,10 @@ blocks:
       commands:
       - script/install_test_example_packages apollo-server apollo-server@latest apollo-server-plugin-base@latest
       - script/test_package_integration apollo-server
+    - name: "@appsignal/apollo-server - apollo-server@3.8.1 - integrations"
+      commands:
+      - script/install_test_example_packages apollo-server apollo-server@3.8.1 apollo-server-plugin-base@3.6.0
+      - script/test_package_integration apollo-server
     - name: "@appsignal/apollo-server - apollo-server@3.6.0 - integrations"
       commands:
       - script/install_test_example_packages apollo-server apollo-server@3.6.0 apollo-server-plugin-base@3.5.0
@@ -228,10 +232,6 @@ blocks:
     - name: "@appsignal/apollo-server - apollo-server@3.5.0 - integrations"
       commands:
       - script/install_test_example_packages apollo-server apollo-server@3.5.0 apollo-server-plugin-base@3.4.0
-      - script/test_package_integration apollo-server
-    - name: "@appsignal/apollo-server - apollo-server@3.4.0 - integrations"
-      commands:
-      - script/install_test_example_packages apollo-server apollo-server@3.4.0 apollo-server-plugin-base@3.3.0
       - script/test_package_integration apollo-server
     - name: "@appsignal/express - express@latest - integrations"
       commands:
@@ -319,6 +319,10 @@ blocks:
       commands:
       - script/install_test_example_packages apollo-server apollo-server@latest apollo-server-plugin-base@latest
       - script/test_package_integration apollo-server
+    - name: "@appsignal/apollo-server - apollo-server@3.8.1 - integrations"
+      commands:
+      - script/install_test_example_packages apollo-server apollo-server@3.8.1 apollo-server-plugin-base@3.6.0
+      - script/test_package_integration apollo-server
     - name: "@appsignal/apollo-server - apollo-server@3.6.0 - integrations"
       commands:
       - script/install_test_example_packages apollo-server apollo-server@3.6.0 apollo-server-plugin-base@3.5.0
@@ -326,10 +330,6 @@ blocks:
     - name: "@appsignal/apollo-server - apollo-server@3.5.0 - integrations"
       commands:
       - script/install_test_example_packages apollo-server apollo-server@3.5.0 apollo-server-plugin-base@3.4.0
-      - script/test_package_integration apollo-server
-    - name: "@appsignal/apollo-server - apollo-server@3.4.0 - integrations"
-      commands:
-      - script/install_test_example_packages apollo-server apollo-server@3.4.0 apollo-server-plugin-base@3.3.0
       - script/test_package_integration apollo-server
     - name: "@appsignal/express - express@latest - integrations"
       commands:
@@ -417,6 +417,10 @@ blocks:
       commands:
       - script/install_test_example_packages apollo-server apollo-server@latest apollo-server-plugin-base@latest
       - script/test_package_integration apollo-server
+    - name: "@appsignal/apollo-server - apollo-server@3.8.1 - integrations"
+      commands:
+      - script/install_test_example_packages apollo-server apollo-server@3.8.1 apollo-server-plugin-base@3.6.0
+      - script/test_package_integration apollo-server
     - name: "@appsignal/apollo-server - apollo-server@3.6.0 - integrations"
       commands:
       - script/install_test_example_packages apollo-server apollo-server@3.6.0 apollo-server-plugin-base@3.5.0
@@ -424,10 +428,6 @@ blocks:
     - name: "@appsignal/apollo-server - apollo-server@3.5.0 - integrations"
       commands:
       - script/install_test_example_packages apollo-server apollo-server@3.5.0 apollo-server-plugin-base@3.4.0
-      - script/test_package_integration apollo-server
-    - name: "@appsignal/apollo-server - apollo-server@3.4.0 - integrations"
-      commands:
-      - script/install_test_example_packages apollo-server apollo-server@3.4.0 apollo-server-plugin-base@3.3.0
       - script/test_package_integration apollo-server
     - name: "@appsignal/express - express@latest - integrations"
       commands:

--- a/build_matrix.yml
+++ b/build_matrix.yml
@@ -107,6 +107,10 @@ matrix:
           packages:
             apollo-server: "latest"
             apollo-server-plugin-base: "latest"
+        - name: "apollo-server@3.8.1"
+          packages:
+            apollo-server: "3.8.1"
+            apollo-server-plugin-base: "3.6.0"
         - name: "apollo-server@3.6.0"
           packages:
             apollo-server: "3.6.0"
@@ -115,10 +119,6 @@ matrix:
           packages:
             apollo-server: "3.5.0"
             apollo-server-plugin-base: "3.4.0"
-        - name: "apollo-server@3.4.0"
-          packages:
-            apollo-server: "3.4.0"
-            apollo-server-plugin-base: "3.3.0"
       extra_tests:
         integrations:
           - script/test_package_integration apollo-server


### PR DESCRIPTION
Now that the published packages have been fixed for apollo-server and
apollo-server-plugin-base, add a job for the latest 3.8 release.

Remove the older 3.4 version so that we only test the 3 latest versions.

[skip changeset]
[skip review]