### PR TITLE
Don't transfer closed spans to new async contexts

### DIFF
--- a/packages/nodejs/.changesets/do-not-transfer-closed-spans-for-new-async-contexts.md
+++ b/packages/nodejs/.changesets/do-not-transfer-closed-spans-for-new-async-contexts.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Do not transfer closed spans for new async contexts in the ScopeManager. Rather than relying on `ScopeManager.active()` and `ScopeManager.root()` to make sure the span is not already closed, also make sure it's not closed when transferring spans around between async contexts.

--- a/packages/nodejs/src/__tests__/scope.test.ts
+++ b/packages/nodejs/src/__tests__/scope.test.ts
@@ -60,6 +60,20 @@ describe("ScopeManager", () => {
         asyncTaskWithContext(scopeManager, span, () => scopeManager.active())
       ).resolves.toBe(span)
     })
+
+    it("doesn't return active span is span is closed", async () => {
+      scopeManager = new ScopeManager()
+      const span = new RootSpan()
+
+      scopeManager.enable()
+
+      span.close()
+      await expect(
+        asyncTaskWithContext(scopeManager, span, () => {
+          return scopeManager.active()
+        })
+      ).resolves.toBeUndefined()
+    })
   })
 
   describe(".disable()", () => {


### PR DESCRIPTION
This adds another level of protecting to using closed spans in any
context when returned by the ScopeManager.

It's really tricky to test this in isolation, because fetching the
active span, already performs the check. I can't check the private maps
of spans in the ScopeManager itself in the test. I've tested it by
temporarily removing the `&& span.open` check from
`ScopeManager.active()` which confirmed it works.

Closes #674