### PR TITLE
Ignore HTTP requests to socket.io

### DIFF
--- a/packages/nodejs/.changesets/ignore-http-requests-to-socket-io.md
+++ b/packages/nodejs/.changesets/ignore-http-requests-to-socket-io.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Do not instrument HTTP requests to the default socket.io path. This works around an issue where our HTTP instrumentation breaks socket.io's server side, causing the client side to get stuck in a connection loop.

--- a/packages/nodejs/src/instrumentation/http/lifecycle/incoming.ts
+++ b/packages/nodejs/src/instrumentation/http/lifecycle/incoming.ts
@@ -20,7 +20,9 @@ const DEFAULT_IGNORED_URLS = [
   // gatsby hot reloading
   /(\/__webpack_hmr)/i,
   // next.js integration web vitals endpoint
-  /(\/__appsignal-web-vitals)$/i
+  /(\/__appsignal-web-vitals)$/i,
+  // socket.io default path
+  /^(\/socket.io)/i
 ]
 
 function incomingRequest(


### PR DESCRIPTION
For some reason I haven't quite managed to understand in full, our HTTP instrumentation breaks socket.io by wrapping one of the event callbacks in the request object. It is unclear why wrapping it breaks it -- you can read more about it on [this comment for the related support issue][descent-into-madness].

This commit adds the default path used by the server-side socket.io library to the list of ignored paths in the HTTP instrumentation. While this does not address the underlying issue, it will hopefully side-step it for most socket.io users.

[descent-into-madness]: https://github.com/appsignal/support/issues/173#issuecomment-1142512153

Closes appsignal/support#173, I think. Let me know if you don't agree with closing it from this fix alone.