### PR TITLE
Fix removing wrapped event listeners

### DIFF
--- a/packages/nodejs/.changesets/fix-removing-event-listeners-from-wrapped-event-emitters.md
+++ b/packages/nodejs/.changesets/fix-removing-event-listeners-from-wrapped-event-emitters.md
@@ -1,0 +1,8 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Fix removing event listeners from wrapped event emitters. When using
+`tracer.wrapEmitter` to wrap an event emitter, it was not possible to remove
+any listeners that were added after the event emitter was wrapped.

--- a/packages/nodejs/src/__tests__/scope.test.ts
+++ b/packages/nodejs/src/__tests__/scope.test.ts
@@ -187,6 +187,16 @@ describe("ScopeManager", () => {
 
       fn()
     })
+
+    it("inherits the given function's length and name", () => {
+      function add(x: number, y: number) {
+        return x + y
+      }
+      const boundFn = scopeManager.bindContext(add)
+
+      expect(boundFn.length).toEqual(2)
+      expect(boundFn.name).toEqual("add")
+    })
   })
 
   describe(".active()", () => {

--- a/packages/nodejs/src/scope.ts
+++ b/packages/nodejs/src/scope.ts
@@ -227,13 +227,15 @@ export class ScopeManager {
     // prevent re-wrapping
     contextWrapper[WRAPPED] = true
 
-    // explicitly inherit the original function's length, because it is
-    // otherwise zero-ed out
+    // explicitly inherit the original function's length and name
     Object.defineProperty(contextWrapper, "length", {
-      enumerable: false,
       configurable: true,
-      writable: false,
       value: fn.length
+    })
+
+    Object.defineProperty(contextWrapper, "name", {
+      configurable: true,
+      value: fn.name
     })
 
     return contextWrapper


### PR DESCRIPTION
### [Fix removing listeners in wrapped event emitters](https://github.com/appsignal/appsignal-nodejs/commit/2b812750a0a893f4d18cb8f3f8a9d8c6a30030e2)

The `.emitWithContext` function in the `ScopeManager`, which is called from the `.wrapEmitter` function in the `Tracer`, modifies a given `EventEmitter` so that the callbacks passed to it when registering a listener are bound to the active span of the asynchronous context in which the listener was registered. That is, calling `scopeManager.active()` or `tracer.currentSpan()` from the listener should return the span that was active at the point where the listener was registered. This is done by wrapping the callback in a function that closes over the current span, calling the original callback from within `scopeManager.withContext` with the closed over span, and registering this wrapper function as the callback for the event emitter's listener.

Since the callback that is registered for an event emitter's listener is a wrapper function over the callback, and not the original callback, future attempts to remove the listener from the event emitter silently fail, as the callback function that is passed to `.removeListener` is not the callback function that was originally registered.

This commit fixes this by keeping track of which wrapper functions were created for which events and callbacks, and modifying the given event emitter further, intercepting calls to methods that remove listeners and replacing the given callback with its previously created wrapper.

This commit also adds tests for the .emitWithContext function.

### [Copy original function name to wrapper](https://github.com/appsignal/appsignal-nodejs/commit/37e162c0cf065856262110b3ed0516453fe5e722)

When wrapping a function in `.bindContext`, the `length` property of the original function is copied over to the wrapper function.

This commit changes it so that, in addition to the `length` property, the `name` property is also copied.

Closes appsignal/support#173, for real this time.