### PR TITLE
Refactor scope internals

### DIFF
--- a/packages/nodejs/src/__tests__/scope.test.ts
+++ b/packages/nodejs/src/__tests__/scope.test.ts
@@ -109,6 +109,27 @@ describe("ScopeManager", () => {
     })
   })
 
+  describe(".root()", () => {
+    it("when root span is open, it returns the root span", () => {
+      const root = new RootSpan({ namespace: "root" })
+      scopeManager.setRoot(root)
+      expect(root.open).toBeTruthy()
+
+      const span = scopeManager.root()
+      expect(span).toBe(root)
+    })
+
+    it("when root span is closed, it returns undefined", () => {
+      const root = new RootSpan({ namespace: "root" })
+      scopeManager.setRoot(root)
+      root.close()
+      expect(root.open).toBeFalsy()
+
+      const span = scopeManager.root()
+      expect(span).toBeUndefined()
+    })
+  })
+
   describe(".withContext()", () => {
     it("runs the callback", () => {
       const fn = jest.fn()

--- a/packages/nodejs/src/__tests__/scope.test.ts
+++ b/packages/nodejs/src/__tests__/scope.test.ts
@@ -185,7 +185,7 @@ describe("ScopeManager", () => {
   })
 
   describe(".bindContext()", () => {
-    it("Propagates context to bound functions", () => {
+    it("propagates context to bound functions", () => {
       const test = new RootSpan({ namespace: "test" })
 
       let fn = () => {

--- a/packages/nodejs/src/scope.ts
+++ b/packages/nodejs/src/scope.ts
@@ -199,7 +199,7 @@ export class ScopeManager {
     }
 
     // capture the context of the current `AsyncResource`
-    const boundContext = this.#scopes.get(asyncHooks.executionAsyncId())
+    const boundContext = this.active()
 
     // return if there is no current context to bind
     if (!boundContext) {


### PR DESCRIPTION
Split off from #676 so it can be merged separately and merged already. PR #676 has two approvals so I'm merging this without review.

[skip review]
[skip changeset]

## Add tests for ScopeManager.root() function

These unit tests were missing, especially after the recent changes to
allow `root()` to only return open spans.

## Update bindContext to use internal helpers

Don't do the whole `this.#scopes.get(asyncHooks.executionAsyncId())` if
we can simply call `this.active()`.
