### PR TITLE
Check if spans are open in the ScopeManager before setting as root or active

### DIFF
--- a/packages/nodejs/.changesets/do-not-restore-closed-spans-from-within-withspan.md
+++ b/packages/nodejs/.changesets/do-not-restore-closed-spans-from-within-withspan.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "change"
+---
+
+Do not restore closed spans from within the `withSpan` helper. If a previously active span gets closed while `withSpan` has another span as currently active, do not restore the closed span when the callback has finished.

--- a/packages/nodejs/.changesets/do-not-restore-root-span-after-withcontext-callback-has-finished.md
+++ b/packages/nodejs/.changesets/do-not-restore-root-span-after-withcontext-callback-has-finished.md
@@ -1,0 +1,16 @@
+---
+bump: "patch"
+type: "change"
+---
+
+Do not restore root span after `withSpan` callback has finished. Previously the root span was restored to the original root span before the `withSpan` helper was called. This has been changed, because the `withSpan` helper is only about changing the active span, not the root span. If a new root span has been set within a `withSpan` helper callback, the root span will no longer be restored. We recommend setting a new root span before calling `withSpan` instead.
+
+```js
+const rootSpan = tracer.rootSpan()
+const span = tracer.createSpan(...)
+tracer.withSpan(span, function(span) {
+  tracer.createRootSpan(...)
+});
+// No longer match
+rootSpan != tracer.rootSpan()
+```

--- a/packages/nodejs/.changesets/don-t-return-closed-spans-in-withcontext-helper.md
+++ b/packages/nodejs/.changesets/don-t-return-closed-spans-in-withcontext-helper.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Don't return closed spans in `withSpan` helper. If a closed span was given to the `witSpan` helper it would temporarily overwrite the context with a closed span that cannot be modified. Instead it will return the current active span, if any. If no span was active it will return a `NoopSpan`.

--- a/packages/nodejs/.changesets/only-allow-open-root-spans-to-be-set-as-root.md
+++ b/packages/nodejs/.changesets/only-allow-open-root-spans-to-be-set-as-root.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Only allow open root spans to be set as root. This avoids closed root spans to be reused in child contexts.

--- a/packages/nodejs/src/__tests__/scope.test.ts
+++ b/packages/nodejs/src/__tests__/scope.test.ts
@@ -145,14 +145,22 @@ describe("ScopeManager", () => {
       expect(fn).toBeCalled()
     })
 
-    it("rethrows errors", () => {
+    it("stores and rethrows errors", () => {
+      const rootSpan = new RootSpan()
+      scopeManager.setRoot(rootSpan)
+      const span = new ChildSpan(rootSpan)
       const err = new Error("This should be rethrown")
 
       expect(() =>
-        scopeManager.withContext(new RootSpan(), () => {
+        scopeManager.withContext(span, () => {
           throw err
         })
       ).toThrow(err)
+      expect(rootSpan.toObject().error).toEqual({
+        name: "Error",
+        message: "This should be rethrown",
+        backtrace: expect.any(String)
+      })
     })
 
     it("sets the given span as the active span", () => {

--- a/packages/nodejs/src/__tests__/scope.test.ts
+++ b/packages/nodejs/src/__tests__/scope.test.ts
@@ -108,6 +108,18 @@ describe("ScopeManager", () => {
       expect(scopeManager.root()).toBe(span)
       expect(scopeManager.active()).toBe(span)
     })
+
+    it("when root span is closed, it doesn't overwrite the root span", () => {
+      const span1 = new RootSpan()
+      scopeManager.setRoot(span1)
+
+      const span2 = new RootSpan()
+      span2.close()
+      scopeManager.setRoot(span2)
+
+      expect(scopeManager.root()).toBe(span1)
+      expect(scopeManager.active()).toBe(span1)
+    })
   })
 
   describe(".root()", () => {

--- a/packages/nodejs/src/__tests__/scope.test.ts
+++ b/packages/nodejs/src/__tests__/scope.test.ts
@@ -253,6 +253,26 @@ describe("ScopeManager", () => {
       expect(scopeManager.active()).toBe(outerRootSpan)
       expect(scopeManager.root()).toBe(innerRootSpan)
     })
+
+    it("does not restore the active span if it is closed", () => {
+      const rootSpan = new RootSpan()
+      const activeSpan1 = new ChildSpan(rootSpan)
+      const activeSpan2 = new ChildSpan(rootSpan)
+
+      scopeManager.setRoot(rootSpan)
+      expect(scopeManager.active()).toBe(rootSpan)
+
+      scopeManager.withContext(activeSpan1, () => {
+        expect(scopeManager.active()).toBe(activeSpan1)
+        scopeManager.withContext(activeSpan2, () => {
+          activeSpan1.close()
+          expect(scopeManager.active()).toBe(activeSpan2)
+        })
+        expect(scopeManager.active()).toBeUndefined()
+      })
+
+      expect(scopeManager.active()).toBe(rootSpan)
+    })
   })
 
   describe(".bindContext()", () => {

--- a/packages/nodejs/src/scope.ts
+++ b/packages/nodejs/src/scope.ts
@@ -177,8 +177,8 @@ export class ScopeManager {
    */
   public withContext<T>(span: Span, fn: (s: Span) => T): T {
     const uid = asyncHooks.executionAsyncId()
-    const oldScope = this.#scopes.get(uid)
-    const rootSpan = this.#roots.get(uid)
+    const oldScope = this.active()
+    const rootSpan = this.root()
 
     this.#scopes.set(uid, span)
 

--- a/packages/nodejs/src/scope.ts
+++ b/packages/nodejs/src/scope.ts
@@ -13,6 +13,7 @@ import { Span } from "./interfaces/span"
 import * as asyncHooks from "async_hooks"
 import { EventEmitter } from "events"
 import shimmer from "shimmer"
+import { NoopSpan } from "./noops/span"
 
 // A list of well-known EventEmitter methods that add event listeners.
 const EVENT_EMITTER_ADD_METHODS: Array<keyof EventEmitter> = [
@@ -182,7 +183,11 @@ export class ScopeManager {
     const oldScope = this.active()
     const rootSpan = this.root()
 
-    this.#scopes.set(uid, span)
+    if (span.open) {
+      this.#scopes.set(uid, span)
+    } else {
+      span = oldScope || new NoopSpan()
+    }
 
     try {
       return fn(span)

--- a/packages/nodejs/src/scope.ts
+++ b/packages/nodejs/src/scope.ts
@@ -194,10 +194,11 @@ export class ScopeManager {
       this.root()?.setError(err)
       throw err
     } finally {
-      // revert to the previous span
-      if (oldScope === undefined) {
-        this.#scopes.delete(uid)
-      } else {
+      // Unset the current active span so it doesn't leak outside this context
+      // in case there was no previous active span or it's no longer open.
+      this.#scopes.delete(uid)
+      if (oldScope && oldScope.open) {
+        // Revert the current active span
         this.#scopes.set(uid, oldScope)
       }
     }

--- a/packages/nodejs/src/scope.ts
+++ b/packages/nodejs/src/scope.ts
@@ -181,7 +181,6 @@ export class ScopeManager {
   public withContext<T>(span: Span, fn: (s: Span) => T): T {
     const uid = asyncHooks.executionAsyncId()
     const oldScope = this.active()
-    const rootSpan = this.root()
 
     if (span.open) {
       this.#scopes.set(uid, span)
@@ -192,15 +191,14 @@ export class ScopeManager {
     try {
       return fn(span)
     } catch (err) {
-      rootSpan?.setError(err)
+      this.root()?.setError(err)
       throw err
     } finally {
       // revert to the previous span
       if (oldScope === undefined) {
-        this.removeSpanForUid(uid)
+        this.#scopes.delete(uid)
       } else {
         this.#scopes.set(uid, oldScope)
-        this.#roots.set(uid, rootSpan)
       }
     }
   }

--- a/packages/nodejs/src/scope.ts
+++ b/packages/nodejs/src/scope.ts
@@ -140,9 +140,11 @@ export class ScopeManager {
    * Sets the root `Span`
    */
   public setRoot(rootSpan: Span) {
-    const uid = asyncHooks.executionAsyncId()
-    this.#roots.set(uid, rootSpan)
-    this.#scopes.set(uid, rootSpan)
+    if (rootSpan.open) {
+      const uid = asyncHooks.executionAsyncId()
+      this.#roots.set(uid, rootSpan)
+      this.#scopes.set(uid, rootSpan)
+    }
   }
 
   /*


### PR DESCRIPTION
Previous iteration of this PR was PR #676. Closed in favor of this more incremental change per commit with feedback addressed from that PR.

## Add assertion for storing error in withContext

The ScopeManager.withContext tests did not assert if the error that was
rethrown was also set on the root span or not.

## Reuse scope helpers to fetch active and root span

Do not reimplement fetching the root and active spans again in the
`withContext` function.

## Check if span is active when set as root

Use the `setRoot` function to set the root span. Make sure that when the
root span is set, it's still open. If it's not open, don't set it.
Setting a closed root span is a worse experience and may break things,
because it introduces a broken state.

## Don't set closed spans as active in withContext

When a span is given to `ScopeManager.withContext` check if it is is
open. If it's not don't set it as active. Instead pass in the already
currently active span, or a NoopSpan if no span is active.

This prevents the usage of closed spans, that cannot be used to store
any data after they are closed.

## Don't restore the root span for withContext

The ScopeManager.withContext only temporary sets the current active
span. It then restores the active span afterwards.

But it also restores the root span, even though that should not have
changed. At least not by anything we've done in this withContext
function.

If the user has set another rootSpan, that is their decision, but it's
not up to us to restore it.

## Don't restore active span if closed in withContext

When a span gets closed for whatever reason before getting restored in a
withContext callback, do not restore it. We do not restore closed spans
as active spans.

This is difficult to test, because the `active()` function also does
this check, but removing that check this test will still pass.

## Refactor ScopeManager to use internal helpers

Use internal helpers to set and unset the active span so that it doesn't
repeat this behavior in multiple places.
