### PR TITLE
Add OpenTelemetry wrapper client

### DIFF
--- a/packages/nodejs/.changesets/add-opentelemetry-client-wrapper-for-easy-setup.md
+++ b/packages/nodejs/.changesets/add-opentelemetry-client-wrapper-for-easy-setup.md
@@ -1,0 +1,25 @@
+---
+bump: "patch"
+type: "add"
+---
+
+Add an OpenTelemetry client wrapper for easy setup. This client preconfigures the Appsignal client for better compatibility with our OpenTelemetry integration. It disables the auto instrumentation from the AppSignal package in favor other of the OpenTelemetry instrumentation.
+
+If you previously have set up AppSignal like the example below, please change the import from `Appsignal` to `OpenTelemetryClient as Appsignal`:
+
+```js
+// appsignal.js
+// Remove this old import:
+// const { Appsignal } = require("@appsignal/nodejs")
+
+// Change the line to this import:
+const { AppsignalOpenTelemetry } = require("@appsignal/nodejs");
+
+// Update `Appsignal` to `AppsignalOpenTelemetry`:
+const appsignal = new AppsignalOpenTelemetry({
+  // Your config
+  // If this previously contained any of the following config options, remove them: instrumentHttp, instrumentRedis, instrumentPg
+});
+
+module.exports = { appsignal };
+```

--- a/packages/nodejs/src/__tests__/opentelemetry_client.test.ts
+++ b/packages/nodejs/src/__tests__/opentelemetry_client.test.ts
@@ -1,0 +1,37 @@
+import { OpenTelemetryClient as Client } from "../opentelemetry_client"
+
+jest.mock("../bootstrap", () => {
+  return {
+    initCorePlugins: jest.fn(() => {}),
+    initCoreProbes: jest.fn(() => {})
+  }
+})
+
+import { initCorePlugins } from "../bootstrap"
+
+describe("OpenTelemetryClient", () => {
+  const name = "TEST APP"
+  const pushApiKey = "TEST_API_KEY"
+  const DEFAULT_OPTS = { name, pushApiKey }
+  let client: Client
+
+  beforeEach(() => {
+    client = new Client({ ...DEFAULT_OPTS })
+  })
+
+  afterEach(() => {
+    client.stop()
+  })
+
+  it("does not activate auto instrumention", () => {
+    client.start()
+    expect(initCorePlugins).toHaveBeenCalledWith(expect.anything(), {
+      instrumentationConfig: {
+        http: false,
+        https: false,
+        redis: false,
+        pg: false
+      }
+    })
+  })
+})

--- a/packages/nodejs/src/index.ts
+++ b/packages/nodejs/src/index.ts
@@ -7,6 +7,7 @@
  */
 
 export { BaseClient as Appsignal } from "./client"
+export { OpenTelemetryClient as AppsignalOpenTelemetry } from "./opentelemetry_client"
 export { SpanProcessor } from "./span_processor"
 export { RedisDbStatementSerializer } from "./instrumentation/redis/opentelemetry"
 export { RedisDbStatementSerializer as IORedisDbStatementSerializer } from "./instrumentation/redis/opentelemetry"

--- a/packages/nodejs/src/opentelemetry_client.ts
+++ b/packages/nodejs/src/opentelemetry_client.ts
@@ -1,0 +1,21 @@
+import { AppsignalOptions } from "./interfaces"
+import { BaseClient } from "./client"
+
+/**
+ * AppSignal for Node.js's client for OpenTelemetry.
+ *
+ * This is a wrapper around the AppSignal main Client class, with defaults for
+ * OpenTelemetry.
+ *
+ * @class
+ */
+export class OpenTelemetryClient extends BaseClient {
+  constructor(options: Partial<AppsignalOptions> = {}) {
+    super({
+      instrumentRedis: false,
+      instrumentHttp: false,
+      instrumentPg: false,
+      ...options
+    })
+  }
+}


### PR DESCRIPTION
Hey team,

This is my alternative to what we discussed in the meeting this morning. I wasn't sure if it was understood what I meant so I figured I'd make the change and show it. Let's discuss the options that we have some time. I'd still like to see the alternative with another package.

## Add OpenTelemetry wrapper client

Add a client that disables the auto instrumentation when using this
package for OpenTelemetry. This inherits from the BaseClient but
provides the default instrumentation necessary for better OpenTelemetry
compatibility.

For the user this means they no longer need to configure the
`instrumentHttp`, `instrumentRedis` and `instrumentPg` options manually
anymore. We can update the docs to no longer mention them either for the
OpenTelemetry config. We do need to update the docs to use the new
OpenTelemetry client instead.

```js
// appsignal.js
const { AppsignalOpenTelemetry } = require("@appsignal/nodejs");

const appsignal = new AppsignalOpenTelemetry({
  // Your config
});

module.exports = { appsignal };
```

## Add tests for initCorePlugins in client test file

The client test did not test if the core plugins were called or not, so
I've added tests for it.
