### PR TITLE
Runtime dep @opentelemetry/sdk-trace-base package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1333,7 +1333,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.2.0.tgz",
       "integrity": "sha512-QiKp8fBbT9ZhRTP+ZVVMyqH62tD/ZQa4gWPi+GnpNetvK1SWPO/8DmRpaSXHwAhu5FWUDJrbFgpLsrDd1zGPOw==",
-      "dev": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "1.2.0"
       },
@@ -1348,7 +1347,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.2.0.tgz",
       "integrity": "sha512-S5ZlZa2JF+1qhiF7eb3tTtDfKmTODO//pvam9vEyZvr+/At45rIQ7cyznRdMWCppZbholwXWXnrKml29IIG9vQ==",
-      "dev": true,
       "dependencies": {
         "@opentelemetry/core": "1.2.0",
         "@opentelemetry/semantic-conventions": "1.2.0"
@@ -1364,7 +1362,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.2.0.tgz",
       "integrity": "sha512-eHrG9c9OhoDhUmMe63Qzgpcvlgxr2L7BFBbbj2DdZu3vGstayytTT6TDv6mz727lXBqR1HXMbqTGVafS07r3bg==",
-      "dev": true,
       "dependencies": {
         "@opentelemetry/core": "1.2.0",
         "@opentelemetry/resources": "1.2.0",
@@ -1381,7 +1378,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.2.0.tgz",
       "integrity": "sha512-BNKB9fiYVghALJzCuWO3eNYfdTExPVK4ykrtmfNfy0A6UWYhOYjGMXifUmkunDJNL8ju9tBobo8jF0WR9zGy1Q==",
-      "dev": true,
       "engines": {
         "node": ">=8.12.0"
       }
@@ -11191,6 +11187,7 @@
         "@appsignal/core": "^1.1.4",
         "@appsignal/types": "^3.0.0",
         "@opentelemetry/api": "^1.0.4",
+        "@opentelemetry/sdk-trace-base": "^1.2.0",
         "node-addon-api": "^3.1.0",
         "node-gyp": "^9.0.0",
         "require-in-the-middle": "^5.1.0",
@@ -11203,7 +11200,6 @@
         "appsignal-diagnose": "bin/diagnose"
       },
       "devDependencies": {
-        "@opentelemetry/sdk-trace-base": "^1.2.0",
         "@types/pg": "*",
         "@types/redis": "*",
         "@types/semver": "*",
@@ -12562,7 +12558,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.2.0.tgz",
       "integrity": "sha512-QiKp8fBbT9ZhRTP+ZVVMyqH62tD/ZQa4gWPi+GnpNetvK1SWPO/8DmRpaSXHwAhu5FWUDJrbFgpLsrDd1zGPOw==",
-      "dev": true,
       "requires": {
         "@opentelemetry/semantic-conventions": "1.2.0"
       }
@@ -12571,7 +12566,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.2.0.tgz",
       "integrity": "sha512-S5ZlZa2JF+1qhiF7eb3tTtDfKmTODO//pvam9vEyZvr+/At45rIQ7cyznRdMWCppZbholwXWXnrKml29IIG9vQ==",
-      "dev": true,
       "requires": {
         "@opentelemetry/core": "1.2.0",
         "@opentelemetry/semantic-conventions": "1.2.0"
@@ -12581,7 +12575,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.2.0.tgz",
       "integrity": "sha512-eHrG9c9OhoDhUmMe63Qzgpcvlgxr2L7BFBbbj2DdZu3vGstayytTT6TDv6mz727lXBqR1HXMbqTGVafS07r3bg==",
-      "dev": true,
       "requires": {
         "@opentelemetry/core": "1.2.0",
         "@opentelemetry/resources": "1.2.0",
@@ -12591,8 +12584,7 @@
     "@opentelemetry/semantic-conventions": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.2.0.tgz",
-      "integrity": "sha512-BNKB9fiYVghALJzCuWO3eNYfdTExPVK4ykrtmfNfy0A6UWYhOYjGMXifUmkunDJNL8ju9tBobo8jF0WR9zGy1Q==",
-      "dev": true
+      "integrity": "sha512-BNKB9fiYVghALJzCuWO3eNYfdTExPVK4ykrtmfNfy0A6UWYhOYjGMXifUmkunDJNL8ju9tBobo8jF0WR9zGy1Q=="
     },
     "@protobufjs/aspromise": {
       "version": "1.1.2",

--- a/packages/nodejs/.changesets/add-@opentelemetry-sdk-trace-base-runtime-dependency.md
+++ b/packages/nodejs/.changesets/add-@opentelemetry-sdk-trace-base-runtime-dependency.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Add `@opentelemetry/sdk-trace-base` package runtime dependency. Our OpenTelemetry SpanProcessor needs this package at runtime, not just at compile time.

--- a/packages/nodejs/package.json
+++ b/packages/nodejs/package.json
@@ -16,6 +16,7 @@
     "@appsignal/core": "^1.1.4",
     "@appsignal/types": "^3.0.0",
     "@opentelemetry/api": "^1.0.4",
+    "@opentelemetry/sdk-trace-base": "^1.2.0",
     "node-addon-api": "^3.1.0",
     "node-gyp": "^9.0.0",
     "require-in-the-middle": "^5.1.0",
@@ -30,8 +31,7 @@
     "@types/semver": "*",
     "nock": "^13.2.2",
     "pg": "*",
-    "redis": "*",
-    "@opentelemetry/sdk-trace-base": "^1.2.0"
+    "redis": "*"
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",


### PR DESCRIPTION
In PR #659 we tried to import the OpenTelemetry types at compile time
and include them in our own package, but that's not how TypeScript's
`import type` turns out to work.

This breaks the app for non-OpenTelemetry users as reported in #684. The
easiest fix we can ship right now is to add the package as a runtime
dependency rather than only a development dependency.

Ideally though, we do not ship additional dependencies for thing not all
our users use, but we can figure that out after this immediate fix.

I had missed this in PR #659, but we've also already included the
`@opentelemetry/api` as a dependency since PR #651. Already doing the
same this change does for the `@opentelemetry/sdk-trace-base` package.