### PR TITLE
Improve error reporting on extension load failure

### DIFF
--- a/packages/nodejs/.changesets/improve-error-message-on-extension-load-failure.md
+++ b/packages/nodejs/.changesets/improve-error-message-on-extension-load-failure.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Improve the error message on extension load failure. The error message will now print more details about the installed and expected architecture when they mismatch. This is most common on apps mounted on a container after first being installed on the host with a different architecture than the container.

--- a/packages/nodejs/scripts/extension/report.js
+++ b/packages/nodejs/scripts/extension/report.js
@@ -76,7 +76,7 @@ function createDownloadReport(report) {
   }
 }
 
-// This implementation should match the `packages/nodejs/src/diagnose.ts`
+// This implementation should match the `packages/nodejs/src/utils.ts`
 // implementation to generate the same path.
 function reportPath() {
   return path.join(__dirname, "../../ext/install.report")

--- a/packages/nodejs/src/diagnose.ts
+++ b/packages/nodejs/src/diagnose.ts
@@ -2,7 +2,7 @@ import fs from "fs"
 import path from "path"
 import { URL } from "url"
 
-import { isWritable } from "./utils"
+import { isWritable, installReportPath } from "./utils"
 import { Extension } from "./extension"
 import { Configuration } from "./config"
 import { AGENT_VERSION, VERSION } from "./version"
@@ -90,7 +90,7 @@ export class DiagnoseTool {
   private getInstallationReport() {
     let rawReport
     try {
-      rawReport = fs.readFileSync(reportPath(), "utf8")
+      rawReport = fs.readFileSync(installReportPath(), "utf8")
       return JSON.parse(rawReport)
     } catch (error) {
       const report = {
@@ -260,12 +260,6 @@ export class DiagnoseTool {
         )
       })
   }
-}
-
-// This implementation should match the `scripts/extension/report.js`
-// implementation to generate the same path.
-function reportPath(): string {
-  return path.join(__dirname, "../ext/install.report")
 }
 
 function getPathType(stats: fs.Stats) {

--- a/packages/nodejs/src/extension_wrapper.ts
+++ b/packages/nodejs/src/extension_wrapper.ts
@@ -1,15 +1,38 @@
+import fs from "fs"
 import { ExtensionWrapper } from "./interfaces/extension_wrapper"
+import { installReportPath } from "./utils"
 
 let mod: ExtensionWrapper
+
+function fetchInstalledArch(): [string, string] {
+  try {
+    const rawReport = fs.readFileSync(installReportPath(), "utf8")
+    const buildReport = JSON.parse(rawReport)["build"]
+    return [buildReport["architecture"], buildReport["target"]]
+  } catch (error) {
+    console.error("[appsignal][ERROR] Unable to fetch install report:", error)
+    return ["unknown", "unknown"]
+  }
+}
 
 try {
   mod = require("../build/Release/extension.node") as ExtensionWrapper
   mod.isLoaded = true
-} catch (e) {
-  console.error(
-    "AppSignal extension not loaded. This could mean that your current " +
-      "environment isn't supported, or that another error has occurred."
-  )
+} catch (error) {
+  const [installArch, installTarget] = fetchInstalledArch()
+  const arch = process.arch,
+    target = process.platform
+
+  if (arch !== installArch || target !== installTarget) {
+    console.error(
+      `[appsignal][ERROR] The AppSignal extension was installed for architecture '${installArch}-${installTarget}', but the current architecture is '${arch}-${target}'. Please reinstall the AppSignal package on the host the app is started.`
+    )
+  } else {
+    console.error(
+      "[appsignal][ERROR] AppSignal failed to load the extension. Please run the diagnose tool and email us at support@appsignal.com: https://docs.appsignal.com/nodejs/command-line/diagnose.html\n",
+      error
+    )
+  }
 
   mod = {
     isLoaded: false,

--- a/packages/nodejs/src/utils.ts
+++ b/packages/nodejs/src/utils.ts
@@ -70,3 +70,9 @@ function numberToHrtime(epochMillis: number) {
 
   return [seconds, nanoseconds]
 }
+
+// This implementation should match the `scripts/extension/report.js`
+// implementation to generate the same path.
+export function installReportPath(): string {
+  return path.join(__dirname, "../ext/install.report")
+}


### PR DESCRIPTION
## Improve error reporting on extension load failure

It's a common problem for apps first installed on the host system
(macOS) and then mounted with the `node_modules` directory in a Docker
container that's running another Operating System like Ubuntu to not
start the extension. This is because the extension is not installed for
the container's architecture.

If the target and architecture mismatch, print the installed and current
target and architecture. This will hopefully make the error more clear,
that the user needs to reinstall the extension for their host's
architecture.

I've updated the log message format to match the agreed upon format for
STDERR messages: `appsignal <TYPE>: <message>`
https://github.com/appsignal/integration-guide/blob/main/build/logging.md#warnings-printed-to-stderr
(private link)

I've also added logging for when the install report is not present. This
then returns `unknown-unknown` as the target and architecture. This is
not a pretty log message, but it is such an edge case when the report is
not present at all that I don't think will happen often. It's not worth
the effort to make more pretty right now.

Closes #658

## Move installReportPath function to utils

By moving it to the utils module it's more accessible by other parts of
the package and doesn't have to be considered diagnose tool specific.
