### PR TITLE
Add demo function to restore demo functionality

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -5,6 +5,7 @@ import { Metrics } from "./metrics"
 import * as gcProbe from "./probes/v8"
 import { Logger } from "./logger"
 import { NoopMetrics } from "./noops"
+import { demo } from "./demo"
 import { VERSION } from "./version"
 
 import { SpanProcessor } from "./span_processor"
@@ -121,6 +122,17 @@ export class Client {
 
     this.metrics().probes().stop()
     this.extension.stop()
+  }
+
+  /**
+   * Internal private function used by the demo CLI.
+   *
+   * https://docs.appsignal.com/nodejs/command-line/demo.html
+   *
+   * @private
+   */
+  public demo() {
+    demo(this)
   }
 
   /**

--- a/src/demo.ts
+++ b/src/demo.ts
@@ -1,0 +1,67 @@
+import { randomBytes } from "crypto"
+import { Client } from "./client"
+import { hrTime } from "./utils"
+
+/**
+ * Sends a demonstration/test sample for a exception and a performance issue.
+ *
+ * Note that the agent must be active for at least 60 seconds in order for the payload
+ * to be sent to AppSignal.
+ */
+export function demo(client: Client) {
+  const { sec: startSec, nsec: startNsec } = hrTime()
+  const traceId = randomBytes(10).toString("base64")
+  const rootSpanId = randomBytes(10).toString("base64")
+  const childSpanId = randomBytes(10).toString("base64")
+  // Performance sample
+  const performanceRootSpan = client.extension.createOpenTelemetrySpan(
+    rootSpanId,
+    "",
+    traceId,
+    startSec,
+    startNsec,
+    startSec + 1,
+    startNsec * 1.2,
+    "GET /demo",
+    { demo_sample: true },
+    "@opentelemetry/instrumentation-http"
+  )
+  performanceRootSpan.close()
+  const performanceChildSpan = client.extension.createOpenTelemetrySpan(
+    childSpanId,
+    rootSpanId,
+    traceId,
+    startSec,
+    startNsec * 1.2,
+    startSec + 1,
+    startNsec,
+    "request handler - /",
+    { "express.type": "request_handler" },
+    "@opentelemetry/instrumentation-express"
+  )
+  performanceChildSpan.close()
+
+  // Error sample
+  const errorTraceId = randomBytes(10).toString("base64")
+  const errorRootSpanId = randomBytes(10).toString("base64")
+  const errorRootSpan = client.extension.createOpenTelemetrySpan(
+    errorRootSpanId,
+    "",
+    errorTraceId,
+    startSec,
+    startNsec,
+    startSec + 1,
+    startNsec + 200,
+    "GET /demo",
+    { demo_sample: true },
+    "@opentelemetry/instrumentation-http"
+  )
+  try {
+    throw new Error(
+      "Hello world! This is an error used for demonstration purposes."
+    )
+  } catch (error) {
+    errorRootSpan.setError(error.name, error.message, error.stack)
+  }
+  errorRootSpan.close()
+}


### PR DESCRIPTION
This was previously removed in the OpenTelemetry only step.

I've used the new `createOpenTelemetrySpan` function to create the
spans, link them together with generated ids.
If I hardcode the ids you can see spans from child span all being
reported under the same root span and only one root span becomes visible
in the UI.

The `randomBytes` function has been available for a very long time in
Node.js. I would want to use `randomUUID`, but that's only been
available in Node.js 14.17, and not 14.0.

[skip changeset]