### PR TITLE
Update to Typescript 4.7.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10501,9 +10501,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
-      "integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.3.tgz",
+      "integrity": "sha512-WOkT3XYvrpXx4vMMqlD+8R8R37fZkjyLGlxavMc4iB8lrl8L0DeTcHbYgw/v0N/z9wAFsgBhcsF0ruoySS22mA==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -11096,10 +11096,10 @@
     },
     "packages/apollo-server": {
       "name": "@appsignal/apollo-server",
-      "version": "1.0.31",
+      "version": "1.0.32",
       "license": "MIT",
       "dependencies": {
-        "@appsignal/nodejs": "=2.4.1",
+        "@appsignal/nodejs": "=2.4.2",
         "apollo-server-plugin-base": "^0.10.3",
         "tslib": "^2.0.3"
       },
@@ -11114,10 +11114,10 @@
     },
     "packages/express": {
       "name": "@appsignal/express",
-      "version": "1.0.32",
+      "version": "1.0.33",
       "license": "MIT",
       "dependencies": {
-        "@appsignal/nodejs": "=2.4.1",
+        "@appsignal/nodejs": "=2.4.2",
         "tslib": "^2.0.3"
       },
       "devDependencies": {
@@ -11135,10 +11135,10 @@
     },
     "packages/koa": {
       "name": "@appsignal/koa",
-      "version": "1.0.22",
+      "version": "1.0.23",
       "license": "MIT",
       "dependencies": {
-        "@appsignal/nodejs": "=2.4.1",
+        "@appsignal/nodejs": "=2.4.2",
         "@appsignal/types": "^3.0.0",
         "shimmer": "^1.2.1",
         "tslib": "^2.0.3"
@@ -11160,10 +11160,10 @@
     },
     "packages/nextjs": {
       "name": "@appsignal/nextjs",
-      "version": "2.0.20",
+      "version": "2.0.21",
       "license": "MIT",
       "dependencies": {
-        "@appsignal/nodejs": "=2.4.1",
+        "@appsignal/nodejs": "=2.4.2",
         "tslib": "^2.0.3"
       },
       "devDependencies": {
@@ -11180,7 +11180,7 @@
     },
     "packages/nodejs": {
       "name": "@appsignal/nodejs",
-      "version": "2.4.1",
+      "version": "2.4.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -11381,7 +11381,7 @@
     "@appsignal/apollo-server": {
       "version": "file:packages/apollo-server",
       "requires": {
-        "@appsignal/nodejs": "=2.4.1",
+        "@appsignal/nodejs": "=2.4.2",
         "apollo-server-plugin-base": "*",
         "tslib": "^2.0.3"
       },
@@ -11418,7 +11418,7 @@
     "@appsignal/express": {
       "version": "file:packages/express",
       "requires": {
-        "@appsignal/nodejs": "=2.4.1",
+        "@appsignal/nodejs": "=2.4.2",
         "@types/express": "*",
         "express": "*",
         "tslib": "^2.0.3"
@@ -11434,7 +11434,7 @@
     "@appsignal/koa": {
       "version": "file:packages/koa",
       "requires": {
-        "@appsignal/nodejs": "=2.4.1",
+        "@appsignal/nodejs": "=2.4.2",
         "@appsignal/types": "^3.0.0",
         "@types/koa": "*",
         "@types/koa__router": "*",
@@ -11454,7 +11454,7 @@
     "@appsignal/nextjs": {
       "version": "file:packages/nextjs",
       "requires": {
-        "@appsignal/nodejs": "=2.4.1",
+        "@appsignal/nodejs": "=2.4.2",
         "next": "*",
         "tslib": "^2.0.3"
       },
@@ -19778,9 +19778,9 @@
       }
     },
     "typescript": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
-      "integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.3.tgz",
+      "integrity": "sha512-WOkT3XYvrpXx4vMMqlD+8R8R37fZkjyLGlxavMc4iB8lrl8L0DeTcHbYgw/v0N/z9wAFsgBhcsF0ruoySS22mA==",
       "dev": true
     },
     "unbox-primitive": {

--- a/packages/nodejs/src/bootstrap.ts
+++ b/packages/nodejs/src/bootstrap.ts
@@ -32,10 +32,12 @@ export function initCorePlugins(
   plugins.forEach(({ PLUGIN_NAME, instrument }) => {
     try {
       instrumentation.load(PLUGIN_NAME, instrument)
-    } catch (e) {
-      BaseClient.logger.warn(
-        `Failed to instrument "${PLUGIN_NAME}": ${e.message}`
-      )
+    } catch (error) {
+      if (error instanceof Error) {
+        BaseClient.logger.warn(
+          `Failed to instrument "${PLUGIN_NAME}": ${error.message}`
+        )
+      }
     }
   })
 }

--- a/packages/nodejs/src/diagnose.ts
+++ b/packages/nodejs/src/diagnose.ts
@@ -93,16 +93,18 @@ export class DiagnoseTool {
       rawReport = fs.readFileSync(installReportPath(), "utf8")
       return JSON.parse(rawReport)
     } catch (error) {
-      const report = {
-        parsing_error: {
-          error: `${error.name}: ${error.message}`,
-          backtrace: error.stack.split("\n")
-        } as ParsingError
+      if (error instanceof Error) {
+        const report = {
+          parsing_error: {
+            error: `${error.name}: ${error.message}`,
+            backtrace: (error.stack || "").split("\n")
+          } as ParsingError
+        }
+        if (rawReport) {
+          report.parsing_error.raw = rawReport
+        }
+        return report
       }
-      if (rawReport) {
-        report.parsing_error.raw = rawReport
-      }
-      return report
     }
   }
 

--- a/packages/nodejs/src/instrumentation/http/lifecycle/outgoing.ts
+++ b/packages/nodejs/src/instrumentation/http/lifecycle/outgoing.ts
@@ -99,10 +99,13 @@ function outgoingRequestFunction(
 
       try {
         req = original.apply(this, [urlOrOptions, ...args])
-      } catch (err) {
-        tracer.setError(err)
-        span.close()
-        throw err
+      } catch (error) {
+        if (error instanceof Error) {
+          tracer.setError(error)
+          span.close()
+        }
+
+        throw error
       }
 
       tracer.wrapEmitter(req)

--- a/packages/nodejs/src/scope.ts
+++ b/packages/nodejs/src/scope.ts
@@ -14,6 +14,7 @@ import * as asyncHooks from "async_hooks"
 import { EventEmitter } from "events"
 import shimmer from "shimmer"
 import { NoopSpan } from "./noops/span"
+import { BaseClient } from "./client"
 
 // A list of well-known EventEmitter methods that add event listeners.
 const EVENT_EMITTER_ADD_METHODS: Array<keyof EventEmitter> = [
@@ -206,6 +207,10 @@ export class ScopeManager {
       return fn(span)
     } catch (error) {
       if (error instanceof Error) this.root()?.setError(error)
+      else
+        BaseClient.logger.warn(
+          `Caught non-Error ${error} in Scope.withContext(), skipping...`
+        )
       throw error
     } finally {
       // Unset the current active span so it doesn't leak outside this context

--- a/packages/nodejs/src/scope.ts
+++ b/packages/nodejs/src/scope.ts
@@ -204,9 +204,9 @@ export class ScopeManager {
 
     try {
       return fn(span)
-    } catch (err) {
-      this.root()?.setError(err)
-      throw err
+    } catch (error) {
+      if (error instanceof Error) this.root()?.setError(error)
+      throw error
     } finally {
       // Unset the current active span so it doesn't leak outside this context
       // in case there was no previous active span or it's no longer open.

--- a/packages/nodejs/src/span.ts
+++ b/packages/nodejs/src/span.ts
@@ -127,12 +127,14 @@ export class BaseSpan implements Span {
 
     try {
       span.setSpanSampleData(this._ref, key, Data.generate(data))
-    } catch (e) {
-      BaseClient.logger.error(
-        `Error generating data (${e.name}: ${e.message}) for '${JSON.stringify(
-          data
-        )}'`
-      )
+    } catch (error) {
+      if (error instanceof Error) {
+        BaseClient.logger.error(
+          `Error generating data (${error.name}: ${
+            error.message
+          }) for '${JSON.stringify(data)}'`
+        )
+      }
     }
 
     return this


### PR DESCRIPTION
As per https://github.com/appsignal/appsignal-nodejs/issues/660, this patch updates TypeScript to 4.7.3, which required explicitly testing thrown errors to make sure they’re of the Error type.