### PR TITLE
Add Koa instrumentation

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -18,6 +18,7 @@ import { RedisInstrumentation } from "@opentelemetry/instrumentation-redis"
 import { IORedisInstrumentation } from "@opentelemetry/instrumentation-ioredis"
 import { HttpInstrumentation } from "@opentelemetry/instrumentation-http"
 import { ExpressInstrumentation } from "@opentelemetry/instrumentation-express"
+import { KoaInstrumentation } from "@opentelemetry/instrumentation-koa"
 
 /**
  * AppSignal for Node.js's main class.
@@ -172,6 +173,7 @@ export class Client {
       instrumentations: [
         new HttpInstrumentation(),
         new ExpressInstrumentation(),
+        new KoaInstrumentation(),
         new MySQLInstrumentation(),
         new MySQL2Instrumentation(),
         new RedisInstrumentation({


### PR DESCRIPTION
This commit adds the OpenTelemetry Koa instrumentation to the `initOpenTelemetry` list of instrumentations in the client.

See appsignal/appsignal-agent#769 for the extractor.