### PR TITLE
Remove the mysql2 package peer dependency

### DIFF
--- a/.changesets/remove-mysql2-peer-dependency.md
+++ b/.changesets/remove-mysql2-peer-dependency.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "change"
+---
+
+Remove the mysql2 package peer dependency. It's not only present as a development dependency for the package.

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "husky": "^4.3.6",
         "jest": "^26.6.3",
         "lint-staged": "^10.5.3",
+        "mysql2": "*",
         "nock": "^13.2.2",
         "npm-run-all": "^4.1.5",
         "prettier": "^2.2.1",
@@ -42,9 +43,6 @@
       },
       "engines": {
         "node": ">= 12"
-      },
-      "peerDependencies": {
-        "mysql2": "*"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -4090,7 +4088,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/denque/-/denque-2.0.1.tgz",
       "integrity": "sha512-tfiWc6BQLXNLpNiR5iGd0Ocu3P3VpxfzFiqubLgMfhfOw9WyvgJBd46CClNn9k3qfbjvT//0cf7AlYRX/OslMQ==",
-      "peer": true,
+      "dev": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -5374,7 +5372,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
       "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "is-property": "^1.0.2"
       }
@@ -6204,7 +6202,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
       "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==",
-      "peer": true
+      "dev": true
     },
     "node_modules/is-regex": {
       "version": "1.1.4",
@@ -7422,7 +7420,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
       "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
-      "peer": true
+      "dev": true
     },
     "node_modules/lru-cache": {
       "version": "6.0.0",
@@ -7742,7 +7740,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-2.3.3.tgz",
       "integrity": "sha512-wxJUev6LgMSgACDkb/InIFxDprRa6T95+VEoR+xPvtngtccNH2dGjEB/fVZ8yg1gWv1510c9CvXuJHi5zUm0ZA==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "denque": "^2.0.1",
         "generate-function": "^2.3.1",
@@ -7761,7 +7759,7 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
@@ -7773,7 +7771,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/named-placeholders/-/named-placeholders-1.1.2.tgz",
       "integrity": "sha512-wiFWqxoLL3PGVReSZpjLVxyJ1bRqe+KKJVbr4hGs1KWfTZTQyezHFBbuKj9hsizHyGV2ne7EMjHdxEGAybD5SA==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "lru-cache": "^4.1.3"
       },
@@ -7785,7 +7783,7 @@
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
       "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "pseudomap": "^1.0.2",
         "yallist": "^2.1.2"
@@ -7795,7 +7793,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
       "integrity": "sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A==",
-      "peer": true
+      "dev": true
     },
     "node_modules/nanomatch": {
       "version": "1.2.13",
@@ -8889,7 +8887,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
       "integrity": "sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==",
-      "peer": true
+      "dev": true
     },
     "node_modules/psl": {
       "version": "1.8.0",
@@ -9334,7 +9332,8 @@
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "devOptional": true
     },
     "node_modules/sane": {
       "version": "4.1.0",
@@ -9688,7 +9687,7 @@
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/seq-queue/-/seq-queue-0.0.5.tgz",
       "integrity": "sha512-hr3Wtp/GZIc/6DAGPDcV4/9WoZhjrkXsi5B/07QgX8tsdc6ilr7BFM6PM6rbdAX1kFSDYeZGLipIZZKyQP0O5Q==",
-      "peer": true
+      "dev": true
     },
     "node_modules/set-blocking": {
       "version": "2.0.0",
@@ -10178,7 +10177,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/sqlstring/-/sqlstring-2.3.3.tgz",
       "integrity": "sha512-qC9iz2FlN7DQl3+wjwn3802RTyjCx7sDvfQEXchwa6CWOx07/WVfh91gBmQ9fahw8snwGEWU3xGzOt4tFyHLxg==",
-      "peer": true,
+      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -14525,7 +14524,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/denque/-/denque-2.0.1.tgz",
       "integrity": "sha512-tfiWc6BQLXNLpNiR5iGd0Ocu3P3VpxfzFiqubLgMfhfOw9WyvgJBd46CClNn9k3qfbjvT//0cf7AlYRX/OslMQ==",
-      "peer": true
+      "dev": true
     },
     "depd": {
       "version": "1.1.2",
@@ -15522,7 +15521,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
       "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
-      "peer": true,
+      "dev": true,
       "requires": {
         "is-property": "^1.0.2"
       }
@@ -16113,7 +16112,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
       "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==",
-      "peer": true
+      "dev": true
     },
     "is-regex": {
       "version": "1.1.4",
@@ -17065,7 +17064,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
       "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
-      "peer": true
+      "dev": true
     },
     "lru-cache": {
       "version": "6.0.0",
@@ -17309,7 +17308,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-2.3.3.tgz",
       "integrity": "sha512-wxJUev6LgMSgACDkb/InIFxDprRa6T95+VEoR+xPvtngtccNH2dGjEB/fVZ8yg1gWv1510c9CvXuJHi5zUm0ZA==",
-      "peer": true,
+      "dev": true,
       "requires": {
         "denque": "^2.0.1",
         "generate-function": "^2.3.1",
@@ -17325,7 +17324,7 @@
           "version": "0.6.3",
           "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
           "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-          "peer": true,
+          "dev": true,
           "requires": {
             "safer-buffer": ">= 2.1.2 < 3.0.0"
           }
@@ -17336,7 +17335,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/named-placeholders/-/named-placeholders-1.1.2.tgz",
       "integrity": "sha512-wiFWqxoLL3PGVReSZpjLVxyJ1bRqe+KKJVbr4hGs1KWfTZTQyezHFBbuKj9hsizHyGV2ne7EMjHdxEGAybD5SA==",
-      "peer": true,
+      "dev": true,
       "requires": {
         "lru-cache": "^4.1.3"
       },
@@ -17345,7 +17344,7 @@
           "version": "4.1.5",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
           "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
-          "peer": true,
+          "dev": true,
           "requires": {
             "pseudomap": "^1.0.2",
             "yallist": "^2.1.2"
@@ -17355,7 +17354,7 @@
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
           "integrity": "sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A==",
-          "peer": true
+          "dev": true
         }
       }
     },
@@ -18180,7 +18179,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
       "integrity": "sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==",
-      "peer": true
+      "dev": true
     },
     "psl": {
       "version": "1.8.0",
@@ -18506,7 +18505,8 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "devOptional": true
     },
     "sane": {
       "version": "4.1.0",
@@ -18786,7 +18786,7 @@
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/seq-queue/-/seq-queue-0.0.5.tgz",
       "integrity": "sha512-hr3Wtp/GZIc/6DAGPDcV4/9WoZhjrkXsi5B/07QgX8tsdc6ilr7BFM6PM6rbdAX1kFSDYeZGLipIZZKyQP0O5Q==",
-      "peer": true
+      "dev": true
     },
     "set-blocking": {
       "version": "2.0.0",
@@ -19199,7 +19199,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/sqlstring/-/sqlstring-2.3.3.tgz",
       "integrity": "sha512-qC9iz2FlN7DQl3+wjwn3802RTyjCx7sDvfQEXchwa6CWOx07/WVfh91gBmQ9fahw8snwGEWU3xGzOt4tFyHLxg==",
-      "peer": true
+      "dev": true
     },
     "ssri": {
       "version": "9.0.0",

--- a/package.json
+++ b/package.json
@@ -21,10 +21,8 @@
     "tslib": "^2.0.3",
     "winston": "^3.6.0"
   },
-  "peerDependencies": {
-    "mysql2": "*"
-  },
   "devDependencies": {
+    "mysql2": "*",
     "@types/jest": "^26.0.19",
     "@typescript-eslint/eslint-plugin": "^5.13.0",
     "@typescript-eslint/parser": "^5.13.0",


### PR DESCRIPTION
This peer dependency was added to fix the build for the OpenTelemetry
mysql2 package instrumentation. In the TypeScript build it would import
the mysql2 types in the `@opentelemetry/instrumentation-mysql2` package.

The `@opentelemetry/instrumentation-mysql2` package itself has no
dependency on the mysql2 package, and neither does
`@opentelemetry/auto-instrumentations-node`. Which got me interested to
find out how that package works if we're experiencing the problem
described in PR https://github.com/appsignal/appsignal-nodejs/pull/688

> Control packages peer dependencies
> We need mysql2 as a peer dependency of the package because the
> OpenTelemetry instrumentation library requires it. This could be fixed
> with introspection using require-in-the-middle.

Instead I've moved it to the devDependencies list to fix the build and
remove the dependency for users that do not use the mysql2 package in
their app.

The AppSignal package works without it as a peer dependency, even if the
mysql2 package is not a dependency of the user's app. I've also tested
this in a TypeScript app without any conditional loading for the
`@opentelemetry/instrumentation-mysql2` package.
