### PR TITLE
Map requestHeaders config opt to OpenTelemetry

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -172,7 +172,11 @@ export class Client {
   private initOpenTelemetry() {
     const sdk = new NodeSDK({
       instrumentations: [
-        new HttpInstrumentation(),
+        new HttpInstrumentation({
+          headersToSpanAttributes: {
+            server: { requestHeaders: this.config.data["requestHeaders"] }
+          }
+        }),
         new ExpressInstrumentation(),
         new KoaInstrumentation(),
         new MySQLInstrumentation(),


### PR DESCRIPTION
The requestHeaders config option now maps to OpenTelemetry equivalent:
headersToSpanAttributes.

[skip blogpost]
[skip changeset]

---

With this config:

```js
const appsignal = new Appsignal({
  active: true,
  logLevel: "trace",
  log: "file",
  logPath: "/tmp",
  requestHeaders: ["user-agent", "X-My-Header"]
});
```

The header attributes are added to the span like this:

```
 'http.request.header.user_agent': [ 'insomnia/2022.3.0' ],
 'http.request.header.x_my_header': [ 'Foo bar' ]
```

Complete example:
```js
OpenTelemetry Span: Span {
  attributes: {
    'http.url': 'http://localhost:4001/redis',
    'http.host': 'localhost:4001',
    'net.host.name': 'localhost',
    'http.method': 'GET',
    'http.target': '/redis',
    'http.user_agent': 'insomnia/2022.3.0',
    'http.flavor': '1.1',
    'net.transport': 'ip_tcp',
    'http.request.header.user_agent': [ 'insomnia/2022.3.0' ],
    'http.request.header.x_my_header': [ 'Foo bar' ],
    'net.host.ip': '::ffff:172.21.0.4',
    'net.host.port': 4001,
    'net.peer.ip': '::ffff:172.21.0.1',
    'net.peer.port': 63596,
    'http.status_code': 200,
    'http.status_text': 'OK',
    'http.route': '/redis'
  }
}
```

We'll need to update the agent/processor because they're not showing up in the app.