### PR TITLE
Update OpenTelemetry dependencies for HTTP errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,10 +10,10 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@opentelemetry/api": "^1.0.4",
-        "@opentelemetry/auto-instrumentations-node": "^0.30.0",
-        "@opentelemetry/sdk-node": "^0.28.0",
-        "@opentelemetry/sdk-trace-base": "^1.2.0",
+        "@opentelemetry/api": "^1.1.0",
+        "@opentelemetry/auto-instrumentations-node": "^0.31.0",
+        "@opentelemetry/sdk-node": "^0.30.0",
+        "@opentelemetry/sdk-trace-base": "^1.4.0",
         "node-addon-api": "^3.1.0",
         "node-gyp": "^9.0.0",
         "tslib": "^2.0.3",
@@ -1176,17 +1176,17 @@
       }
     },
     "node_modules/@opentelemetry/api": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.0.4.tgz",
-      "integrity": "sha512-BuJuXRSJNQ3QoKA6GWWDyuLpOUck+9hAXNMCnrloc1aWVoy6Xq6t9PUV08aBZ4Lutqq2LEHM486bpZqoViScog==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.1.0.tgz",
+      "integrity": "sha512-hf+3bwuBwtXsugA2ULBc95qxrOqP2pOekLz34BJhcAKawt94vfeNyUKpYc0lZQ/3sCP6LqRa7UAdHA7i5UODzQ==",
       "engines": {
         "node": ">=8.0.0"
       }
     },
     "node_modules/@opentelemetry/api-metrics": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-metrics/-/api-metrics-0.28.0.tgz",
-      "integrity": "sha512-UcrJqEiV20YTibYXUT0TDBtl4uLh4tMpAYSa1g1780QrVMlsOMAnBrdD3EYTMPog14Zw+2QzPnDJ4X7q67YrSA==",
+      "version": "0.29.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-metrics/-/api-metrics-0.29.2.tgz",
+      "integrity": "sha512-yRdF5beqKuEdsPNoO7ijWCQ9HcyN0Tlgicf8RS6gzGOI54d6Hj7yKquJ6+X9XV+CSRbRWJYb+lOsXyso7uyX2g==",
       "dependencies": {
         "@opentelemetry/api": "^1.0.0"
       },
@@ -1195,40 +1195,40 @@
       }
     },
     "node_modules/@opentelemetry/auto-instrumentations-node": {
-      "version": "0.30.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/auto-instrumentations-node/-/auto-instrumentations-node-0.30.0.tgz",
-      "integrity": "sha512-4YSvvw8I4Ci09sQPdV3CMorSdUQrfwelUNYIN0CDVxh9TO2gfe9nWbpKYeD88+Sz+jUVFLIdTqPlj+6FQ382NA==",
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/auto-instrumentations-node/-/auto-instrumentations-node-0.31.0.tgz",
+      "integrity": "sha512-UQ4u3hVNGS5B2utNWWp2+R49H8xO7rXk4Q78V5cnnbmLjNtuI597Mm4dXiWGhpNm5LgYyBsxh2HLusQEAJo//A==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.28.0",
-        "@opentelemetry/instrumentation-amqplib": "^0.29.0",
-        "@opentelemetry/instrumentation-aws-lambda": "^0.31.0",
-        "@opentelemetry/instrumentation-aws-sdk": "^0.7.0",
-        "@opentelemetry/instrumentation-bunyan": "^0.28.0",
-        "@opentelemetry/instrumentation-cassandra-driver": "^0.28.0",
-        "@opentelemetry/instrumentation-connect": "^0.28.0",
-        "@opentelemetry/instrumentation-dns": "^0.28.0",
-        "@opentelemetry/instrumentation-express": "^0.29.0",
-        "@opentelemetry/instrumentation-fastify": "^0.27.0",
-        "@opentelemetry/instrumentation-generic-pool": "^0.28.0",
-        "@opentelemetry/instrumentation-graphql": "^0.28.0",
-        "@opentelemetry/instrumentation-grpc": "^0.28.0",
-        "@opentelemetry/instrumentation-hapi": "^0.28.0",
-        "@opentelemetry/instrumentation-http": "^0.28.0",
-        "@opentelemetry/instrumentation-ioredis": "^0.29.0",
-        "@opentelemetry/instrumentation-knex": "^0.28.0",
-        "@opentelemetry/instrumentation-koa": "^0.29.0",
-        "@opentelemetry/instrumentation-memcached": "^0.28.0",
-        "@opentelemetry/instrumentation-mongodb": "^0.30.0",
-        "@opentelemetry/instrumentation-mysql": "^0.29.0",
-        "@opentelemetry/instrumentation-mysql2": "^0.30.0",
-        "@opentelemetry/instrumentation-nestjs-core": "^0.29.0",
-        "@opentelemetry/instrumentation-net": "^0.28.0",
-        "@opentelemetry/instrumentation-pg": "^0.29.0",
-        "@opentelemetry/instrumentation-pino": "^0.29.0",
-        "@opentelemetry/instrumentation-redis": "^0.31.0",
-        "@opentelemetry/instrumentation-redis-4": "^0.30.0",
-        "@opentelemetry/instrumentation-restify": "^0.28.0",
-        "@opentelemetry/instrumentation-winston": "^0.28.0"
+        "@opentelemetry/instrumentation": "^0.29.2",
+        "@opentelemetry/instrumentation-amqplib": "^0.30.0",
+        "@opentelemetry/instrumentation-aws-lambda": "^0.32.0",
+        "@opentelemetry/instrumentation-aws-sdk": "^0.8.0",
+        "@opentelemetry/instrumentation-bunyan": "^0.29.0",
+        "@opentelemetry/instrumentation-cassandra-driver": "^0.29.0",
+        "@opentelemetry/instrumentation-connect": "^0.29.0",
+        "@opentelemetry/instrumentation-dns": "^0.29.0",
+        "@opentelemetry/instrumentation-express": "^0.30.0",
+        "@opentelemetry/instrumentation-fastify": "^0.28.0",
+        "@opentelemetry/instrumentation-generic-pool": "^0.29.0",
+        "@opentelemetry/instrumentation-graphql": "^0.29.0",
+        "@opentelemetry/instrumentation-grpc": "^0.29.2",
+        "@opentelemetry/instrumentation-hapi": "^0.29.0",
+        "@opentelemetry/instrumentation-http": "^0.29.2",
+        "@opentelemetry/instrumentation-ioredis": "^0.30.0",
+        "@opentelemetry/instrumentation-knex": "^0.29.0",
+        "@opentelemetry/instrumentation-koa": "^0.30.0",
+        "@opentelemetry/instrumentation-memcached": "^0.29.0",
+        "@opentelemetry/instrumentation-mongodb": "^0.31.0",
+        "@opentelemetry/instrumentation-mysql": "^0.30.0",
+        "@opentelemetry/instrumentation-mysql2": "^0.31.0",
+        "@opentelemetry/instrumentation-nestjs-core": "^0.30.0",
+        "@opentelemetry/instrumentation-net": "^0.29.0",
+        "@opentelemetry/instrumentation-pg": "^0.30.0",
+        "@opentelemetry/instrumentation-pino": "^0.30.0",
+        "@opentelemetry/instrumentation-redis": "^0.32.0",
+        "@opentelemetry/instrumentation-redis-4": "^0.31.0",
+        "@opentelemetry/instrumentation-restify": "^0.29.0",
+        "@opentelemetry/instrumentation-winston": "^0.29.0"
       },
       "engines": {
         "node": ">=8.12.0"
@@ -1238,36 +1238,36 @@
       }
     },
     "node_modules/@opentelemetry/context-async-hooks": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.2.0.tgz",
-      "integrity": "sha512-b0ui4aDc5UtU+EWkQlgyxPrTPjird8RhzdyaruoTyiHECWXs9O6qiTv4GLAnBt1XIPK4A/t5aqdW5whDcXDBnA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.4.0.tgz",
+      "integrity": "sha512-yXpe1qCK3CevzWN3VmLlEOcipNdSV6al204lWMDoBI4eCy3rWZZEAGlwRvIiEy3uPrHClh6BQ5Z0q1+LEB/y8g==",
       "engines": {
-        "node": ">=8.12.0"
+        "node": ">=14"
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.2.0"
       }
     },
     "node_modules/@opentelemetry/core": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.3.1.tgz",
-      "integrity": "sha512-k7lOC86N7WIyUZsUuSKZfFIrUtINtlauMGQsC1r7jNmcr0vVJGqK1ROBvt7WWMxLbpMnt1q2pXJO8tKu0b9auA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.4.0.tgz",
+      "integrity": "sha512-faq50VFEdyC7ICAOlhSi+yYZ+peznnGjTJToha9R63i9fVopzpKrkZt7AIdXUmz2+L2OqXrcJs7EIdN/oDyr5w==",
       "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.3.1"
+        "@opentelemetry/semantic-conventions": "1.4.0"
       },
       "engines": {
-        "node": ">=8.12.0"
+        "node": ">=14"
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.2.0"
       }
     },
     "node_modules/@opentelemetry/instrumentation": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.28.0.tgz",
-      "integrity": "sha512-hcL+U02vp0vcouoMjoJArP0USBuBXnWF+sAt+Z5k77ROEcSCHZh0DkWigWGMyN8w3M5SpoqRlJiXLDM+9RtXNg==",
+      "version": "0.29.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.29.2.tgz",
+      "integrity": "sha512-LXx5V0ONNATQFCE8C5uqnxWSm4rcXLssdLHdXjtGdxRmURqj/JO8jYefqXCD0LzsqEQ6yxOx2GZ0dgXvhBVdTw==",
       "dependencies": {
-        "@opentelemetry/api-metrics": "0.28.0",
+        "@opentelemetry/api-metrics": "0.29.2",
         "require-in-the-middle": "^5.0.3",
         "semver": "^7.3.2",
         "shimmer": "^1.2.1"
@@ -1277,12 +1277,12 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-amqplib": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-amqplib/-/instrumentation-amqplib-0.29.0.tgz",
-      "integrity": "sha512-hoRuD6d/yUm7fUJChKJPsusM3OfD3DlqTZe834g+d9ewDdayRBH6SNlFvIHj68tTbVOZRHmL0k5SBQr3xX/FyA==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-amqplib/-/instrumentation-amqplib-0.30.0.tgz",
+      "integrity": "sha512-aZZgi/O/kwrCIGSkf/7Sy7dB4ZzRTLcnU7A62SZWWU7f6C4KUXQ1TMizwJphF4P8QheqlgqJfoWrw+KDLheJbw==",
       "dependencies": {
         "@opentelemetry/core": "^1.0.0",
-        "@opentelemetry/instrumentation": "^0.28.0",
+        "@opentelemetry/instrumentation": "^0.29.2",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/amqplib": "^0.5.17"
       },
@@ -1294,11 +1294,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-aws-lambda": {
-      "version": "0.31.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-aws-lambda/-/instrumentation-aws-lambda-0.31.0.tgz",
-      "integrity": "sha512-Ii8GnwpGVdMXwSnA0gekajwmgP+QgtogekTULEel5en+zx9gNQO9p7zTFb3J/upiEtGYZOzkqKI93Vf7XTFVZA==",
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-aws-lambda/-/instrumentation-aws-lambda-0.32.0.tgz",
+      "integrity": "sha512-mVgd03G292DSkix5ARkTdp/dkPEhLwgwNDhEHsR1isOW2Lw3WKr4dCjMQKAYmbhhj3jg1/ovlwkhEQz6hIqXYQ==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.28.0",
+        "@opentelemetry/instrumentation": "^0.29.2",
         "@opentelemetry/propagator-aws-xray": "^1.1.0",
         "@opentelemetry/resources": "^1.0.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
@@ -1312,12 +1312,12 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-aws-sdk": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-aws-sdk/-/instrumentation-aws-sdk-0.7.0.tgz",
-      "integrity": "sha512-+4ibii4BvdPrIW9MOuj1wnTDkYHpX04gepPNfYcBseC9I5ZOAdz1a2Kj41FpweIlrlz0CPtbuLP2EFCyqb9EaQ==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-aws-sdk/-/instrumentation-aws-sdk-0.8.0.tgz",
+      "integrity": "sha512-F29TmSsq8LWeZZXHV72b3B+QItZPVPsPx1DuQYPcKeCwAJUAg0huukXbf2U2XskA1fmw49+t9AM8fFPdytftyA==",
       "dependencies": {
         "@opentelemetry/core": "^1.0.0",
-        "@opentelemetry/instrumentation": "^0.28.0",
+        "@opentelemetry/instrumentation": "^0.29.2",
         "@opentelemetry/propagation-utils": "^0.28.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       },
@@ -1329,11 +1329,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-bunyan": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-bunyan/-/instrumentation-bunyan-0.28.0.tgz",
-      "integrity": "sha512-Fm51yOnaiEOqd1vdWTmLnKLRe8q6zbYhQ/Axe3IlXN6785xXtfJh9WV372cD/pXqqyYMGJTriTsepaA11gzwTQ==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-bunyan/-/instrumentation-bunyan-0.29.0.tgz",
+      "integrity": "sha512-i1FZ+W96vQCIpkMKPZW0HOA79ve9PLIcTAFH0adU/CvtRRMSxyKPTKzWMGHcWr6DueKIPEorpMG+nO2Z/yk9iQ==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.28.0",
+        "@opentelemetry/instrumentation": "^0.29.2",
         "@types/bunyan": "1.8.7"
       },
       "engines": {
@@ -1344,11 +1344,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-cassandra-driver": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-cassandra-driver/-/instrumentation-cassandra-driver-0.28.0.tgz",
-      "integrity": "sha512-WON4H+Ji53Vfbtgk6eSeT1r0wYYKENlHTX/+XgI2KXjbDsKHvigXe92xbVTW+oRBu76mG6Bx74FcG5YJBysEow==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-cassandra-driver/-/instrumentation-cassandra-driver-0.29.0.tgz",
+      "integrity": "sha512-Wp7ntJVHwI5wN/cTMnBJJeQ8PmgordnHbq+B1k+xzBLPz7Pro+6q8SFmiupZvrZmfzWsdSDaO2XM/6CIdtFB5Q==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.28.0",
+        "@opentelemetry/instrumentation": "^0.29.2",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "engines": {
@@ -1359,12 +1359,12 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-connect": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-connect/-/instrumentation-connect-0.28.0.tgz",
-      "integrity": "sha512-MR5/t7GEhUOyY01Tb9o64LGZS1CfYaVwOuBXCBfupJrXpunHeL87goOxgkXhc6aGMQ9k21z/VC1meJW73hMyRg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-connect/-/instrumentation-connect-0.29.0.tgz",
+      "integrity": "sha512-2BvdIdUCPIYNnROaMToLG76wZXvZXM2L9zOtEFlUnp8teI3Lu2mSPKRaSZ6XAmVVgTAtpfq2IuJMcZ5zAhJuCg==",
       "dependencies": {
         "@opentelemetry/core": "^1.0.0",
-        "@opentelemetry/instrumentation": "^0.28.0",
+        "@opentelemetry/instrumentation": "^0.29.2",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/connect": "3.4.35"
       },
@@ -1376,11 +1376,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-dns": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-dns/-/instrumentation-dns-0.28.0.tgz",
-      "integrity": "sha512-2g8bJ9jYG+Xn31tMk/K0QY5gCSntIWhErSdKHMKyrpFmypP+t9LwDO1hqTRMTkdGgWm3dxONi6B4ibPTsusA+Q==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-dns/-/instrumentation-dns-0.29.0.tgz",
+      "integrity": "sha512-3WTC4m6JKviaABiR3a+56WUMvrUp9WW9EYC0+LRpqm7RK/1a5bYq2Cozc2SlFYX9ZfWKMqGS39/fU24mKQ5toA==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.28.0",
+        "@opentelemetry/instrumentation": "^0.29.2",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "semver": "^7.3.2"
       },
@@ -1392,12 +1392,12 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-express": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-express/-/instrumentation-express-0.29.0.tgz",
-      "integrity": "sha512-7pSPNDw9mUlNBRDP20vBQfbVxdjrEz86WKVatIWz1lpJJSLofMFT/IgASt147wnHX05e6sb8wG7q6aRO61UVBg==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-express/-/instrumentation-express-0.30.0.tgz",
+      "integrity": "sha512-OsCfM+ThAXh3wzsyHgXyA5HUoLMdLd6Asix2Jx8yxniruU/Gq8y4Cz7aLy/vXNckXHWO3fwwL5gb7K3dykTnAQ==",
       "dependencies": {
         "@opentelemetry/core": "^1.0.0",
-        "@opentelemetry/instrumentation": "^0.28.0",
+        "@opentelemetry/instrumentation": "^0.29.2",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/express": "4.17.13"
       },
@@ -1409,12 +1409,12 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-fastify": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fastify/-/instrumentation-fastify-0.27.0.tgz",
-      "integrity": "sha512-+63KrwjYt468yWXT0cIISi3iOsowOF4tFcFXjMbXz2UyOk1o940KTh0O6Ynq7xM9kDJnK7iNZl0KxHvSrF9iPQ==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fastify/-/instrumentation-fastify-0.28.0.tgz",
+      "integrity": "sha512-HVvxTDgAhGZqp5k/JA/W4cMpHMy25CXy1pJDOoVB08gC6TKDBg/54iKgLr+g+nqV9RejIKfydt+35Xesynay/g==",
       "dependencies": {
         "@opentelemetry/core": "^1.0.0",
-        "@opentelemetry/instrumentation": "^0.28.0",
+        "@opentelemetry/instrumentation": "^0.29.2",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "fastify": "^3.19.2"
       },
@@ -1426,11 +1426,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-generic-pool": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-generic-pool/-/instrumentation-generic-pool-0.28.0.tgz",
-      "integrity": "sha512-PcEroYBqx6Mrb71A+BBzgYIFWwDaT/O8wPeSPcq44dBWV2sZT92k00K2Q8rK8ycS5Iva72kLWh/7cCZUvMThjg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-generic-pool/-/instrumentation-generic-pool-0.29.0.tgz",
+      "integrity": "sha512-tCVIVdGLS4bsFOwYGcbzuESh3XREfdhtMU9iXkULON1KoYi1c68HlWC9yyNQL7yTCBkbYSk2XjWKs6dHbcSf3A==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.28.0",
+        "@opentelemetry/instrumentation": "^0.29.2",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/generic-pool": "^3.1.9"
       },
@@ -1442,11 +1442,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-graphql": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-graphql/-/instrumentation-graphql-0.28.0.tgz",
-      "integrity": "sha512-Pisi5nfxVs7j414z/3En3g29LOXW0CzTZLY/MRpXUDDElk4b7d1hJe9hh5kjdRogiuP15ta111KtchaQZjWN6g==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-graphql/-/instrumentation-graphql-0.29.0.tgz",
+      "integrity": "sha512-mAjz326UtWGQUAmmEY6VB4XV1kbgQGBmRWjh/QT0giLwcbKa9RdO0x0B+VbALbrth7ZtHuoyKaDjCWowuzUujw==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.28.0",
+        "@opentelemetry/instrumentation": "^0.29.2",
         "graphql": "^15.5.1"
       },
       "engines": {
@@ -1457,13 +1457,13 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-grpc": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-grpc/-/instrumentation-grpc-0.28.0.tgz",
-      "integrity": "sha512-MRYLENztpQKr3/f3ps09x9wxJ+kg3pNNqPz1qzW95w//eIxwye5repK3auXLdVib+e8md9elhpqDmlUjtKs75w==",
+      "version": "0.29.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-grpc/-/instrumentation-grpc-0.29.2.tgz",
+      "integrity": "sha512-rWyx/a7CsEYopwxaND47z+I8SrTLTHEz9sm8sf30FkMviVyRzYqt2PJT+JMGInM7Om/IpZNEc29kSzUjLmqddQ==",
       "dependencies": {
-        "@opentelemetry/api-metrics": "0.28.0",
-        "@opentelemetry/instrumentation": "0.28.0",
-        "@opentelemetry/semantic-conventions": "1.2.0"
+        "@opentelemetry/api-metrics": "0.29.2",
+        "@opentelemetry/instrumentation": "0.29.2",
+        "@opentelemetry/semantic-conventions": "1.3.1"
       },
       "engines": {
         "node": ">=8.12.0"
@@ -1473,20 +1473,20 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-grpc/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.2.0.tgz",
-      "integrity": "sha512-BNKB9fiYVghALJzCuWO3eNYfdTExPVK4ykrtmfNfy0A6UWYhOYjGMXifUmkunDJNL8ju9tBobo8jF0WR9zGy1Q==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.3.1.tgz",
+      "integrity": "sha512-wU5J8rUoo32oSef/rFpOT1HIjLjAv3qIDHkw1QIhODV3OpAVHi5oVzlouozg9obUmZKtbZ0qUe/m7FP0y0yBzA==",
       "engines": {
         "node": ">=8.12.0"
       }
     },
     "node_modules/@opentelemetry/instrumentation-hapi": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-hapi/-/instrumentation-hapi-0.28.0.tgz",
-      "integrity": "sha512-DzOB1JtwgIU0WJVqPxQPcW7HrLN63YXkRU0tlYt63tzdLNEErgLHvfxzQLZxBxGekzKpUC9wRUw0gFgXiOPiSw==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-hapi/-/instrumentation-hapi-0.29.0.tgz",
+      "integrity": "sha512-yqfuKALO20Mx6F8GStnwTmD/JUhR9JGV3GJVH3UJ5TDAvz61hhoQWaBm0iAP5cJhrKRMD8mictAT2OiHSPUpLw==",
       "dependencies": {
         "@opentelemetry/core": "^1.0.0",
-        "@opentelemetry/instrumentation": "^0.28.0",
+        "@opentelemetry/instrumentation": "^0.29.2",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/hapi__hapi": "20.0.9"
       },
@@ -1498,13 +1498,13 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-http": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.28.0.tgz",
-      "integrity": "sha512-j6nqdGekv7Xtq3uRgiHdRrf1s9Y/fJTD//z8NG2RHGJAlOPRIzDO4m2tzZ5DX03Yzbb7tVgRsYhJJVsinQl9Bw==",
+      "version": "0.29.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.29.2.tgz",
+      "integrity": "sha512-XIF9WCH03rp3vQjwXXVdTxlsXT2AG6LYfFKO8r2QC+w4F4KFuZa4J3VPYJ0L/a/6dWt34DA67eBh3l6Z1rMZrg==",
       "dependencies": {
-        "@opentelemetry/core": "1.2.0",
-        "@opentelemetry/instrumentation": "0.28.0",
-        "@opentelemetry/semantic-conventions": "1.2.0",
+        "@opentelemetry/core": "1.3.1",
+        "@opentelemetry/instrumentation": "0.29.2",
+        "@opentelemetry/semantic-conventions": "1.3.1",
         "semver": "^7.3.5"
       },
       "engines": {
@@ -1515,11 +1515,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-http/node_modules/@opentelemetry/core": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.2.0.tgz",
-      "integrity": "sha512-QiKp8fBbT9ZhRTP+ZVVMyqH62tD/ZQa4gWPi+GnpNetvK1SWPO/8DmRpaSXHwAhu5FWUDJrbFgpLsrDd1zGPOw==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.3.1.tgz",
+      "integrity": "sha512-k7lOC86N7WIyUZsUuSKZfFIrUtINtlauMGQsC1r7jNmcr0vVJGqK1ROBvt7WWMxLbpMnt1q2pXJO8tKu0b9auA==",
       "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.2.0"
+        "@opentelemetry/semantic-conventions": "1.3.1"
       },
       "engines": {
         "node": ">=8.12.0"
@@ -1529,19 +1529,19 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-http/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.2.0.tgz",
-      "integrity": "sha512-BNKB9fiYVghALJzCuWO3eNYfdTExPVK4ykrtmfNfy0A6UWYhOYjGMXifUmkunDJNL8ju9tBobo8jF0WR9zGy1Q==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.3.1.tgz",
+      "integrity": "sha512-wU5J8rUoo32oSef/rFpOT1HIjLjAv3qIDHkw1QIhODV3OpAVHi5oVzlouozg9obUmZKtbZ0qUe/m7FP0y0yBzA==",
       "engines": {
         "node": ">=8.12.0"
       }
     },
     "node_modules/@opentelemetry/instrumentation-ioredis": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-ioredis/-/instrumentation-ioredis-0.29.0.tgz",
-      "integrity": "sha512-buZzi94XiXsv9H0wtJ3tiOWHe//83BCVozxHn5Gc/AefJSp//xe0zUdgJ3LBFuJSv5JEh4Xj7QvtjRqlG+yLGA==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-ioredis/-/instrumentation-ioredis-0.30.0.tgz",
+      "integrity": "sha512-iYdVWRz53kZ3DsEMt5es8KF+OrfRi4M6gSQYA7q6OcVXrucAUZA+juK8Rl3IgWjXG5wKCzr/liKs6HDAVJ9f/Q==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.28.0",
+        "@opentelemetry/instrumentation": "^0.29.2",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/ioredis": "4.26.6"
       },
@@ -1553,11 +1553,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-knex": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-knex/-/instrumentation-knex-0.28.0.tgz",
-      "integrity": "sha512-bUnFg8VA8e+WrqFzdyNQO7/nzsOdnQg7UzANB+5xwzsCL8JyDoxATwaM7Xxe7y6bk2g0GexyuwgytLwCJxONqQ==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-knex/-/instrumentation-knex-0.29.0.tgz",
+      "integrity": "sha512-M00bEYxl5VZV53jVxxnweGrEO9AMuSPIAz1mIzk/Z3bXU/KK9GxCBCZajwxdXv1SKj6KMQ+mOfXOOnY8Y0Wbcg==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.28.0",
+        "@opentelemetry/instrumentation": "^0.29.2",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "engines": {
@@ -1568,12 +1568,12 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-koa": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-koa/-/instrumentation-koa-0.29.0.tgz",
-      "integrity": "sha512-ycuNJT7PyR9eDuKu5WgPbgs7pn0BjCogX+USQ3mBkfQwQn8jbjZW1ntEsbZ7AoehYsGhaP4X+WuE9hRXyndduw==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-koa/-/instrumentation-koa-0.30.0.tgz",
+      "integrity": "sha512-GWm8L8HzMK0f+ZpRhBQc+JVwNL7+7zAm9w/HVAzfCGJyushU/wWkso1xOlwumiJndfRaqYqxg9FW32Yw3vYrng==",
       "dependencies": {
         "@opentelemetry/core": "^1.0.0",
-        "@opentelemetry/instrumentation": "^0.28.0",
+        "@opentelemetry/instrumentation": "^0.29.2",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/koa": "2.13.4",
         "@types/koa__router": "8.0.7"
@@ -1586,11 +1586,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-memcached": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-memcached/-/instrumentation-memcached-0.28.0.tgz",
-      "integrity": "sha512-o2SOwSs8oOgNf1w9UOMAHCEzEtf5IKVjuSQe5hicJJ2LmGC56CNKw8aeY7QYsS2BCydnr8cpL1g8GhG4sQ0KgA==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-memcached/-/instrumentation-memcached-0.29.0.tgz",
+      "integrity": "sha512-th+zERg1/1DpCVZ3doKPmjVnbPFBZO5RHcteFkt28ibYTrPEL6K4EciTybdIyC10madFOJRydC9lfvDfgY857g==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.28.0",
+        "@opentelemetry/instrumentation": "^0.29.2",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/memcached": "^2.2.6"
       },
@@ -1602,11 +1602,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-mongodb": {
-      "version": "0.30.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongodb/-/instrumentation-mongodb-0.30.0.tgz",
-      "integrity": "sha512-E2KayCr/whhCjFHZILjuMURzehFpI4aNlQ/lUFyHkc+tXSUlohHWsIriMxCIlHOZx51RTPuq7u2tix+GxXCV8g==",
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongodb/-/instrumentation-mongodb-0.31.0.tgz",
+      "integrity": "sha512-4pyjBeSZucUoKoQqqjwv693NmvvG7/HFCFUwN+f1wxliRq+2uuJoT/bp9wcrwLG4IW+8QvxVyN++Hn5LgQeSwQ==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.28.0",
+        "@opentelemetry/instrumentation": "^0.29.2",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/mongodb": "3.6.20"
       },
@@ -1618,11 +1618,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-mysql": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql/-/instrumentation-mysql-0.29.0.tgz",
-      "integrity": "sha512-vNeEScgtswbgzMu8mVC+Wl74DLurxZAFELmzP2R6ws3Gumat6cNe81MtFM9jwWoDjiB/6ga6G8WfWUUHgWEuqQ==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql/-/instrumentation-mysql-0.30.0.tgz",
+      "integrity": "sha512-FdbZ2Yb15OTGa6HZYXxUL0yhcXNec2HHbUp9nn3x2B9YO9bJHJQoNVyHVd5gssMVYKFg4dgZodY/YXYu9xj2Ow==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.28.0",
+        "@opentelemetry/instrumentation": "^0.29.2",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/mysql": "2.15.19"
       },
@@ -1634,11 +1634,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-mysql2": {
-      "version": "0.30.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql2/-/instrumentation-mysql2-0.30.0.tgz",
-      "integrity": "sha512-bwi7UzgCYJFriMUlnpRPlP+8GechI07lGXJr/wZ1+qYlBnxJT17Qr/6pKEN89nfJhYwwdNTM2toqtIopfZnsVw==",
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql2/-/instrumentation-mysql2-0.31.0.tgz",
+      "integrity": "sha512-Pcm9i0dwLk5yvP11knL8z63Cu0djy9CYSE3ZDvIQinF/HcOmFTKUYqIeX+8XZkIupgDmeFEy6rWZEvvko8sanw==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.28.0",
+        "@opentelemetry/instrumentation": "^0.29.2",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "engines": {
@@ -1649,11 +1649,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-nestjs-core": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-nestjs-core/-/instrumentation-nestjs-core-0.29.0.tgz",
-      "integrity": "sha512-ArGeud9aUyd5cnkpGbGyi+ptszjpVpgYurD+a1sIWYm7snKrN/mXRJ4Rj/h27Z9eeW0DtO1ojKASqO60ulIxMw==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-nestjs-core/-/instrumentation-nestjs-core-0.30.0.tgz",
+      "integrity": "sha512-z9HSjL4Udx2tteqyjvzrmNk6mxhip4BkWSWWZKN0z7t+waIHKfTTgJiTn5/YxwGYLUIKVigmNlAoo987rmK+xA==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.28.0",
+        "@opentelemetry/instrumentation": "^0.29.2",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "engines": {
@@ -1664,11 +1664,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-net": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-net/-/instrumentation-net-0.28.0.tgz",
-      "integrity": "sha512-VtP5tjfiGcgF7qZM7m0f69v3rDtH7+/gI5CHO21EmefcvqLJDQmk7LtuURXjuTIswznT6snPna/k2KpiM/TtbA==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-net/-/instrumentation-net-0.29.0.tgz",
+      "integrity": "sha512-93acTBKvrzyTbQ5g+VItpCqxMn0lcLb8re7wOh7v+hnMAaKc431fcPuVbOcsNHdMZ7LF1qnOZfs0sooT/chIDA==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.28.0",
+        "@opentelemetry/instrumentation": "^0.29.2",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "engines": {
@@ -1679,11 +1679,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-pg": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pg/-/instrumentation-pg-0.29.0.tgz",
-      "integrity": "sha512-ANHxShvLlp+B+TFFGDZ+ZyzRFCa3JrDwwGM63JptMZZDAiXsOj7vQGTvwegy5r5S+rRzt/Ebei1mfz0B9xFgIQ==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pg/-/instrumentation-pg-0.30.0.tgz",
+      "integrity": "sha512-RQ3cTTJnCBE/9GagjSpaM+yzxN25MvEwOxDFes3y8c1cqrMgqxukQLm3MbcqCQ8e1g/8d18+oyiEeBUjZJ5jnw==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.28.0",
+        "@opentelemetry/instrumentation": "^0.29.2",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/pg": "8.6.1",
         "@types/pg-pool": "2.0.3"
@@ -1696,11 +1696,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-pino": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pino/-/instrumentation-pino-0.29.0.tgz",
-      "integrity": "sha512-01PILc/y1pBqyE0FfXAMMxWrx8VYPxu3MiyOqW7HkUWCQD0eBGuzO4fgprEksEYfmHiDcvRFUwmHW7c9LoflPA==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pino/-/instrumentation-pino-0.30.0.tgz",
+      "integrity": "sha512-ZbmRL58f3Qviwai/JunUZb/uKo1NYRLdCrKoss7seJ3mEvuTcgTIVeo93PSqxk2c4LMdvkTcNAcIAv1Ymw/PyQ==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.28.0",
+        "@opentelemetry/instrumentation": "^0.29.2",
         "pino": "7.10.0",
         "semver": "^7.3.5"
       },
@@ -1712,11 +1712,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-redis": {
-      "version": "0.31.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis/-/instrumentation-redis-0.31.0.tgz",
-      "integrity": "sha512-c1nrWEl7eITOZVnLwqAyAzZ7Fc1ZbJ+N0J55XaggstYgbcG7XiPywfXY76CC7a10D/K3aCq3b2MRar30Cm6eyg==",
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis/-/instrumentation-redis-0.32.0.tgz",
+      "integrity": "sha512-KaZnYhz8dZ9gHkvrBo2U7bp/HABM2JXd3i6e8cUP8MyNA8x5P+EUbeSzzBMe6bAZH35S60dAQbBAhRji3ZlPRw==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.28.0",
+        "@opentelemetry/instrumentation": "^0.29.2",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/redis": "2.8.31"
       },
@@ -1728,11 +1728,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-redis-4": {
-      "version": "0.30.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis-4/-/instrumentation-redis-4-0.30.0.tgz",
-      "integrity": "sha512-/Unwo2pPKj3pCzvXcequxktVqr7w5XMFQwjY6K9d835nPk9dsqRnPUeyowL8VbsobjULXFOwB6YmlYz0Z0SncA==",
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis-4/-/instrumentation-redis-4-0.31.0.tgz",
+      "integrity": "sha512-3DY6bkqKnVlPc2WWHelb6DnU78ryYLQFqv0lqnVsoSkr7b6hnmw1Bzuwo/5YmS4C3XuTAD4/6dZVrQJ23g8HNA==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.28.0",
+        "@opentelemetry/instrumentation": "^0.29.2",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "engines": {
@@ -1743,12 +1743,12 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-restify": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-restify/-/instrumentation-restify-0.28.0.tgz",
-      "integrity": "sha512-wbqy4NB4/X8M3LL+tETPV1DUH7o7blVFZiSI/wzHxgV2IPzmvrBEe33FT/OPhlDiTjMNpRSst+FJqfbEeY6O0w==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-restify/-/instrumentation-restify-0.29.0.tgz",
+      "integrity": "sha512-jjXtzNut03FBernMrEjJnkX9SdUAjpGh04mauR2GhBjSrkQg73gS7jeMS/xyN6/ufphA0tyFygxNPOWFvjXM6g==",
       "dependencies": {
         "@opentelemetry/core": "^1.0.0",
-        "@opentelemetry/instrumentation": "^0.28.0",
+        "@opentelemetry/instrumentation": "^0.29.2",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/restify": "4.3.8"
       },
@@ -1760,11 +1760,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-winston": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-winston/-/instrumentation-winston-0.28.0.tgz",
-      "integrity": "sha512-NJESVbQiKOt78R7xoRTHQ32gysMH5VsU6EzdwoB5UHtVa4/GXPhisyZUpxSOcukYBbhrwn0orHTypOwko2bD7Q==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-winston/-/instrumentation-winston-0.29.0.tgz",
+      "integrity": "sha512-z48oitpODk5BkJXp4OlRLAQf5JLH0jcSmHvqhlgB9tHddNG+xQWa1Xb0kyBX4i4r0jGFR7cvImIb53wrEavUBA==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.28.0"
+        "@opentelemetry/instrumentation": "^0.29.2"
       },
       "engines": {
         "node": ">=8.12.0"
@@ -1799,352 +1799,165 @@
       }
     },
     "node_modules/@opentelemetry/propagator-b3": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.2.0.tgz",
-      "integrity": "sha512-sjZNnJb3Dz8il5hvaDcScSMBZcwsAs8rnZ4cXMhe3Gv4ewO0x+B7rzWS4k7wDwXPijmuTFy3mj0otDiJhp6bVA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.4.0.tgz",
+      "integrity": "sha512-KKFjvU2qrOEoK2S9FfSkE11u3AVxCniJOH7av6pmbFwkv1YD6uHNqvjvY4Xe6VwFOyKuTYS69VydO9OjJ5gvVA==",
       "dependencies": {
-        "@opentelemetry/core": "1.2.0"
+        "@opentelemetry/core": "1.4.0"
       },
       "engines": {
-        "node": ">=8.12.0"
+        "node": ">=14"
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.2.0"
-      }
-    },
-    "node_modules/@opentelemetry/propagator-b3/node_modules/@opentelemetry/core": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.2.0.tgz",
-      "integrity": "sha512-QiKp8fBbT9ZhRTP+ZVVMyqH62tD/ZQa4gWPi+GnpNetvK1SWPO/8DmRpaSXHwAhu5FWUDJrbFgpLsrDd1zGPOw==",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.2.0"
-      },
-      "engines": {
-        "node": ">=8.12.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.2.0"
-      }
-    },
-    "node_modules/@opentelemetry/propagator-b3/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.2.0.tgz",
-      "integrity": "sha512-BNKB9fiYVghALJzCuWO3eNYfdTExPVK4ykrtmfNfy0A6UWYhOYjGMXifUmkunDJNL8ju9tBobo8jF0WR9zGy1Q==",
-      "engines": {
-        "node": ">=8.12.0"
       }
     },
     "node_modules/@opentelemetry/propagator-jaeger": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.2.0.tgz",
-      "integrity": "sha512-xs/7VTADlCbMY96dMmgS4RKokZ6k5EfFgWcQriaIkpM+Mb/Snh4wZlfAx4Mr4vPCVM92MwshZ02WI2Ssg0DU8w==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.4.0.tgz",
+      "integrity": "sha512-LvSzgt9RIGYiMP9E45ifT5WtALsDyY74y/1Ol0DK4xmJt8Sku7YastjCZaxpsvLGA4CGAtth0ozic88AvJrmgw==",
       "dependencies": {
-        "@opentelemetry/core": "1.2.0"
+        "@opentelemetry/core": "1.4.0"
       },
       "engines": {
-        "node": ">=8.12.0"
+        "node": ">=14"
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.2.0"
-      }
-    },
-    "node_modules/@opentelemetry/propagator-jaeger/node_modules/@opentelemetry/core": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.2.0.tgz",
-      "integrity": "sha512-QiKp8fBbT9ZhRTP+ZVVMyqH62tD/ZQa4gWPi+GnpNetvK1SWPO/8DmRpaSXHwAhu5FWUDJrbFgpLsrDd1zGPOw==",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.2.0"
-      },
-      "engines": {
-        "node": ">=8.12.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.2.0"
-      }
-    },
-    "node_modules/@opentelemetry/propagator-jaeger/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.2.0.tgz",
-      "integrity": "sha512-BNKB9fiYVghALJzCuWO3eNYfdTExPVK4ykrtmfNfy0A6UWYhOYjGMXifUmkunDJNL8ju9tBobo8jF0WR9zGy1Q==",
-      "engines": {
-        "node": ">=8.12.0"
-      }
-    },
-    "node_modules/@opentelemetry/resource-detector-aws": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-aws/-/resource-detector-aws-1.0.3.tgz",
-      "integrity": "sha512-0bhy8L1JZfqGqMjaPu1tV3rBsmtN42+wycJYhxMBbaB4E0ZDshDLnBHn3AeLMPLtFUqiyyn48JluuBfD7KPkhA==",
-      "dependencies": {
-        "@opentelemetry/core": "^1.0.0",
-        "@opentelemetry/resources": "^1.0.0",
-        "@opentelemetry/semantic-conventions": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=8.5.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.0.2"
-      }
-    },
-    "node_modules/@opentelemetry/resource-detector-gcp": {
-      "version": "0.26.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-gcp/-/resource-detector-gcp-0.26.2.tgz",
-      "integrity": "sha512-CuFqdUGfQtVJ6paaasUaUN6dHxbu0CpUFnHws4Vj/K5SDUxR4l3/Vy5SvMiQ21mRCkeDDDbnw8cPEoA/xGKTrg==",
-      "dependencies": {
-        "@opentelemetry/resources": "^1.0.0",
-        "@opentelemetry/semantic-conventions": "^1.0.0",
-        "gcp-metadata": "^4.1.4",
-        "semver": "7.3.5"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.0.2"
-      }
-    },
-    "node_modules/@opentelemetry/resource-detector-gcp/node_modules/semver": {
-      "version": "7.3.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/@opentelemetry/resources": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.3.1.tgz",
-      "integrity": "sha512-X8bl3X0YjlsHWy0Iv0KUETtZuRUznX4yr1iScKCtfy8AoRfZFc2xxWKMDJ0TrqYwSapgeg4YwpmRzUKmmnrbeA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.4.0.tgz",
+      "integrity": "sha512-Q3pI5+pCM+Ur7YwK9GbG89UBipwJbfmuzSPAXTw964ZHFzSrz+JAgrETC9rqsUOYdUlj/V7LbRMG5bo72xE0Xw==",
       "dependencies": {
-        "@opentelemetry/core": "1.3.1",
-        "@opentelemetry/semantic-conventions": "1.3.1"
+        "@opentelemetry/core": "1.4.0",
+        "@opentelemetry/semantic-conventions": "1.4.0"
       },
       "engines": {
-        "node": ">=8.12.0"
+        "node": ">=14"
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.2.0"
       }
     },
     "node_modules/@opentelemetry/sdk-metrics-base": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics-base/-/sdk-metrics-base-0.28.0.tgz",
-      "integrity": "sha512-PFjk9+WWU6Y51ZjxClnPW1rzTtcT79pR1FTiFjTsNmKSG0zU3qvUHAoTo0+jvvrO0Djihj7AE+iIG2xLWY4GNQ==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics-base/-/sdk-metrics-base-0.30.0.tgz",
+      "integrity": "sha512-3BDg1MYDInDyGvy+bSH8OuCX5nsue7omH6Y2eidCGTTDYRPxDmq9tsRJxnTUepoMAvWX+1sTwZ4JqTFmc1z8Mw==",
       "dependencies": {
-        "@opentelemetry/api-metrics": "0.28.0",
-        "@opentelemetry/core": "1.2.0",
-        "@opentelemetry/resources": "1.2.0",
+        "@opentelemetry/api-metrics": "0.30.0",
+        "@opentelemetry/core": "1.4.0",
+        "@opentelemetry/resources": "1.4.0",
         "lodash.merge": "4.6.2"
       },
       "engines": {
-        "node": ">=8.12.0"
+        "node": ">=14"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.0.0"
       }
     },
-    "node_modules/@opentelemetry/sdk-metrics-base/node_modules/@opentelemetry/core": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.2.0.tgz",
-      "integrity": "sha512-QiKp8fBbT9ZhRTP+ZVVMyqH62tD/ZQa4gWPi+GnpNetvK1SWPO/8DmRpaSXHwAhu5FWUDJrbFgpLsrDd1zGPOw==",
+    "node_modules/@opentelemetry/sdk-metrics-base/node_modules/@opentelemetry/api-metrics": {
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-metrics/-/api-metrics-0.30.0.tgz",
+      "integrity": "sha512-jSb7iiYPY+DSUKIyzfGt0a5K1QGzWY5fSWtUB8Alfi27NhQGHBeuYYC5n9MaBP/HNWw5GpEIhXGEYCF9Pf8IEg==",
       "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.2.0"
+        "@opentelemetry/api": "^1.0.0"
       },
       "engines": {
-        "node": ">=8.12.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.2.0"
-      }
-    },
-    "node_modules/@opentelemetry/sdk-metrics-base/node_modules/@opentelemetry/resources": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.2.0.tgz",
-      "integrity": "sha512-S5ZlZa2JF+1qhiF7eb3tTtDfKmTODO//pvam9vEyZvr+/At45rIQ7cyznRdMWCppZbholwXWXnrKml29IIG9vQ==",
-      "dependencies": {
-        "@opentelemetry/core": "1.2.0",
-        "@opentelemetry/semantic-conventions": "1.2.0"
-      },
-      "engines": {
-        "node": ">=8.12.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.2.0"
-      }
-    },
-    "node_modules/@opentelemetry/sdk-metrics-base/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.2.0.tgz",
-      "integrity": "sha512-BNKB9fiYVghALJzCuWO3eNYfdTExPVK4ykrtmfNfy0A6UWYhOYjGMXifUmkunDJNL8ju9tBobo8jF0WR9zGy1Q==",
-      "engines": {
-        "node": ">=8.12.0"
+        "node": ">=14"
       }
     },
     "node_modules/@opentelemetry/sdk-node": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-node/-/sdk-node-0.28.0.tgz",
-      "integrity": "sha512-DNJdaAxcVPFBxHNGfBfwIjeeGk8C0Uv2eG8wnWPlIrhW/803oAt80DXK1NiT3qNeASauHrx3AWozn2sJoua5NA==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-node/-/sdk-node-0.30.0.tgz",
+      "integrity": "sha512-Zq6tpXSVV16CpDbFbAiH0YNWe72oq7Y6RpbcofJ0a2q7ywLWdZpIgh/YDIjkmHQegqCYlZQwMv4Ru+PydFyjzQ==",
       "dependencies": {
-        "@opentelemetry/api-metrics": "0.28.0",
-        "@opentelemetry/core": "1.2.0",
-        "@opentelemetry/instrumentation": "0.28.0",
-        "@opentelemetry/resource-detector-aws": "~1.0.0",
-        "@opentelemetry/resource-detector-gcp": "~0.26.0",
-        "@opentelemetry/resources": "1.2.0",
-        "@opentelemetry/sdk-metrics-base": "0.28.0",
-        "@opentelemetry/sdk-trace-base": "1.2.0",
-        "@opentelemetry/sdk-trace-node": "1.2.0"
+        "@opentelemetry/api-metrics": "0.30.0",
+        "@opentelemetry/core": "1.4.0",
+        "@opentelemetry/instrumentation": "0.30.0",
+        "@opentelemetry/resources": "1.4.0",
+        "@opentelemetry/sdk-metrics-base": "0.30.0",
+        "@opentelemetry/sdk-trace-base": "1.4.0",
+        "@opentelemetry/sdk-trace-node": "1.4.0"
       },
       "engines": {
-        "node": ">=8.12.0"
+        "node": ">=14"
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.2.0"
       }
     },
-    "node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/core": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.2.0.tgz",
-      "integrity": "sha512-QiKp8fBbT9ZhRTP+ZVVMyqH62tD/ZQa4gWPi+GnpNetvK1SWPO/8DmRpaSXHwAhu5FWUDJrbFgpLsrDd1zGPOw==",
+    "node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/api-metrics": {
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-metrics/-/api-metrics-0.30.0.tgz",
+      "integrity": "sha512-jSb7iiYPY+DSUKIyzfGt0a5K1QGzWY5fSWtUB8Alfi27NhQGHBeuYYC5n9MaBP/HNWw5GpEIhXGEYCF9Pf8IEg==",
       "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.2.0"
+        "@opentelemetry/api": "^1.0.0"
       },
       "engines": {
-        "node": ">=8.12.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.2.0"
+        "node": ">=14"
       }
     },
-    "node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/resources": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.2.0.tgz",
-      "integrity": "sha512-S5ZlZa2JF+1qhiF7eb3tTtDfKmTODO//pvam9vEyZvr+/At45rIQ7cyznRdMWCppZbholwXWXnrKml29IIG9vQ==",
+    "node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/instrumentation": {
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.30.0.tgz",
+      "integrity": "sha512-9bjRx81B6wbJ7CGWc/WCUfcb0QIG5UIcjnPTzwYIURjYPd8d0ZzRlrnqEdQG62jn4lSPEvnNqTlyC7qXtn9nAA==",
       "dependencies": {
-        "@opentelemetry/core": "1.2.0",
-        "@opentelemetry/semantic-conventions": "1.2.0"
+        "@opentelemetry/api-metrics": "0.30.0",
+        "require-in-the-middle": "^5.0.3",
+        "semver": "^7.3.2",
+        "shimmer": "^1.2.1"
       },
       "engines": {
-        "node": ">=8.12.0"
+        "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.2.0"
-      }
-    },
-    "node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.2.0.tgz",
-      "integrity": "sha512-BNKB9fiYVghALJzCuWO3eNYfdTExPVK4ykrtmfNfy0A6UWYhOYjGMXifUmkunDJNL8ju9tBobo8jF0WR9zGy1Q==",
-      "engines": {
-        "node": ">=8.12.0"
+        "@opentelemetry/api": "^1.0.0"
       }
     },
     "node_modules/@opentelemetry/sdk-trace-base": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.2.0.tgz",
-      "integrity": "sha512-eHrG9c9OhoDhUmMe63Qzgpcvlgxr2L7BFBbbj2DdZu3vGstayytTT6TDv6mz727lXBqR1HXMbqTGVafS07r3bg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.4.0.tgz",
+      "integrity": "sha512-l7EEjcOgYlKWK0hfxz4Jtkkk2DuGiqBDWmRZf7g2Is9RVneF1IgcrbYZTKGaVfBKA7lPuVtUiQ2qTv3R+dKJrw==",
       "dependencies": {
-        "@opentelemetry/core": "1.2.0",
-        "@opentelemetry/resources": "1.2.0",
-        "@opentelemetry/semantic-conventions": "1.2.0"
+        "@opentelemetry/core": "1.4.0",
+        "@opentelemetry/resources": "1.4.0",
+        "@opentelemetry/semantic-conventions": "1.4.0"
       },
       "engines": {
-        "node": ">=8.12.0"
+        "node": ">=14"
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.2.0"
-      }
-    },
-    "node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/core": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.2.0.tgz",
-      "integrity": "sha512-QiKp8fBbT9ZhRTP+ZVVMyqH62tD/ZQa4gWPi+GnpNetvK1SWPO/8DmRpaSXHwAhu5FWUDJrbFgpLsrDd1zGPOw==",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.2.0"
-      },
-      "engines": {
-        "node": ">=8.12.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.2.0"
-      }
-    },
-    "node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/resources": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.2.0.tgz",
-      "integrity": "sha512-S5ZlZa2JF+1qhiF7eb3tTtDfKmTODO//pvam9vEyZvr+/At45rIQ7cyznRdMWCppZbholwXWXnrKml29IIG9vQ==",
-      "dependencies": {
-        "@opentelemetry/core": "1.2.0",
-        "@opentelemetry/semantic-conventions": "1.2.0"
-      },
-      "engines": {
-        "node": ">=8.12.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.2.0"
-      }
-    },
-    "node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.2.0.tgz",
-      "integrity": "sha512-BNKB9fiYVghALJzCuWO3eNYfdTExPVK4ykrtmfNfy0A6UWYhOYjGMXifUmkunDJNL8ju9tBobo8jF0WR9zGy1Q==",
-      "engines": {
-        "node": ">=8.12.0"
       }
     },
     "node_modules/@opentelemetry/sdk-trace-node": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.2.0.tgz",
-      "integrity": "sha512-QchyGlJ63qosjmEl1Rl0kpX5GTBFqQCWo8L6JdTAufvTexrQwlcvQ5Qy4y2bFX0vQ23d/4aBv5ScRg9V+liZAg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.4.0.tgz",
+      "integrity": "sha512-LET70LwaE8gK3W6jpeG6C7BNbl5m8fnEgNmO0LFXHyl4yofIzficDy06zjgVtPp1urygNuYPtK/4yiactzTvZg==",
       "dependencies": {
-        "@opentelemetry/context-async-hooks": "1.2.0",
-        "@opentelemetry/core": "1.2.0",
-        "@opentelemetry/propagator-b3": "1.2.0",
-        "@opentelemetry/propagator-jaeger": "1.2.0",
-        "@opentelemetry/sdk-trace-base": "1.2.0",
+        "@opentelemetry/context-async-hooks": "1.4.0",
+        "@opentelemetry/core": "1.4.0",
+        "@opentelemetry/propagator-b3": "1.4.0",
+        "@opentelemetry/propagator-jaeger": "1.4.0",
+        "@opentelemetry/sdk-trace-base": "1.4.0",
         "semver": "^7.3.5"
       },
       "engines": {
-        "node": ">=8.12.0"
+        "node": ">=14"
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.2.0"
-      }
-    },
-    "node_modules/@opentelemetry/sdk-trace-node/node_modules/@opentelemetry/core": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.2.0.tgz",
-      "integrity": "sha512-QiKp8fBbT9ZhRTP+ZVVMyqH62tD/ZQa4gWPi+GnpNetvK1SWPO/8DmRpaSXHwAhu5FWUDJrbFgpLsrDd1zGPOw==",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.2.0"
-      },
-      "engines": {
-        "node": ">=8.12.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.2.0"
-      }
-    },
-    "node_modules/@opentelemetry/sdk-trace-node/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.2.0.tgz",
-      "integrity": "sha512-BNKB9fiYVghALJzCuWO3eNYfdTExPVK4ykrtmfNfy0A6UWYhOYjGMXifUmkunDJNL8ju9tBobo8jF0WR9zGy1Q==",
-      "engines": {
-        "node": ">=8.12.0"
       }
     },
     "node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.3.1.tgz",
-      "integrity": "sha512-wU5J8rUoo32oSef/rFpOT1HIjLjAv3qIDHkw1QIhODV3OpAVHi5oVzlouozg9obUmZKtbZ0qUe/m7FP0y0yBzA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.4.0.tgz",
+      "integrity": "sha512-Hzl8soGpmyzja9w3kiFFcYJ7n5HNETpplY6cb67KR4QPlxp4FTTresO06qXHgHDhyIInmbLJXuwARjjpsKYGuQ==",
       "engines": {
-        "node": ">=8.12.0"
+        "node": ">=14"
       }
     },
     "node_modules/@sideway/address": {
@@ -2331,9 +2144,9 @@
       }
     },
     "node_modules/@types/generic-pool": {
-      "version": "3.1.10",
-      "resolved": "https://registry.npmjs.org/@types/generic-pool/-/generic-pool-3.1.10.tgz",
-      "integrity": "sha512-WRT/9taXh9XJRA9yvrbC02IqGZhK9GbFE/vuP2LeSLrqmDzz5wdXsH0Ige/F+3+rbbZfwH3LEazDsU0JiSV3vA==",
+      "version": "3.1.11",
+      "resolved": "https://registry.npmjs.org/@types/generic-pool/-/generic-pool-3.1.11.tgz",
+      "integrity": "sha512-3mcD3ewmaKPbiAZglGj8We4ohlSMfw/xS+bbYUhTv/ALgqrrtJjyL4Ju9IgapXooBCTFEew5LAKQqzZV6/43xg==",
       "dependencies": {
         "@types/node": "*"
       }
@@ -2804,17 +2617,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
-    },
-    "node_modules/abort-controller": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
-      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-      "dependencies": {
-        "event-target-shim": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=6.5"
-      }
     },
     "node_modules/abstract-logging": {
       "version": "2.0.1",
@@ -3300,14 +3102,6 @@
         }
       ]
     },
-    "node_modules/bignumber.js": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.2.tgz",
-      "integrity": "sha512-GAcQvbpsM0pUb0zw1EI0KhQEZ+lRwR5fYaAp3vPOYuP7aDvGy6cVN6XHLauvF8SOga2y0dcLcjt3iQDTSEliyw==",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -3386,9 +3180,9 @@
       }
     },
     "node_modules/bson": {
-      "version": "4.6.4",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-4.6.4.tgz",
-      "integrity": "sha512-TdQ3FzguAu5HKPPlr0kYQCyrYUYh8tFM+CMTpxjNzVzxeiJY00Rtuj3LXLHSgiGvmaWlZ8PE+4KyM2thqE38pQ==",
+      "version": "4.6.5",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-4.6.5.tgz",
+      "integrity": "sha512-uqrgcjyOaZsHfz7ea8zLRCLe1u+QGUSzMZmvXqO24CDW7DWoW1qiN9folSwa7hSneTSgM2ykDIzF5kcQQ8cwNw==",
       "dependencies": {
         "buffer": "^5.6.0"
       },
@@ -4690,14 +4484,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/event-target-shim": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/exec-sh": {
       "version": "0.3.6",
       "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.3.6.tgz",
@@ -4890,11 +4676,6 @@
         "node": ">= 10.14.2"
       }
     },
-    "node_modules/extend": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
-    },
     "node_modules/extend-shallow": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
@@ -5043,9 +4824,9 @@
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="
     },
     "node_modules/fastify": {
-      "version": "3.29.0",
-      "resolved": "https://registry.npmjs.org/fastify/-/fastify-3.29.0.tgz",
-      "integrity": "sha512-zXSiDTdHJCHcmDrSje1f1RfzTmUTjMtHnPhh6cdokgfHhloQ+gy0Du+KlEjwTbcNC3Djj4GAsBzl6KvfI9Ah2g==",
+      "version": "3.29.1",
+      "resolved": "https://registry.npmjs.org/fastify/-/fastify-3.29.1.tgz",
+      "integrity": "sha512-UhGmh0/J0YQetqULYfv/utvut0R6ICQvO6Oh81JvG75UbjVgueqoE6EPChB3gR5aF3dVKpT/qFTgc7zvpGTYNg==",
       "dependencies": {
         "@fastify/ajv-compiler": "^1.0.0",
         "@fastify/error": "^2.0.0",
@@ -5339,33 +5120,6 @@
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/gaxios": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-4.3.3.tgz",
-      "integrity": "sha512-gSaYYIO1Y3wUtdfHmjDUZ8LWaxJQpiavzbF5Kq53akSzvmVg0RfyOcFDbO1KJ/KCGRFz2qG+lS81F0nkr7cRJA==",
-      "dependencies": {
-        "abort-controller": "^3.0.0",
-        "extend": "^3.0.2",
-        "https-proxy-agent": "^5.0.0",
-        "is-stream": "^2.0.0",
-        "node-fetch": "^2.6.7"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/gcp-metadata": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-4.3.1.tgz",
-      "integrity": "sha512-x850LS5N7V1F3UcV7PoupzGsyD6iVwTVvsh3tbXfkctZnBnjW5yu5z1/3k3SehF7TyoTIe78rJs02GMMy+LF+A==",
-      "dependencies": {
-        "gaxios": "^4.0.0",
-        "json-bigint": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/generate-function": {
@@ -7087,14 +6841,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/json-bigint": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
-      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
-      "dependencies": {
-        "bignumber.js": "^9.0.0"
-      }
-    },
     "node_modules/json-parse-better-errors": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
@@ -7848,44 +7594,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.1.0.tgz",
       "integrity": "sha512-flmrDNB06LIl5lywUz7YlNGZH/5p0M7W28k8hzd9Lshtdh1wshD2Y+U4h9LD6KObOy1f+fEVdgprPrEymjM5uw=="
-    },
-    "node_modules/node-fetch": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/node-fetch/node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
-    },
-    "node_modules/node-fetch/node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
-    },
-    "node_modules/node-fetch/node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
     },
     "node_modules/node-gyp": {
       "version": "9.0.0",
@@ -12353,97 +12061,97 @@
       }
     },
     "@opentelemetry/api": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.0.4.tgz",
-      "integrity": "sha512-BuJuXRSJNQ3QoKA6GWWDyuLpOUck+9hAXNMCnrloc1aWVoy6Xq6t9PUV08aBZ4Lutqq2LEHM486bpZqoViScog=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.1.0.tgz",
+      "integrity": "sha512-hf+3bwuBwtXsugA2ULBc95qxrOqP2pOekLz34BJhcAKawt94vfeNyUKpYc0lZQ/3sCP6LqRa7UAdHA7i5UODzQ=="
     },
     "@opentelemetry/api-metrics": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-metrics/-/api-metrics-0.28.0.tgz",
-      "integrity": "sha512-UcrJqEiV20YTibYXUT0TDBtl4uLh4tMpAYSa1g1780QrVMlsOMAnBrdD3EYTMPog14Zw+2QzPnDJ4X7q67YrSA==",
+      "version": "0.29.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-metrics/-/api-metrics-0.29.2.tgz",
+      "integrity": "sha512-yRdF5beqKuEdsPNoO7ijWCQ9HcyN0Tlgicf8RS6gzGOI54d6Hj7yKquJ6+X9XV+CSRbRWJYb+lOsXyso7uyX2g==",
       "requires": {
         "@opentelemetry/api": "^1.0.0"
       }
     },
     "@opentelemetry/auto-instrumentations-node": {
-      "version": "0.30.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/auto-instrumentations-node/-/auto-instrumentations-node-0.30.0.tgz",
-      "integrity": "sha512-4YSvvw8I4Ci09sQPdV3CMorSdUQrfwelUNYIN0CDVxh9TO2gfe9nWbpKYeD88+Sz+jUVFLIdTqPlj+6FQ382NA==",
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/auto-instrumentations-node/-/auto-instrumentations-node-0.31.0.tgz",
+      "integrity": "sha512-UQ4u3hVNGS5B2utNWWp2+R49H8xO7rXk4Q78V5cnnbmLjNtuI597Mm4dXiWGhpNm5LgYyBsxh2HLusQEAJo//A==",
       "requires": {
-        "@opentelemetry/instrumentation": "^0.28.0",
-        "@opentelemetry/instrumentation-amqplib": "^0.29.0",
-        "@opentelemetry/instrumentation-aws-lambda": "^0.31.0",
-        "@opentelemetry/instrumentation-aws-sdk": "^0.7.0",
-        "@opentelemetry/instrumentation-bunyan": "^0.28.0",
-        "@opentelemetry/instrumentation-cassandra-driver": "^0.28.0",
-        "@opentelemetry/instrumentation-connect": "^0.28.0",
-        "@opentelemetry/instrumentation-dns": "^0.28.0",
-        "@opentelemetry/instrumentation-express": "^0.29.0",
-        "@opentelemetry/instrumentation-fastify": "^0.27.0",
-        "@opentelemetry/instrumentation-generic-pool": "^0.28.0",
-        "@opentelemetry/instrumentation-graphql": "^0.28.0",
-        "@opentelemetry/instrumentation-grpc": "^0.28.0",
-        "@opentelemetry/instrumentation-hapi": "^0.28.0",
-        "@opentelemetry/instrumentation-http": "^0.28.0",
-        "@opentelemetry/instrumentation-ioredis": "^0.29.0",
-        "@opentelemetry/instrumentation-knex": "^0.28.0",
-        "@opentelemetry/instrumentation-koa": "^0.29.0",
-        "@opentelemetry/instrumentation-memcached": "^0.28.0",
-        "@opentelemetry/instrumentation-mongodb": "^0.30.0",
-        "@opentelemetry/instrumentation-mysql": "^0.29.0",
-        "@opentelemetry/instrumentation-mysql2": "^0.30.0",
-        "@opentelemetry/instrumentation-nestjs-core": "^0.29.0",
-        "@opentelemetry/instrumentation-net": "^0.28.0",
-        "@opentelemetry/instrumentation-pg": "^0.29.0",
-        "@opentelemetry/instrumentation-pino": "^0.29.0",
-        "@opentelemetry/instrumentation-redis": "^0.31.0",
-        "@opentelemetry/instrumentation-redis-4": "^0.30.0",
-        "@opentelemetry/instrumentation-restify": "^0.28.0",
-        "@opentelemetry/instrumentation-winston": "^0.28.0"
+        "@opentelemetry/instrumentation": "^0.29.2",
+        "@opentelemetry/instrumentation-amqplib": "^0.30.0",
+        "@opentelemetry/instrumentation-aws-lambda": "^0.32.0",
+        "@opentelemetry/instrumentation-aws-sdk": "^0.8.0",
+        "@opentelemetry/instrumentation-bunyan": "^0.29.0",
+        "@opentelemetry/instrumentation-cassandra-driver": "^0.29.0",
+        "@opentelemetry/instrumentation-connect": "^0.29.0",
+        "@opentelemetry/instrumentation-dns": "^0.29.0",
+        "@opentelemetry/instrumentation-express": "^0.30.0",
+        "@opentelemetry/instrumentation-fastify": "^0.28.0",
+        "@opentelemetry/instrumentation-generic-pool": "^0.29.0",
+        "@opentelemetry/instrumentation-graphql": "^0.29.0",
+        "@opentelemetry/instrumentation-grpc": "^0.29.2",
+        "@opentelemetry/instrumentation-hapi": "^0.29.0",
+        "@opentelemetry/instrumentation-http": "^0.29.2",
+        "@opentelemetry/instrumentation-ioredis": "^0.30.0",
+        "@opentelemetry/instrumentation-knex": "^0.29.0",
+        "@opentelemetry/instrumentation-koa": "^0.30.0",
+        "@opentelemetry/instrumentation-memcached": "^0.29.0",
+        "@opentelemetry/instrumentation-mongodb": "^0.31.0",
+        "@opentelemetry/instrumentation-mysql": "^0.30.0",
+        "@opentelemetry/instrumentation-mysql2": "^0.31.0",
+        "@opentelemetry/instrumentation-nestjs-core": "^0.30.0",
+        "@opentelemetry/instrumentation-net": "^0.29.0",
+        "@opentelemetry/instrumentation-pg": "^0.30.0",
+        "@opentelemetry/instrumentation-pino": "^0.30.0",
+        "@opentelemetry/instrumentation-redis": "^0.32.0",
+        "@opentelemetry/instrumentation-redis-4": "^0.31.0",
+        "@opentelemetry/instrumentation-restify": "^0.29.0",
+        "@opentelemetry/instrumentation-winston": "^0.29.0"
       }
     },
     "@opentelemetry/context-async-hooks": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.2.0.tgz",
-      "integrity": "sha512-b0ui4aDc5UtU+EWkQlgyxPrTPjird8RhzdyaruoTyiHECWXs9O6qiTv4GLAnBt1XIPK4A/t5aqdW5whDcXDBnA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.4.0.tgz",
+      "integrity": "sha512-yXpe1qCK3CevzWN3VmLlEOcipNdSV6al204lWMDoBI4eCy3rWZZEAGlwRvIiEy3uPrHClh6BQ5Z0q1+LEB/y8g==",
       "requires": {}
     },
     "@opentelemetry/core": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.3.1.tgz",
-      "integrity": "sha512-k7lOC86N7WIyUZsUuSKZfFIrUtINtlauMGQsC1r7jNmcr0vVJGqK1ROBvt7WWMxLbpMnt1q2pXJO8tKu0b9auA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.4.0.tgz",
+      "integrity": "sha512-faq50VFEdyC7ICAOlhSi+yYZ+peznnGjTJToha9R63i9fVopzpKrkZt7AIdXUmz2+L2OqXrcJs7EIdN/oDyr5w==",
       "requires": {
-        "@opentelemetry/semantic-conventions": "1.3.1"
+        "@opentelemetry/semantic-conventions": "1.4.0"
       }
     },
     "@opentelemetry/instrumentation": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.28.0.tgz",
-      "integrity": "sha512-hcL+U02vp0vcouoMjoJArP0USBuBXnWF+sAt+Z5k77ROEcSCHZh0DkWigWGMyN8w3M5SpoqRlJiXLDM+9RtXNg==",
+      "version": "0.29.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.29.2.tgz",
+      "integrity": "sha512-LXx5V0ONNATQFCE8C5uqnxWSm4rcXLssdLHdXjtGdxRmURqj/JO8jYefqXCD0LzsqEQ6yxOx2GZ0dgXvhBVdTw==",
       "requires": {
-        "@opentelemetry/api-metrics": "0.28.0",
+        "@opentelemetry/api-metrics": "0.29.2",
         "require-in-the-middle": "^5.0.3",
         "semver": "^7.3.2",
         "shimmer": "^1.2.1"
       }
     },
     "@opentelemetry/instrumentation-amqplib": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-amqplib/-/instrumentation-amqplib-0.29.0.tgz",
-      "integrity": "sha512-hoRuD6d/yUm7fUJChKJPsusM3OfD3DlqTZe834g+d9ewDdayRBH6SNlFvIHj68tTbVOZRHmL0k5SBQr3xX/FyA==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-amqplib/-/instrumentation-amqplib-0.30.0.tgz",
+      "integrity": "sha512-aZZgi/O/kwrCIGSkf/7Sy7dB4ZzRTLcnU7A62SZWWU7f6C4KUXQ1TMizwJphF4P8QheqlgqJfoWrw+KDLheJbw==",
       "requires": {
         "@opentelemetry/core": "^1.0.0",
-        "@opentelemetry/instrumentation": "^0.28.0",
+        "@opentelemetry/instrumentation": "^0.29.2",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/amqplib": "^0.5.17"
       }
     },
     "@opentelemetry/instrumentation-aws-lambda": {
-      "version": "0.31.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-aws-lambda/-/instrumentation-aws-lambda-0.31.0.tgz",
-      "integrity": "sha512-Ii8GnwpGVdMXwSnA0gekajwmgP+QgtogekTULEel5en+zx9gNQO9p7zTFb3J/upiEtGYZOzkqKI93Vf7XTFVZA==",
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-aws-lambda/-/instrumentation-aws-lambda-0.32.0.tgz",
+      "integrity": "sha512-mVgd03G292DSkix5ARkTdp/dkPEhLwgwNDhEHsR1isOW2Lw3WKr4dCjMQKAYmbhhj3jg1/ovlwkhEQz6hIqXYQ==",
       "requires": {
-        "@opentelemetry/instrumentation": "^0.28.0",
+        "@opentelemetry/instrumentation": "^0.29.2",
         "@opentelemetry/propagator-aws-xray": "^1.1.0",
         "@opentelemetry/resources": "^1.0.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
@@ -12451,295 +12159,295 @@
       }
     },
     "@opentelemetry/instrumentation-aws-sdk": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-aws-sdk/-/instrumentation-aws-sdk-0.7.0.tgz",
-      "integrity": "sha512-+4ibii4BvdPrIW9MOuj1wnTDkYHpX04gepPNfYcBseC9I5ZOAdz1a2Kj41FpweIlrlz0CPtbuLP2EFCyqb9EaQ==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-aws-sdk/-/instrumentation-aws-sdk-0.8.0.tgz",
+      "integrity": "sha512-F29TmSsq8LWeZZXHV72b3B+QItZPVPsPx1DuQYPcKeCwAJUAg0huukXbf2U2XskA1fmw49+t9AM8fFPdytftyA==",
       "requires": {
         "@opentelemetry/core": "^1.0.0",
-        "@opentelemetry/instrumentation": "^0.28.0",
+        "@opentelemetry/instrumentation": "^0.29.2",
         "@opentelemetry/propagation-utils": "^0.28.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       }
     },
     "@opentelemetry/instrumentation-bunyan": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-bunyan/-/instrumentation-bunyan-0.28.0.tgz",
-      "integrity": "sha512-Fm51yOnaiEOqd1vdWTmLnKLRe8q6zbYhQ/Axe3IlXN6785xXtfJh9WV372cD/pXqqyYMGJTriTsepaA11gzwTQ==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-bunyan/-/instrumentation-bunyan-0.29.0.tgz",
+      "integrity": "sha512-i1FZ+W96vQCIpkMKPZW0HOA79ve9PLIcTAFH0adU/CvtRRMSxyKPTKzWMGHcWr6DueKIPEorpMG+nO2Z/yk9iQ==",
       "requires": {
-        "@opentelemetry/instrumentation": "^0.28.0",
+        "@opentelemetry/instrumentation": "^0.29.2",
         "@types/bunyan": "1.8.7"
       }
     },
     "@opentelemetry/instrumentation-cassandra-driver": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-cassandra-driver/-/instrumentation-cassandra-driver-0.28.0.tgz",
-      "integrity": "sha512-WON4H+Ji53Vfbtgk6eSeT1r0wYYKENlHTX/+XgI2KXjbDsKHvigXe92xbVTW+oRBu76mG6Bx74FcG5YJBysEow==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-cassandra-driver/-/instrumentation-cassandra-driver-0.29.0.tgz",
+      "integrity": "sha512-Wp7ntJVHwI5wN/cTMnBJJeQ8PmgordnHbq+B1k+xzBLPz7Pro+6q8SFmiupZvrZmfzWsdSDaO2XM/6CIdtFB5Q==",
       "requires": {
-        "@opentelemetry/instrumentation": "^0.28.0",
+        "@opentelemetry/instrumentation": "^0.29.2",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       }
     },
     "@opentelemetry/instrumentation-connect": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-connect/-/instrumentation-connect-0.28.0.tgz",
-      "integrity": "sha512-MR5/t7GEhUOyY01Tb9o64LGZS1CfYaVwOuBXCBfupJrXpunHeL87goOxgkXhc6aGMQ9k21z/VC1meJW73hMyRg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-connect/-/instrumentation-connect-0.29.0.tgz",
+      "integrity": "sha512-2BvdIdUCPIYNnROaMToLG76wZXvZXM2L9zOtEFlUnp8teI3Lu2mSPKRaSZ6XAmVVgTAtpfq2IuJMcZ5zAhJuCg==",
       "requires": {
         "@opentelemetry/core": "^1.0.0",
-        "@opentelemetry/instrumentation": "^0.28.0",
+        "@opentelemetry/instrumentation": "^0.29.2",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/connect": "3.4.35"
       }
     },
     "@opentelemetry/instrumentation-dns": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-dns/-/instrumentation-dns-0.28.0.tgz",
-      "integrity": "sha512-2g8bJ9jYG+Xn31tMk/K0QY5gCSntIWhErSdKHMKyrpFmypP+t9LwDO1hqTRMTkdGgWm3dxONi6B4ibPTsusA+Q==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-dns/-/instrumentation-dns-0.29.0.tgz",
+      "integrity": "sha512-3WTC4m6JKviaABiR3a+56WUMvrUp9WW9EYC0+LRpqm7RK/1a5bYq2Cozc2SlFYX9ZfWKMqGS39/fU24mKQ5toA==",
       "requires": {
-        "@opentelemetry/instrumentation": "^0.28.0",
+        "@opentelemetry/instrumentation": "^0.29.2",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "semver": "^7.3.2"
       }
     },
     "@opentelemetry/instrumentation-express": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-express/-/instrumentation-express-0.29.0.tgz",
-      "integrity": "sha512-7pSPNDw9mUlNBRDP20vBQfbVxdjrEz86WKVatIWz1lpJJSLofMFT/IgASt147wnHX05e6sb8wG7q6aRO61UVBg==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-express/-/instrumentation-express-0.30.0.tgz",
+      "integrity": "sha512-OsCfM+ThAXh3wzsyHgXyA5HUoLMdLd6Asix2Jx8yxniruU/Gq8y4Cz7aLy/vXNckXHWO3fwwL5gb7K3dykTnAQ==",
       "requires": {
         "@opentelemetry/core": "^1.0.0",
-        "@opentelemetry/instrumentation": "^0.28.0",
+        "@opentelemetry/instrumentation": "^0.29.2",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/express": "4.17.13"
       }
     },
     "@opentelemetry/instrumentation-fastify": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fastify/-/instrumentation-fastify-0.27.0.tgz",
-      "integrity": "sha512-+63KrwjYt468yWXT0cIISi3iOsowOF4tFcFXjMbXz2UyOk1o940KTh0O6Ynq7xM9kDJnK7iNZl0KxHvSrF9iPQ==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fastify/-/instrumentation-fastify-0.28.0.tgz",
+      "integrity": "sha512-HVvxTDgAhGZqp5k/JA/W4cMpHMy25CXy1pJDOoVB08gC6TKDBg/54iKgLr+g+nqV9RejIKfydt+35Xesynay/g==",
       "requires": {
         "@opentelemetry/core": "^1.0.0",
-        "@opentelemetry/instrumentation": "^0.28.0",
+        "@opentelemetry/instrumentation": "^0.29.2",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "fastify": "^3.19.2"
       }
     },
     "@opentelemetry/instrumentation-generic-pool": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-generic-pool/-/instrumentation-generic-pool-0.28.0.tgz",
-      "integrity": "sha512-PcEroYBqx6Mrb71A+BBzgYIFWwDaT/O8wPeSPcq44dBWV2sZT92k00K2Q8rK8ycS5Iva72kLWh/7cCZUvMThjg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-generic-pool/-/instrumentation-generic-pool-0.29.0.tgz",
+      "integrity": "sha512-tCVIVdGLS4bsFOwYGcbzuESh3XREfdhtMU9iXkULON1KoYi1c68HlWC9yyNQL7yTCBkbYSk2XjWKs6dHbcSf3A==",
       "requires": {
-        "@opentelemetry/instrumentation": "^0.28.0",
+        "@opentelemetry/instrumentation": "^0.29.2",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/generic-pool": "^3.1.9"
       }
     },
     "@opentelemetry/instrumentation-graphql": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-graphql/-/instrumentation-graphql-0.28.0.tgz",
-      "integrity": "sha512-Pisi5nfxVs7j414z/3En3g29LOXW0CzTZLY/MRpXUDDElk4b7d1hJe9hh5kjdRogiuP15ta111KtchaQZjWN6g==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-graphql/-/instrumentation-graphql-0.29.0.tgz",
+      "integrity": "sha512-mAjz326UtWGQUAmmEY6VB4XV1kbgQGBmRWjh/QT0giLwcbKa9RdO0x0B+VbALbrth7ZtHuoyKaDjCWowuzUujw==",
       "requires": {
-        "@opentelemetry/instrumentation": "^0.28.0",
+        "@opentelemetry/instrumentation": "^0.29.2",
         "graphql": "^15.5.1"
       }
     },
     "@opentelemetry/instrumentation-grpc": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-grpc/-/instrumentation-grpc-0.28.0.tgz",
-      "integrity": "sha512-MRYLENztpQKr3/f3ps09x9wxJ+kg3pNNqPz1qzW95w//eIxwye5repK3auXLdVib+e8md9elhpqDmlUjtKs75w==",
+      "version": "0.29.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-grpc/-/instrumentation-grpc-0.29.2.tgz",
+      "integrity": "sha512-rWyx/a7CsEYopwxaND47z+I8SrTLTHEz9sm8sf30FkMviVyRzYqt2PJT+JMGInM7Om/IpZNEc29kSzUjLmqddQ==",
       "requires": {
-        "@opentelemetry/api-metrics": "0.28.0",
-        "@opentelemetry/instrumentation": "0.28.0",
-        "@opentelemetry/semantic-conventions": "1.2.0"
+        "@opentelemetry/api-metrics": "0.29.2",
+        "@opentelemetry/instrumentation": "0.29.2",
+        "@opentelemetry/semantic-conventions": "1.3.1"
       },
       "dependencies": {
         "@opentelemetry/semantic-conventions": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.2.0.tgz",
-          "integrity": "sha512-BNKB9fiYVghALJzCuWO3eNYfdTExPVK4ykrtmfNfy0A6UWYhOYjGMXifUmkunDJNL8ju9tBobo8jF0WR9zGy1Q=="
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.3.1.tgz",
+          "integrity": "sha512-wU5J8rUoo32oSef/rFpOT1HIjLjAv3qIDHkw1QIhODV3OpAVHi5oVzlouozg9obUmZKtbZ0qUe/m7FP0y0yBzA=="
         }
       }
     },
     "@opentelemetry/instrumentation-hapi": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-hapi/-/instrumentation-hapi-0.28.0.tgz",
-      "integrity": "sha512-DzOB1JtwgIU0WJVqPxQPcW7HrLN63YXkRU0tlYt63tzdLNEErgLHvfxzQLZxBxGekzKpUC9wRUw0gFgXiOPiSw==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-hapi/-/instrumentation-hapi-0.29.0.tgz",
+      "integrity": "sha512-yqfuKALO20Mx6F8GStnwTmD/JUhR9JGV3GJVH3UJ5TDAvz61hhoQWaBm0iAP5cJhrKRMD8mictAT2OiHSPUpLw==",
       "requires": {
         "@opentelemetry/core": "^1.0.0",
-        "@opentelemetry/instrumentation": "^0.28.0",
+        "@opentelemetry/instrumentation": "^0.29.2",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/hapi__hapi": "20.0.9"
       }
     },
     "@opentelemetry/instrumentation-http": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.28.0.tgz",
-      "integrity": "sha512-j6nqdGekv7Xtq3uRgiHdRrf1s9Y/fJTD//z8NG2RHGJAlOPRIzDO4m2tzZ5DX03Yzbb7tVgRsYhJJVsinQl9Bw==",
+      "version": "0.29.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.29.2.tgz",
+      "integrity": "sha512-XIF9WCH03rp3vQjwXXVdTxlsXT2AG6LYfFKO8r2QC+w4F4KFuZa4J3VPYJ0L/a/6dWt34DA67eBh3l6Z1rMZrg==",
       "requires": {
-        "@opentelemetry/core": "1.2.0",
-        "@opentelemetry/instrumentation": "0.28.0",
-        "@opentelemetry/semantic-conventions": "1.2.0",
+        "@opentelemetry/core": "1.3.1",
+        "@opentelemetry/instrumentation": "0.29.2",
+        "@opentelemetry/semantic-conventions": "1.3.1",
         "semver": "^7.3.5"
       },
       "dependencies": {
         "@opentelemetry/core": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.2.0.tgz",
-          "integrity": "sha512-QiKp8fBbT9ZhRTP+ZVVMyqH62tD/ZQa4gWPi+GnpNetvK1SWPO/8DmRpaSXHwAhu5FWUDJrbFgpLsrDd1zGPOw==",
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.3.1.tgz",
+          "integrity": "sha512-k7lOC86N7WIyUZsUuSKZfFIrUtINtlauMGQsC1r7jNmcr0vVJGqK1ROBvt7WWMxLbpMnt1q2pXJO8tKu0b9auA==",
           "requires": {
-            "@opentelemetry/semantic-conventions": "1.2.0"
+            "@opentelemetry/semantic-conventions": "1.3.1"
           }
         },
         "@opentelemetry/semantic-conventions": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.2.0.tgz",
-          "integrity": "sha512-BNKB9fiYVghALJzCuWO3eNYfdTExPVK4ykrtmfNfy0A6UWYhOYjGMXifUmkunDJNL8ju9tBobo8jF0WR9zGy1Q=="
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.3.1.tgz",
+          "integrity": "sha512-wU5J8rUoo32oSef/rFpOT1HIjLjAv3qIDHkw1QIhODV3OpAVHi5oVzlouozg9obUmZKtbZ0qUe/m7FP0y0yBzA=="
         }
       }
     },
     "@opentelemetry/instrumentation-ioredis": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-ioredis/-/instrumentation-ioredis-0.29.0.tgz",
-      "integrity": "sha512-buZzi94XiXsv9H0wtJ3tiOWHe//83BCVozxHn5Gc/AefJSp//xe0zUdgJ3LBFuJSv5JEh4Xj7QvtjRqlG+yLGA==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-ioredis/-/instrumentation-ioredis-0.30.0.tgz",
+      "integrity": "sha512-iYdVWRz53kZ3DsEMt5es8KF+OrfRi4M6gSQYA7q6OcVXrucAUZA+juK8Rl3IgWjXG5wKCzr/liKs6HDAVJ9f/Q==",
       "requires": {
-        "@opentelemetry/instrumentation": "^0.28.0",
+        "@opentelemetry/instrumentation": "^0.29.2",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/ioredis": "4.26.6"
       }
     },
     "@opentelemetry/instrumentation-knex": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-knex/-/instrumentation-knex-0.28.0.tgz",
-      "integrity": "sha512-bUnFg8VA8e+WrqFzdyNQO7/nzsOdnQg7UzANB+5xwzsCL8JyDoxATwaM7Xxe7y6bk2g0GexyuwgytLwCJxONqQ==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-knex/-/instrumentation-knex-0.29.0.tgz",
+      "integrity": "sha512-M00bEYxl5VZV53jVxxnweGrEO9AMuSPIAz1mIzk/Z3bXU/KK9GxCBCZajwxdXv1SKj6KMQ+mOfXOOnY8Y0Wbcg==",
       "requires": {
-        "@opentelemetry/instrumentation": "^0.28.0",
+        "@opentelemetry/instrumentation": "^0.29.2",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       }
     },
     "@opentelemetry/instrumentation-koa": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-koa/-/instrumentation-koa-0.29.0.tgz",
-      "integrity": "sha512-ycuNJT7PyR9eDuKu5WgPbgs7pn0BjCogX+USQ3mBkfQwQn8jbjZW1ntEsbZ7AoehYsGhaP4X+WuE9hRXyndduw==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-koa/-/instrumentation-koa-0.30.0.tgz",
+      "integrity": "sha512-GWm8L8HzMK0f+ZpRhBQc+JVwNL7+7zAm9w/HVAzfCGJyushU/wWkso1xOlwumiJndfRaqYqxg9FW32Yw3vYrng==",
       "requires": {
         "@opentelemetry/core": "^1.0.0",
-        "@opentelemetry/instrumentation": "^0.28.0",
+        "@opentelemetry/instrumentation": "^0.29.2",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/koa": "2.13.4",
         "@types/koa__router": "8.0.7"
       }
     },
     "@opentelemetry/instrumentation-memcached": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-memcached/-/instrumentation-memcached-0.28.0.tgz",
-      "integrity": "sha512-o2SOwSs8oOgNf1w9UOMAHCEzEtf5IKVjuSQe5hicJJ2LmGC56CNKw8aeY7QYsS2BCydnr8cpL1g8GhG4sQ0KgA==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-memcached/-/instrumentation-memcached-0.29.0.tgz",
+      "integrity": "sha512-th+zERg1/1DpCVZ3doKPmjVnbPFBZO5RHcteFkt28ibYTrPEL6K4EciTybdIyC10madFOJRydC9lfvDfgY857g==",
       "requires": {
-        "@opentelemetry/instrumentation": "^0.28.0",
+        "@opentelemetry/instrumentation": "^0.29.2",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/memcached": "^2.2.6"
       }
     },
     "@opentelemetry/instrumentation-mongodb": {
-      "version": "0.30.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongodb/-/instrumentation-mongodb-0.30.0.tgz",
-      "integrity": "sha512-E2KayCr/whhCjFHZILjuMURzehFpI4aNlQ/lUFyHkc+tXSUlohHWsIriMxCIlHOZx51RTPuq7u2tix+GxXCV8g==",
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongodb/-/instrumentation-mongodb-0.31.0.tgz",
+      "integrity": "sha512-4pyjBeSZucUoKoQqqjwv693NmvvG7/HFCFUwN+f1wxliRq+2uuJoT/bp9wcrwLG4IW+8QvxVyN++Hn5LgQeSwQ==",
       "requires": {
-        "@opentelemetry/instrumentation": "^0.28.0",
+        "@opentelemetry/instrumentation": "^0.29.2",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/mongodb": "3.6.20"
       }
     },
     "@opentelemetry/instrumentation-mysql": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql/-/instrumentation-mysql-0.29.0.tgz",
-      "integrity": "sha512-vNeEScgtswbgzMu8mVC+Wl74DLurxZAFELmzP2R6ws3Gumat6cNe81MtFM9jwWoDjiB/6ga6G8WfWUUHgWEuqQ==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql/-/instrumentation-mysql-0.30.0.tgz",
+      "integrity": "sha512-FdbZ2Yb15OTGa6HZYXxUL0yhcXNec2HHbUp9nn3x2B9YO9bJHJQoNVyHVd5gssMVYKFg4dgZodY/YXYu9xj2Ow==",
       "requires": {
-        "@opentelemetry/instrumentation": "^0.28.0",
+        "@opentelemetry/instrumentation": "^0.29.2",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/mysql": "2.15.19"
       }
     },
     "@opentelemetry/instrumentation-mysql2": {
-      "version": "0.30.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql2/-/instrumentation-mysql2-0.30.0.tgz",
-      "integrity": "sha512-bwi7UzgCYJFriMUlnpRPlP+8GechI07lGXJr/wZ1+qYlBnxJT17Qr/6pKEN89nfJhYwwdNTM2toqtIopfZnsVw==",
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql2/-/instrumentation-mysql2-0.31.0.tgz",
+      "integrity": "sha512-Pcm9i0dwLk5yvP11knL8z63Cu0djy9CYSE3ZDvIQinF/HcOmFTKUYqIeX+8XZkIupgDmeFEy6rWZEvvko8sanw==",
       "requires": {
-        "@opentelemetry/instrumentation": "^0.28.0",
+        "@opentelemetry/instrumentation": "^0.29.2",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       }
     },
     "@opentelemetry/instrumentation-nestjs-core": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-nestjs-core/-/instrumentation-nestjs-core-0.29.0.tgz",
-      "integrity": "sha512-ArGeud9aUyd5cnkpGbGyi+ptszjpVpgYurD+a1sIWYm7snKrN/mXRJ4Rj/h27Z9eeW0DtO1ojKASqO60ulIxMw==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-nestjs-core/-/instrumentation-nestjs-core-0.30.0.tgz",
+      "integrity": "sha512-z9HSjL4Udx2tteqyjvzrmNk6mxhip4BkWSWWZKN0z7t+waIHKfTTgJiTn5/YxwGYLUIKVigmNlAoo987rmK+xA==",
       "requires": {
-        "@opentelemetry/instrumentation": "^0.28.0",
+        "@opentelemetry/instrumentation": "^0.29.2",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       }
     },
     "@opentelemetry/instrumentation-net": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-net/-/instrumentation-net-0.28.0.tgz",
-      "integrity": "sha512-VtP5tjfiGcgF7qZM7m0f69v3rDtH7+/gI5CHO21EmefcvqLJDQmk7LtuURXjuTIswznT6snPna/k2KpiM/TtbA==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-net/-/instrumentation-net-0.29.0.tgz",
+      "integrity": "sha512-93acTBKvrzyTbQ5g+VItpCqxMn0lcLb8re7wOh7v+hnMAaKc431fcPuVbOcsNHdMZ7LF1qnOZfs0sooT/chIDA==",
       "requires": {
-        "@opentelemetry/instrumentation": "^0.28.0",
+        "@opentelemetry/instrumentation": "^0.29.2",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       }
     },
     "@opentelemetry/instrumentation-pg": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pg/-/instrumentation-pg-0.29.0.tgz",
-      "integrity": "sha512-ANHxShvLlp+B+TFFGDZ+ZyzRFCa3JrDwwGM63JptMZZDAiXsOj7vQGTvwegy5r5S+rRzt/Ebei1mfz0B9xFgIQ==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pg/-/instrumentation-pg-0.30.0.tgz",
+      "integrity": "sha512-RQ3cTTJnCBE/9GagjSpaM+yzxN25MvEwOxDFes3y8c1cqrMgqxukQLm3MbcqCQ8e1g/8d18+oyiEeBUjZJ5jnw==",
       "requires": {
-        "@opentelemetry/instrumentation": "^0.28.0",
+        "@opentelemetry/instrumentation": "^0.29.2",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/pg": "8.6.1",
         "@types/pg-pool": "2.0.3"
       }
     },
     "@opentelemetry/instrumentation-pino": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pino/-/instrumentation-pino-0.29.0.tgz",
-      "integrity": "sha512-01PILc/y1pBqyE0FfXAMMxWrx8VYPxu3MiyOqW7HkUWCQD0eBGuzO4fgprEksEYfmHiDcvRFUwmHW7c9LoflPA==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pino/-/instrumentation-pino-0.30.0.tgz",
+      "integrity": "sha512-ZbmRL58f3Qviwai/JunUZb/uKo1NYRLdCrKoss7seJ3mEvuTcgTIVeo93PSqxk2c4LMdvkTcNAcIAv1Ymw/PyQ==",
       "requires": {
-        "@opentelemetry/instrumentation": "^0.28.0",
+        "@opentelemetry/instrumentation": "^0.29.2",
         "pino": "7.10.0",
         "semver": "^7.3.5"
       }
     },
     "@opentelemetry/instrumentation-redis": {
-      "version": "0.31.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis/-/instrumentation-redis-0.31.0.tgz",
-      "integrity": "sha512-c1nrWEl7eITOZVnLwqAyAzZ7Fc1ZbJ+N0J55XaggstYgbcG7XiPywfXY76CC7a10D/K3aCq3b2MRar30Cm6eyg==",
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis/-/instrumentation-redis-0.32.0.tgz",
+      "integrity": "sha512-KaZnYhz8dZ9gHkvrBo2U7bp/HABM2JXd3i6e8cUP8MyNA8x5P+EUbeSzzBMe6bAZH35S60dAQbBAhRji3ZlPRw==",
       "requires": {
-        "@opentelemetry/instrumentation": "^0.28.0",
+        "@opentelemetry/instrumentation": "^0.29.2",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/redis": "2.8.31"
       }
     },
     "@opentelemetry/instrumentation-redis-4": {
-      "version": "0.30.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis-4/-/instrumentation-redis-4-0.30.0.tgz",
-      "integrity": "sha512-/Unwo2pPKj3pCzvXcequxktVqr7w5XMFQwjY6K9d835nPk9dsqRnPUeyowL8VbsobjULXFOwB6YmlYz0Z0SncA==",
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis-4/-/instrumentation-redis-4-0.31.0.tgz",
+      "integrity": "sha512-3DY6bkqKnVlPc2WWHelb6DnU78ryYLQFqv0lqnVsoSkr7b6hnmw1Bzuwo/5YmS4C3XuTAD4/6dZVrQJ23g8HNA==",
       "requires": {
-        "@opentelemetry/instrumentation": "^0.28.0",
+        "@opentelemetry/instrumentation": "^0.29.2",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       }
     },
     "@opentelemetry/instrumentation-restify": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-restify/-/instrumentation-restify-0.28.0.tgz",
-      "integrity": "sha512-wbqy4NB4/X8M3LL+tETPV1DUH7o7blVFZiSI/wzHxgV2IPzmvrBEe33FT/OPhlDiTjMNpRSst+FJqfbEeY6O0w==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-restify/-/instrumentation-restify-0.29.0.tgz",
+      "integrity": "sha512-jjXtzNut03FBernMrEjJnkX9SdUAjpGh04mauR2GhBjSrkQg73gS7jeMS/xyN6/ufphA0tyFygxNPOWFvjXM6g==",
       "requires": {
         "@opentelemetry/core": "^1.0.0",
-        "@opentelemetry/instrumentation": "^0.28.0",
+        "@opentelemetry/instrumentation": "^0.29.2",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/restify": "4.3.8"
       }
     },
     "@opentelemetry/instrumentation-winston": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-winston/-/instrumentation-winston-0.28.0.tgz",
-      "integrity": "sha512-NJESVbQiKOt78R7xoRTHQ32gysMH5VsU6EzdwoB5UHtVa4/GXPhisyZUpxSOcukYBbhrwn0orHTypOwko2bD7Q==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-winston/-/instrumentation-winston-0.29.0.tgz",
+      "integrity": "sha512-z48oitpODk5BkJXp4OlRLAQf5JLH0jcSmHvqhlgB9tHddNG+xQWa1Xb0kyBX4i4r0jGFR7cvImIb53wrEavUBA==",
       "requires": {
-        "@opentelemetry/instrumentation": "^0.28.0"
+        "@opentelemetry/instrumentation": "^0.29.2"
       }
     },
     "@opentelemetry/propagation-utils": {
@@ -12757,232 +12465,113 @@
       }
     },
     "@opentelemetry/propagator-b3": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.2.0.tgz",
-      "integrity": "sha512-sjZNnJb3Dz8il5hvaDcScSMBZcwsAs8rnZ4cXMhe3Gv4ewO0x+B7rzWS4k7wDwXPijmuTFy3mj0otDiJhp6bVA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.4.0.tgz",
+      "integrity": "sha512-KKFjvU2qrOEoK2S9FfSkE11u3AVxCniJOH7av6pmbFwkv1YD6uHNqvjvY4Xe6VwFOyKuTYS69VydO9OjJ5gvVA==",
       "requires": {
-        "@opentelemetry/core": "1.2.0"
-      },
-      "dependencies": {
-        "@opentelemetry/core": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.2.0.tgz",
-          "integrity": "sha512-QiKp8fBbT9ZhRTP+ZVVMyqH62tD/ZQa4gWPi+GnpNetvK1SWPO/8DmRpaSXHwAhu5FWUDJrbFgpLsrDd1zGPOw==",
-          "requires": {
-            "@opentelemetry/semantic-conventions": "1.2.0"
-          }
-        },
-        "@opentelemetry/semantic-conventions": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.2.0.tgz",
-          "integrity": "sha512-BNKB9fiYVghALJzCuWO3eNYfdTExPVK4ykrtmfNfy0A6UWYhOYjGMXifUmkunDJNL8ju9tBobo8jF0WR9zGy1Q=="
-        }
+        "@opentelemetry/core": "1.4.0"
       }
     },
     "@opentelemetry/propagator-jaeger": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.2.0.tgz",
-      "integrity": "sha512-xs/7VTADlCbMY96dMmgS4RKokZ6k5EfFgWcQriaIkpM+Mb/Snh4wZlfAx4Mr4vPCVM92MwshZ02WI2Ssg0DU8w==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.4.0.tgz",
+      "integrity": "sha512-LvSzgt9RIGYiMP9E45ifT5WtALsDyY74y/1Ol0DK4xmJt8Sku7YastjCZaxpsvLGA4CGAtth0ozic88AvJrmgw==",
       "requires": {
-        "@opentelemetry/core": "1.2.0"
-      },
-      "dependencies": {
-        "@opentelemetry/core": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.2.0.tgz",
-          "integrity": "sha512-QiKp8fBbT9ZhRTP+ZVVMyqH62tD/ZQa4gWPi+GnpNetvK1SWPO/8DmRpaSXHwAhu5FWUDJrbFgpLsrDd1zGPOw==",
-          "requires": {
-            "@opentelemetry/semantic-conventions": "1.2.0"
-          }
-        },
-        "@opentelemetry/semantic-conventions": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.2.0.tgz",
-          "integrity": "sha512-BNKB9fiYVghALJzCuWO3eNYfdTExPVK4ykrtmfNfy0A6UWYhOYjGMXifUmkunDJNL8ju9tBobo8jF0WR9zGy1Q=="
-        }
-      }
-    },
-    "@opentelemetry/resource-detector-aws": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-aws/-/resource-detector-aws-1.0.3.tgz",
-      "integrity": "sha512-0bhy8L1JZfqGqMjaPu1tV3rBsmtN42+wycJYhxMBbaB4E0ZDshDLnBHn3AeLMPLtFUqiyyn48JluuBfD7KPkhA==",
-      "requires": {
-        "@opentelemetry/core": "^1.0.0",
-        "@opentelemetry/resources": "^1.0.0",
-        "@opentelemetry/semantic-conventions": "^1.0.0"
-      }
-    },
-    "@opentelemetry/resource-detector-gcp": {
-      "version": "0.26.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-gcp/-/resource-detector-gcp-0.26.2.tgz",
-      "integrity": "sha512-CuFqdUGfQtVJ6paaasUaUN6dHxbu0CpUFnHws4Vj/K5SDUxR4l3/Vy5SvMiQ21mRCkeDDDbnw8cPEoA/xGKTrg==",
-      "requires": {
-        "@opentelemetry/resources": "^1.0.0",
-        "@opentelemetry/semantic-conventions": "^1.0.0",
-        "gcp-metadata": "^4.1.4",
-        "semver": "7.3.5"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "7.3.5",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        }
+        "@opentelemetry/core": "1.4.0"
       }
     },
     "@opentelemetry/resources": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.3.1.tgz",
-      "integrity": "sha512-X8bl3X0YjlsHWy0Iv0KUETtZuRUznX4yr1iScKCtfy8AoRfZFc2xxWKMDJ0TrqYwSapgeg4YwpmRzUKmmnrbeA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.4.0.tgz",
+      "integrity": "sha512-Q3pI5+pCM+Ur7YwK9GbG89UBipwJbfmuzSPAXTw964ZHFzSrz+JAgrETC9rqsUOYdUlj/V7LbRMG5bo72xE0Xw==",
       "requires": {
-        "@opentelemetry/core": "1.3.1",
-        "@opentelemetry/semantic-conventions": "1.3.1"
+        "@opentelemetry/core": "1.4.0",
+        "@opentelemetry/semantic-conventions": "1.4.0"
       }
     },
     "@opentelemetry/sdk-metrics-base": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics-base/-/sdk-metrics-base-0.28.0.tgz",
-      "integrity": "sha512-PFjk9+WWU6Y51ZjxClnPW1rzTtcT79pR1FTiFjTsNmKSG0zU3qvUHAoTo0+jvvrO0Djihj7AE+iIG2xLWY4GNQ==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics-base/-/sdk-metrics-base-0.30.0.tgz",
+      "integrity": "sha512-3BDg1MYDInDyGvy+bSH8OuCX5nsue7omH6Y2eidCGTTDYRPxDmq9tsRJxnTUepoMAvWX+1sTwZ4JqTFmc1z8Mw==",
       "requires": {
-        "@opentelemetry/api-metrics": "0.28.0",
-        "@opentelemetry/core": "1.2.0",
-        "@opentelemetry/resources": "1.2.0",
+        "@opentelemetry/api-metrics": "0.30.0",
+        "@opentelemetry/core": "1.4.0",
+        "@opentelemetry/resources": "1.4.0",
         "lodash.merge": "4.6.2"
       },
       "dependencies": {
-        "@opentelemetry/core": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.2.0.tgz",
-          "integrity": "sha512-QiKp8fBbT9ZhRTP+ZVVMyqH62tD/ZQa4gWPi+GnpNetvK1SWPO/8DmRpaSXHwAhu5FWUDJrbFgpLsrDd1zGPOw==",
+        "@opentelemetry/api-metrics": {
+          "version": "0.30.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/api-metrics/-/api-metrics-0.30.0.tgz",
+          "integrity": "sha512-jSb7iiYPY+DSUKIyzfGt0a5K1QGzWY5fSWtUB8Alfi27NhQGHBeuYYC5n9MaBP/HNWw5GpEIhXGEYCF9Pf8IEg==",
           "requires": {
-            "@opentelemetry/semantic-conventions": "1.2.0"
+            "@opentelemetry/api": "^1.0.0"
           }
-        },
-        "@opentelemetry/resources": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.2.0.tgz",
-          "integrity": "sha512-S5ZlZa2JF+1qhiF7eb3tTtDfKmTODO//pvam9vEyZvr+/At45rIQ7cyznRdMWCppZbholwXWXnrKml29IIG9vQ==",
-          "requires": {
-            "@opentelemetry/core": "1.2.0",
-            "@opentelemetry/semantic-conventions": "1.2.0"
-          }
-        },
-        "@opentelemetry/semantic-conventions": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.2.0.tgz",
-          "integrity": "sha512-BNKB9fiYVghALJzCuWO3eNYfdTExPVK4ykrtmfNfy0A6UWYhOYjGMXifUmkunDJNL8ju9tBobo8jF0WR9zGy1Q=="
         }
       }
     },
     "@opentelemetry/sdk-node": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-node/-/sdk-node-0.28.0.tgz",
-      "integrity": "sha512-DNJdaAxcVPFBxHNGfBfwIjeeGk8C0Uv2eG8wnWPlIrhW/803oAt80DXK1NiT3qNeASauHrx3AWozn2sJoua5NA==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-node/-/sdk-node-0.30.0.tgz",
+      "integrity": "sha512-Zq6tpXSVV16CpDbFbAiH0YNWe72oq7Y6RpbcofJ0a2q7ywLWdZpIgh/YDIjkmHQegqCYlZQwMv4Ru+PydFyjzQ==",
       "requires": {
-        "@opentelemetry/api-metrics": "0.28.0",
-        "@opentelemetry/core": "1.2.0",
-        "@opentelemetry/instrumentation": "0.28.0",
-        "@opentelemetry/resource-detector-aws": "~1.0.0",
-        "@opentelemetry/resource-detector-gcp": "~0.26.0",
-        "@opentelemetry/resources": "1.2.0",
-        "@opentelemetry/sdk-metrics-base": "0.28.0",
-        "@opentelemetry/sdk-trace-base": "1.2.0",
-        "@opentelemetry/sdk-trace-node": "1.2.0"
+        "@opentelemetry/api-metrics": "0.30.0",
+        "@opentelemetry/core": "1.4.0",
+        "@opentelemetry/instrumentation": "0.30.0",
+        "@opentelemetry/resources": "1.4.0",
+        "@opentelemetry/sdk-metrics-base": "0.30.0",
+        "@opentelemetry/sdk-trace-base": "1.4.0",
+        "@opentelemetry/sdk-trace-node": "1.4.0"
       },
       "dependencies": {
-        "@opentelemetry/core": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.2.0.tgz",
-          "integrity": "sha512-QiKp8fBbT9ZhRTP+ZVVMyqH62tD/ZQa4gWPi+GnpNetvK1SWPO/8DmRpaSXHwAhu5FWUDJrbFgpLsrDd1zGPOw==",
+        "@opentelemetry/api-metrics": {
+          "version": "0.30.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/api-metrics/-/api-metrics-0.30.0.tgz",
+          "integrity": "sha512-jSb7iiYPY+DSUKIyzfGt0a5K1QGzWY5fSWtUB8Alfi27NhQGHBeuYYC5n9MaBP/HNWw5GpEIhXGEYCF9Pf8IEg==",
           "requires": {
-            "@opentelemetry/semantic-conventions": "1.2.0"
+            "@opentelemetry/api": "^1.0.0"
           }
         },
-        "@opentelemetry/resources": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.2.0.tgz",
-          "integrity": "sha512-S5ZlZa2JF+1qhiF7eb3tTtDfKmTODO//pvam9vEyZvr+/At45rIQ7cyznRdMWCppZbholwXWXnrKml29IIG9vQ==",
+        "@opentelemetry/instrumentation": {
+          "version": "0.30.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.30.0.tgz",
+          "integrity": "sha512-9bjRx81B6wbJ7CGWc/WCUfcb0QIG5UIcjnPTzwYIURjYPd8d0ZzRlrnqEdQG62jn4lSPEvnNqTlyC7qXtn9nAA==",
           "requires": {
-            "@opentelemetry/core": "1.2.0",
-            "@opentelemetry/semantic-conventions": "1.2.0"
+            "@opentelemetry/api-metrics": "0.30.0",
+            "require-in-the-middle": "^5.0.3",
+            "semver": "^7.3.2",
+            "shimmer": "^1.2.1"
           }
-        },
-        "@opentelemetry/semantic-conventions": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.2.0.tgz",
-          "integrity": "sha512-BNKB9fiYVghALJzCuWO3eNYfdTExPVK4ykrtmfNfy0A6UWYhOYjGMXifUmkunDJNL8ju9tBobo8jF0WR9zGy1Q=="
         }
       }
     },
     "@opentelemetry/sdk-trace-base": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.2.0.tgz",
-      "integrity": "sha512-eHrG9c9OhoDhUmMe63Qzgpcvlgxr2L7BFBbbj2DdZu3vGstayytTT6TDv6mz727lXBqR1HXMbqTGVafS07r3bg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.4.0.tgz",
+      "integrity": "sha512-l7EEjcOgYlKWK0hfxz4Jtkkk2DuGiqBDWmRZf7g2Is9RVneF1IgcrbYZTKGaVfBKA7lPuVtUiQ2qTv3R+dKJrw==",
       "requires": {
-        "@opentelemetry/core": "1.2.0",
-        "@opentelemetry/resources": "1.2.0",
-        "@opentelemetry/semantic-conventions": "1.2.0"
-      },
-      "dependencies": {
-        "@opentelemetry/core": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.2.0.tgz",
-          "integrity": "sha512-QiKp8fBbT9ZhRTP+ZVVMyqH62tD/ZQa4gWPi+GnpNetvK1SWPO/8DmRpaSXHwAhu5FWUDJrbFgpLsrDd1zGPOw==",
-          "requires": {
-            "@opentelemetry/semantic-conventions": "1.2.0"
-          }
-        },
-        "@opentelemetry/resources": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.2.0.tgz",
-          "integrity": "sha512-S5ZlZa2JF+1qhiF7eb3tTtDfKmTODO//pvam9vEyZvr+/At45rIQ7cyznRdMWCppZbholwXWXnrKml29IIG9vQ==",
-          "requires": {
-            "@opentelemetry/core": "1.2.0",
-            "@opentelemetry/semantic-conventions": "1.2.0"
-          }
-        },
-        "@opentelemetry/semantic-conventions": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.2.0.tgz",
-          "integrity": "sha512-BNKB9fiYVghALJzCuWO3eNYfdTExPVK4ykrtmfNfy0A6UWYhOYjGMXifUmkunDJNL8ju9tBobo8jF0WR9zGy1Q=="
-        }
+        "@opentelemetry/core": "1.4.0",
+        "@opentelemetry/resources": "1.4.0",
+        "@opentelemetry/semantic-conventions": "1.4.0"
       }
     },
     "@opentelemetry/sdk-trace-node": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.2.0.tgz",
-      "integrity": "sha512-QchyGlJ63qosjmEl1Rl0kpX5GTBFqQCWo8L6JdTAufvTexrQwlcvQ5Qy4y2bFX0vQ23d/4aBv5ScRg9V+liZAg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.4.0.tgz",
+      "integrity": "sha512-LET70LwaE8gK3W6jpeG6C7BNbl5m8fnEgNmO0LFXHyl4yofIzficDy06zjgVtPp1urygNuYPtK/4yiactzTvZg==",
       "requires": {
-        "@opentelemetry/context-async-hooks": "1.2.0",
-        "@opentelemetry/core": "1.2.0",
-        "@opentelemetry/propagator-b3": "1.2.0",
-        "@opentelemetry/propagator-jaeger": "1.2.0",
-        "@opentelemetry/sdk-trace-base": "1.2.0",
+        "@opentelemetry/context-async-hooks": "1.4.0",
+        "@opentelemetry/core": "1.4.0",
+        "@opentelemetry/propagator-b3": "1.4.0",
+        "@opentelemetry/propagator-jaeger": "1.4.0",
+        "@opentelemetry/sdk-trace-base": "1.4.0",
         "semver": "^7.3.5"
-      },
-      "dependencies": {
-        "@opentelemetry/core": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.2.0.tgz",
-          "integrity": "sha512-QiKp8fBbT9ZhRTP+ZVVMyqH62tD/ZQa4gWPi+GnpNetvK1SWPO/8DmRpaSXHwAhu5FWUDJrbFgpLsrDd1zGPOw==",
-          "requires": {
-            "@opentelemetry/semantic-conventions": "1.2.0"
-          }
-        },
-        "@opentelemetry/semantic-conventions": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.2.0.tgz",
-          "integrity": "sha512-BNKB9fiYVghALJzCuWO3eNYfdTExPVK4ykrtmfNfy0A6UWYhOYjGMXifUmkunDJNL8ju9tBobo8jF0WR9zGy1Q=="
-        }
       }
     },
     "@opentelemetry/semantic-conventions": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.3.1.tgz",
-      "integrity": "sha512-wU5J8rUoo32oSef/rFpOT1HIjLjAv3qIDHkw1QIhODV3OpAVHi5oVzlouozg9obUmZKtbZ0qUe/m7FP0y0yBzA=="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.4.0.tgz",
+      "integrity": "sha512-Hzl8soGpmyzja9w3kiFFcYJ7n5HNETpplY6cb67KR4QPlxp4FTTresO06qXHgHDhyIInmbLJXuwARjjpsKYGuQ=="
     },
     "@sideway/address": {
       "version": "4.1.4",
@@ -13164,9 +12753,9 @@
       }
     },
     "@types/generic-pool": {
-      "version": "3.1.10",
-      "resolved": "https://registry.npmjs.org/@types/generic-pool/-/generic-pool-3.1.10.tgz",
-      "integrity": "sha512-WRT/9taXh9XJRA9yvrbC02IqGZhK9GbFE/vuP2LeSLrqmDzz5wdXsH0Ige/F+3+rbbZfwH3LEazDsU0JiSV3vA==",
+      "version": "3.1.11",
+      "resolved": "https://registry.npmjs.org/@types/generic-pool/-/generic-pool-3.1.11.tgz",
+      "integrity": "sha512-3mcD3ewmaKPbiAZglGj8We4ohlSMfw/xS+bbYUhTv/ALgqrrtJjyL4Ju9IgapXooBCTFEew5LAKQqzZV6/43xg==",
       "requires": {
         "@types/node": "*"
       }
@@ -13549,14 +13138,6 @@
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
     },
-    "abort-controller": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
-      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-      "requires": {
-        "event-target-shim": "^5.0.0"
-      }
-    },
     "abstract-logging": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/abstract-logging/-/abstract-logging-2.0.1.tgz",
@@ -13912,11 +13493,6 @@
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
     },
-    "bignumber.js": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.2.tgz",
-      "integrity": "sha512-GAcQvbpsM0pUb0zw1EI0KhQEZ+lRwR5fYaAp3vPOYuP7aDvGy6cVN6XHLauvF8SOga2y0dcLcjt3iQDTSEliyw=="
-    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -13973,9 +13549,9 @@
       }
     },
     "bson": {
-      "version": "4.6.4",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-4.6.4.tgz",
-      "integrity": "sha512-TdQ3FzguAu5HKPPlr0kYQCyrYUYh8tFM+CMTpxjNzVzxeiJY00Rtuj3LXLHSgiGvmaWlZ8PE+4KyM2thqE38pQ==",
+      "version": "4.6.5",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-4.6.5.tgz",
+      "integrity": "sha512-uqrgcjyOaZsHfz7ea8zLRCLe1u+QGUSzMZmvXqO24CDW7DWoW1qiN9folSwa7hSneTSgM2ykDIzF5kcQQ8cwNw==",
       "requires": {
         "buffer": "^5.6.0"
       }
@@ -14963,11 +14539,6 @@
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
     },
-    "event-target-shim": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
-    },
     "exec-sh": {
       "version": "0.3.6",
       "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.3.6.tgz",
@@ -15124,11 +14695,6 @@
         "jest-regex-util": "^26.0.0"
       }
     },
-    "extend": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
-    },
     "extend-shallow": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
@@ -15254,9 +14820,9 @@
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="
     },
     "fastify": {
-      "version": "3.29.0",
-      "resolved": "https://registry.npmjs.org/fastify/-/fastify-3.29.0.tgz",
-      "integrity": "sha512-zXSiDTdHJCHcmDrSje1f1RfzTmUTjMtHnPhh6cdokgfHhloQ+gy0Du+KlEjwTbcNC3Djj4GAsBzl6KvfI9Ah2g==",
+      "version": "3.29.1",
+      "resolved": "https://registry.npmjs.org/fastify/-/fastify-3.29.1.tgz",
+      "integrity": "sha512-UhGmh0/J0YQetqULYfv/utvut0R6ICQvO6Oh81JvG75UbjVgueqoE6EPChB3gR5aF3dVKpT/qFTgc7zvpGTYNg==",
       "requires": {
         "@fastify/ajv-compiler": "^1.0.0",
         "@fastify/error": "^2.0.0",
@@ -15494,27 +15060,6 @@
         "string-width": "^4.2.3",
         "strip-ansi": "^6.0.1",
         "wide-align": "^1.1.5"
-      }
-    },
-    "gaxios": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-4.3.3.tgz",
-      "integrity": "sha512-gSaYYIO1Y3wUtdfHmjDUZ8LWaxJQpiavzbF5Kq53akSzvmVg0RfyOcFDbO1KJ/KCGRFz2qG+lS81F0nkr7cRJA==",
-      "requires": {
-        "abort-controller": "^3.0.0",
-        "extend": "^3.0.2",
-        "https-proxy-agent": "^5.0.0",
-        "is-stream": "^2.0.0",
-        "node-fetch": "^2.6.7"
-      }
-    },
-    "gcp-metadata": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-4.3.1.tgz",
-      "integrity": "sha512-x850LS5N7V1F3UcV7PoupzGsyD6iVwTVvsh3tbXfkctZnBnjW5yu5z1/3k3SehF7TyoTIe78rJs02GMMy+LF+A==",
-      "requires": {
-        "gaxios": "^4.0.0",
-        "json-bigint": "^1.0.0"
       }
     },
     "generate-function": {
@@ -16795,14 +16340,6 @@
       "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
       "dev": true
     },
-    "json-bigint": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
-      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
-      "requires": {
-        "bignumber.js": "^9.0.0"
-      }
-    },
     "json-parse-better-errors": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
@@ -17405,35 +16942,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.1.0.tgz",
       "integrity": "sha512-flmrDNB06LIl5lywUz7YlNGZH/5p0M7W28k8hzd9Lshtdh1wshD2Y+U4h9LD6KObOy1f+fEVdgprPrEymjM5uw=="
-    },
-    "node-fetch": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-      "requires": {
-        "whatwg-url": "^5.0.0"
-      },
-      "dependencies": {
-        "tr46": {
-          "version": "0.0.3",
-          "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-          "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
-        },
-        "webidl-conversions": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-          "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
-        },
-        "whatwg-url": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-          "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
-          "requires": {
-            "tr46": "~0.0.3",
-            "webidl-conversions": "^3.0.0"
-          }
-        }
-      }
     },
     "node-gyp": {
       "version": "9.0.0",

--- a/package.json
+++ b/package.json
@@ -12,10 +12,10 @@
     "appsignal-diagnose": "./bin/diagnose"
   },
   "dependencies": {
-    "@opentelemetry/api": "^1.0.4",
-    "@opentelemetry/auto-instrumentations-node": "^0.30.0",
-    "@opentelemetry/sdk-node": "^0.28.0",
-    "@opentelemetry/sdk-trace-base": "^1.2.0",
+    "@opentelemetry/api": "^1.1.0",
+    "@opentelemetry/auto-instrumentations-node": "^0.31.0",
+    "@opentelemetry/sdk-node": "^0.30.0",
+    "@opentelemetry/sdk-trace-base": "^1.4.0",
     "node-addon-api": "^3.1.0",
     "node-gyp": "^9.0.0",
     "tslib": "^2.0.3",


### PR DESCRIPTION
Errors happening in HTTP transactions are now properly recorded in the
most recent OpenTelemetry versions. This commit upgrades our
OpenTelemetry dependencies to get that feature.

[skip changeset]