### PR TITLE
Accept all case diagnose send report confirm input

### DIFF
--- a/.changesets/accept-uppercase-input-in-diagnose-tool-send-report-prompt.md
+++ b/.changesets/accept-uppercase-input-in-diagnose-tool-send-report-prompt.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Accept uppercase input in diagnose tool send report prompt. When prompted to send the report when the diagnose tool, it will now also accept uppercase values like "Y" and "N".

--- a/src/cli/diagnose.ts
+++ b/src/cli/diagnose.ts
@@ -216,7 +216,7 @@ export class Diagnose {
       rl.question(
         `  Send diagnostics report to AppSignal? (Y/n): `,
         async function (answer: string) {
-          switch (answer || "y") {
+          switch ((answer || "y").toLowerCase()) {
             case "y":
               await self.sendReport(data)
               break


### PR DESCRIPTION
We prompt the user with the following when running the diagnose tool:

```
Send diagnostics report to AppSignal? (Y/n):
```

When a user submits this with "Y", we do not accept it. This was because
the input checker only accepted for the lowercase value.

I've lowercased all input, so that "Y", "y", "N" and "n" all work like
they should in this confirmation prompt.

Part of https://github.com/appsignal/support/issues/204