### PR TITLE
Bump agent to 06391fb

### DIFF
--- a/.changesets/bump-agent-06391fb.md
+++ b/.changesets/bump-agent-06391fb.md
@@ -1,0 +1,11 @@
+---
+bump: "patch"
+type: "change"
+---
+
+Bump agent to 06391fb
+
+- Accept "warning" value for the `log_level` config option.
+- Add aarch64 Linux musl build. Doesn't work for Node.js package.
+- Improve debug logging from the extension.
+- Fix high CPU issue for appsignal-agent when nothing could be read from the socket.

--- a/scripts/extension/support/constants.js
+++ b/scripts/extension/support/constants.js
@@ -3,7 +3,7 @@
 // appsignal-agent repository.
 // Modifications to this file will be overwritten with the next agent release.
 
-const AGENT_VERSION = "d573c9b"
+const AGENT_VERSION = "06391fb"
 const MIRRORS = [
   "https://appsignal-agent-releases.global.ssl.fastly.net",
   "https://d135dj0rjqvssy.cloudfront.net"
@@ -12,62 +12,67 @@ const MIRRORS = [
 const TRIPLES = {
   "x86_64-darwin": {
     checksum:
-      "a9a86594e50f22e7f7fd93a050e334048248a6dc971015e66c26150c4a689345",
+      "9bf41c183d94c80e980f57ea2e29d08bae97e8097b5284a2b91a5484bf866f8c",
     filename: "appsignal-x86_64-darwin-all-static.tar.gz"
   },
   "universal-darwin": {
     checksum:
-      "a9a86594e50f22e7f7fd93a050e334048248a6dc971015e66c26150c4a689345",
+      "9bf41c183d94c80e980f57ea2e29d08bae97e8097b5284a2b91a5484bf866f8c",
     filename: "appsignal-x86_64-darwin-all-static.tar.gz"
   },
   "aarch64-darwin": {
     checksum:
-      "92f7f71b685985b310a9f3693a96a5db6b9133b0af807d000b90248e097063c7",
+      "74edd7b97995f3314c10e3d84fc832c1b842c236c331ed4f2f77146ad004d179",
     filename: "appsignal-aarch64-darwin-all-static.tar.gz"
   },
   "arm64-darwin": {
     checksum:
-      "92f7f71b685985b310a9f3693a96a5db6b9133b0af807d000b90248e097063c7",
+      "74edd7b97995f3314c10e3d84fc832c1b842c236c331ed4f2f77146ad004d179",
     filename: "appsignal-aarch64-darwin-all-static.tar.gz"
   },
   "arm-darwin": {
     checksum:
-      "92f7f71b685985b310a9f3693a96a5db6b9133b0af807d000b90248e097063c7",
+      "74edd7b97995f3314c10e3d84fc832c1b842c236c331ed4f2f77146ad004d179",
     filename: "appsignal-aarch64-darwin-all-static.tar.gz"
   },
   "aarch64-linux": {
     checksum:
-      "79f1e7f9c34ab36c06d5c3d676173ee7c1219af2f51dc77865897598dc01349a",
+      "0f2430e637eb77ce2093f021777087e87cb1e7be7c86a53771172696791c4879",
     filename: "appsignal-aarch64-linux-all-static.tar.gz"
   },
   "i686-linux": {
     checksum:
-      "835c6f823a2c6e9f8fa12704bf0953e3610dc9836355b57d2d6981e6ae412fb4",
+      "449ba623aaa1853c2d211bf1e2d3a14e5ae09225a62457cbdbcc0983a5713a52",
     filename: "appsignal-i686-linux-all-static.tar.gz"
   },
   "x86-linux": {
     checksum:
-      "835c6f823a2c6e9f8fa12704bf0953e3610dc9836355b57d2d6981e6ae412fb4",
+      "449ba623aaa1853c2d211bf1e2d3a14e5ae09225a62457cbdbcc0983a5713a52",
     filename: "appsignal-i686-linux-all-static.tar.gz"
   },
   "x86_64-linux": {
     checksum:
-      "6eb6f0df2f8c62a29769bf7f21cefaec92a24ee0ab363acc5bd4f9c2d1241c53",
+      "394796c0ddeb4881c9f2e6ce82f840e66bcb69e027324f6c04f6671067445fbb",
     filename: "appsignal-x86_64-linux-all-static.tar.gz"
   },
   "x86_64-linux-musl": {
     checksum:
-      "b16d46074527da5700e10e5a8b176aeb46b7bbb19431653029eda04437bef918",
+      "673271c8c5fd55053d8a719bcd307f787db4ca4633baf8cf961c442bf1805614",
     filename: "appsignal-x86_64-linux-musl-all-static.tar.gz"
+  },
+  "aarch64-linux-musl": {
+    checksum:
+      "e90ca19bf61596be022ba04897e8902b3401add58f351a40a3d3a7af241d0bbb",
+    filename: "appsignal-aarch64-linux-musl-all-static.tar.gz"
   },
   "x86_64-freebsd": {
     checksum:
-      "e7bfc1dc355ce1237aaee6fdf967c78ecca533db41b09c2b10716e7f8593dbe0",
+      "cb45da91c51123859e5ef5cea850460c28d6e77dfa08b90375178d9017162ba8",
     filename: "appsignal-x86_64-freebsd-all-static.tar.gz"
   },
   "amd64-freebsd": {
     checksum:
-      "e7bfc1dc355ce1237aaee6fdf967c78ecca533db41b09c2b10716e7f8593dbe0",
+      "cb45da91c51123859e5ef5cea850460c28d6e77dfa08b90375178d9017162ba8",
     filename: "appsignal-x86_64-freebsd-all-static.tar.gz"
   }
 }

--- a/src/__tests__/span_processor.test.ts
+++ b/src/__tests__/span_processor.test.ts
@@ -88,7 +88,7 @@ describe("Span processor", () => {
     const ctx = trace.setSpan(context.active(), parentSpan)
     context.with(ctx, () => {
       const childSpan = tracer.startSpan("childSpan")
-      childSpan.recordException(createError("ignored"))
+      childSpan.recordException(createError("childSpanError"))
       childSpan.end()
     })
 
@@ -115,7 +115,11 @@ describe("Span processor", () => {
         closed: true,
         parent_span_id: createdParentSpan?.span_id,
         trace_id: createdParentSpan?.trace_id,
-        error: null
+        error: {
+          name: "Error",
+          message: "childSpanError",
+          backtrace: expect.any(String)
+        }
       })
     )
   })


### PR DESCRIPTION
- Accept "warning" value for the `log_level` config option.
- Add aarch64 Linux musl build. Doesn't work for Node.js package.
- Improve debug logging from the extension.
- Fix high CPU issue for appsignal-agent when nothing could be read from
  the socket.

[skip review]