### PR TITLE
Add error event listener correctly in README

### DIFF
--- a/packages/koa/README.md
+++ b/packages/koa/README.md
@@ -39,6 +39,8 @@ appsignal.instrument(require("@appsignal/koa"));
 const Koa = require("koa");
 const Router = require("@koa/router"); // @koa/router is also supported out of the box!
 
+const app = new Koa();
+
 // Add error handling
 
 app.on("error", (error) => {
@@ -46,8 +48,6 @@ app.on("error", (error) => {
     .tracer()
     .setError(error)
 });
-
-const app = new Koa();
 ```
 
 ## Contributing


### PR DESCRIPTION
Before this change, the code example in the README would try to add an error event listener to the Koa app before the Koa app was instantiated, which (obviously) failed.