### PR TITLE
Add OTel tracer provider as a client property

### DIFF
--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -2,6 +2,7 @@ import { Extension } from "../extension"
 import { Client } from "../client"
 import { Metrics } from "../metrics"
 import { NoopMetrics } from "../noops"
+import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node"
 
 describe("Client", () => {
   const name = "TEST APP"
@@ -101,5 +102,10 @@ describe("Client", () => {
     client = new Client({ ...DEFAULT_OPTS, active: true })
     const meter = client.metrics()
     expect(meter).toBeInstanceOf(Metrics)
+  })
+
+  it("sets up an OpenTelemetry `NodeTracerProvider` in the tracerProvider property", () => {
+    client = new Client(DEFAULT_OPTS)
+    expect(client.tracerProvider).toBeInstanceOf(NodeTracerProvider)
   })
 })

--- a/src/client.ts
+++ b/src/client.ts
@@ -35,6 +35,7 @@ export class Client {
   config: Configuration
   readonly logger: Logger
   extension: Extension
+  readonly tracerProvider: NodeTracerProvider
 
   #metrics: Metrics
 
@@ -77,7 +78,7 @@ export class Client {
     }
 
     this.initCoreProbes()
-    this.initOpenTelemetry()
+    this.tracerProvider = this.initOpenTelemetry()
   }
 
   /**
@@ -199,6 +200,7 @@ export class Client {
     const tracerProvider = new NodeTracerProvider()
     tracerProvider.addSpanProcessor(new SpanProcessor(this))
     tracerProvider.register()
+    return tracerProvider
   }
 
   /**


### PR DESCRIPTION
Adding OpenTelemetry tracer provider to the globally stored client gives
users ability to handle spans from it.

[skip changeset]