### PR TITLE
Do not instrument Koa generator middleware

### DIFF
--- a/packages/koa/.changesets/do-not-break-requests-using-legacy-generator-middleware.md
+++ b/packages/koa/.changesets/do-not-break-requests-using-legacy-generator-middleware.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Do not break requests using legacy generator middleware. Before this change, using a generator middleware, which are deprecated, would make our instrumentation break the request by not calling the next middleware in the chain. This change fixes this by not instrumenting generator middleware.

--- a/packages/koa/README.md
+++ b/packages/koa/README.md
@@ -50,6 +50,12 @@ app.on("error", (error) => {
 });
 ```
 
+Note that generator-based middleware was deprecated in Koa version 2.x, and the next major Koa version will remove support for them entirely.
+
+Our instrumentation does not instrument generator-based middleware. The [Koa 2.x migration guide][guide] explains how you can use the `koa-convert` library to convert them to new-style async middleware.
+
+[guide]: https://github.com/koajs/koa/blob/v2.x/docs/migration.md#using-v1x-middleware-in-v2x
+
 ## Contributing
 
 Thinking of contributing to this repo? Awesome! 🚀

--- a/packages/koa/src/patches/index.ts
+++ b/packages/koa/src/patches/index.ts
@@ -21,6 +21,13 @@ type KoaMiddleware = Middleware<DefaultState, KoaContext> & {
 export function getKoaUsePatch(tracer: Tracer) {
   return function koaUsePatch(original: (middleware: KoaMiddleware) => koa) {
     return function use(this: koa, middlewareFunction: KoaMiddleware) {
+      if (
+        middlewareFunction.constructor.name == "GeneratorFunction" ||
+        middlewareFunction.constructor.name == "AsyncGeneratorFunction"
+      ) {
+        return original.apply(this, [middlewareFunction])
+      }
+
       let patchedFunction: KoaMiddleware
 
       if (middlewareFunction.router) {

--- a/packages/koa/test/example/index.js
+++ b/packages/koa/test/example/index.js
@@ -11,6 +11,12 @@ const Koa = require("koa")
 const app = new Koa()
 const port = 4010
 
+app.use(function* (next) {
+  // This middleware should not be instrumented, but its presence
+  // should not break the request either.
+  yield next
+})
+
 app.use(async ctx => {
   ctx.body = "Hello World!"
 })


### PR DESCRIPTION
In Koa versions 0.x and 1.x, it was possible to implement middleware using generator functions. In Koa version 2.x, these are referred as "legacy middleware" and their use is deprecated, emitting a warning when they are used. However, it is still possible to use them, as Koa uses an utility called `koa-convert` internally to transform legacy middleware into new-style middleware. In Koa version 3.x, support for generator middleware will be removed entirely.

Our instrumentation does not support generator-based middleware, and it will break the request if a generator-based middleware is used early in the middleware chain, by failing to yield to the following middleware. Unfortunately, low-quality tutorial websites continue to recommend using generator-based middleware for error handling, and these sites rank high for relevant keywords.

This commit changes our Koa instrumentation so that it does not attempt to instrument generator-based middleware. On Koa version 2.x, this allows the Koa internals to convert the middleware and emit the deprecation warning. On Koa version 3.x, this will outright fail, which is the best possible deprecation warning.

The docs are also updated to point out that generator-based middleware will not be instrumented, and it points users to `koa-convert`, which they can use to convert the middleware _before_ passing it to the Koa application's `.use` method, which would allow AppSignal to instrument it.