### PR TITLE
update readme: syntax error in config object

### DIFF
--- a/packages/nodejs/README.md
+++ b/packages/nodejs/README.md
@@ -32,7 +32,7 @@ const { Appsignal } = require("@appsignal/nodejs");
 
 const appsignal = new Appsignal({
   active: true,
-  name: "<YOUR APPLICATION NAME>"
+  name: "<YOUR APPLICATION NAME>",
   pushApiKey: "<YOUR API KEY>"
 });
 


### PR DESCRIPTION
Hi, I added a comma after a property in the appSignal configuration file.