### PR TITLE
Update error handling in demo script

### DIFF
--- a/src/demo.ts
+++ b/src/demo.ts
@@ -61,7 +61,9 @@ export function demo(client: Client) {
       "Hello world! This is an error used for demonstration purposes."
     )
   } catch (error) {
-    errorRootSpan.setError(error.name, error.message, error.stack)
+    if (error instanceof Error) {
+      errorRootSpan.setError(error.name, error.message, error.stack as string)
+    }
   }
   errorRootSpan.close()
 }


### PR DESCRIPTION
To comply with the latest TypeScript requirements about error handling,
there's a check now in the demo script for the class of the caught
object.

[skip changeset]