### PR TITLE
Otel request hooks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "MIT",
       "dependencies": {
         "@opentelemetry/api": "^1.1.0",
-        "@opentelemetry/auto-instrumentations-node": "^0.31.0",
+        "@opentelemetry/auto-instrumentations-node": "^0.32.0",
         "@opentelemetry/sdk-node": "^0.30.0",
         "@opentelemetry/sdk-trace-base": "^1.4.0",
         "node-addon-api": "^3.1.0",
@@ -616,6 +616,7 @@
     },
     "node_modules/@fastify/ajv-compiler": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@fastify/ajv-compiler/-/ajv-compiler-1.1.0.tgz",
       "integrity": "sha512-gvCOUNpXsWrIQ3A4aXCLIdblL0tDq42BG/2Xw7oxbil9h11uow10ztS2GuFazNBfjbrsZ5nl+nPl5jDSjj5TSg==",
       "dependencies": {
         "ajv": "^6.12.6"
@@ -623,6 +624,7 @@
     },
     "node_modules/@fastify/error": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@fastify/error/-/error-2.0.0.tgz",
       "integrity": "sha512-wI3fpfDT0t7p8E6dA2eTECzzOd+bZsZCJ2Hcv+Onn2b7ZwK3RwD27uW2QDaMtQhAfWQQP+WNK7nKf0twLsBf9w=="
     },
     "node_modules/@gar/promisify": {
@@ -631,6 +633,7 @@
     },
     "node_modules/@hapi/b64": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/b64/-/b64-5.0.0.tgz",
       "integrity": "sha512-ngu0tSEmrezoiIaNGG6rRvKOUkUuDdf4XTPnONHGYfSGRmDqPZX5oJL6HAdKTo1UQHECbdB4OzhWrfgVppjHUw==",
       "dependencies": {
         "@hapi/hoek": "9.x.x"
@@ -638,6 +641,7 @@
     },
     "node_modules/@hapi/boom": {
       "version": "9.1.4",
+      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-9.1.4.tgz",
       "integrity": "sha512-Ls1oH8jaN1vNsqcaHVYJrKmgMcKsC1wcp8bujvXrHaAqD2iDYq3HoOwsxwo09Cuda5R5nC0o0IxlrlTuvPuzSw==",
       "dependencies": {
         "@hapi/hoek": "9.x.x"
@@ -645,10 +649,12 @@
     },
     "node_modules/@hapi/bourne": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-2.1.0.tgz",
       "integrity": "sha512-i1BpaNDVLJdRBEKeJWkVO6tYX6DMFBuwMhSuWqLsY4ufeTKGVuV5rBsUhxPayXqnnWHgXUAmWK16H/ykO5Wj4Q=="
     },
     "node_modules/@hapi/cryptiles": {
       "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/cryptiles/-/cryptiles-5.1.0.tgz",
       "integrity": "sha512-fo9+d1Ba5/FIoMySfMqPBR/7Pa29J2RsiPrl7bkwo5W5o+AN1dAYQRi4SPrPwwVxVGKjgLOEWrsvt1BonJSfLA==",
       "dependencies": {
         "@hapi/boom": "9.x.x"
@@ -659,10 +665,12 @@
     },
     "node_modules/@hapi/hoek": {
       "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
       "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="
     },
     "node_modules/@hapi/iron": {
       "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/iron/-/iron-6.0.0.tgz",
       "integrity": "sha512-zvGvWDufiTGpTJPG1Y/McN8UqWBu0k/xs/7l++HVU535NLHXsHhy54cfEMdW7EjwKfbBfM9Xy25FmTiobb7Hvw==",
       "dependencies": {
         "@hapi/b64": "5.x.x",
@@ -674,6 +682,7 @@
     },
     "node_modules/@hapi/podium": {
       "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@hapi/podium/-/podium-4.1.3.tgz",
       "integrity": "sha512-ljsKGQzLkFqnQxE7qeanvgGj4dejnciErYd30dbrYzUOF/FyS/DOF97qcrT3bhoVwCYmxa6PEMhxfCPlnUcD2g==",
       "dependencies": {
         "@hapi/hoek": "9.x.x",
@@ -683,6 +692,7 @@
     },
     "node_modules/@hapi/teamwork": {
       "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/teamwork/-/teamwork-5.1.1.tgz",
       "integrity": "sha512-1oPx9AE5TIv+V6Ih54RP9lTZBso3rP8j4Xhb6iSVwPXtAM+sDopl5TFMv5Paw73UnpZJ9gjcrTE1BXrWt9eQrg==",
       "engines": {
         "node": ">=12.0.0"
@@ -690,6 +700,7 @@
     },
     "node_modules/@hapi/topo": {
       "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
       "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
       "dependencies": {
         "@hapi/hoek": "^9.0.0"
@@ -697,6 +708,7 @@
     },
     "node_modules/@hapi/validate": {
       "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@hapi/validate/-/validate-1.1.3.tgz",
       "integrity": "sha512-/XMR0N0wjw0Twzq2pQOzPBZlDzkekGcoCtzO314BpIEsbXdYGthQUbxgkGDf4nhk1+IPDAsXqWjMohRQYO06UA==",
       "dependencies": {
         "@hapi/hoek": "^9.0.0",
@@ -1092,49 +1104,52 @@
       }
     },
     "node_modules/@opentelemetry/api-metrics": {
-      "version": "0.29.2",
-      "integrity": "sha512-yRdF5beqKuEdsPNoO7ijWCQ9HcyN0Tlgicf8RS6gzGOI54d6Hj7yKquJ6+X9XV+CSRbRWJYb+lOsXyso7uyX2g==",
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-metrics/-/api-metrics-0.32.0.tgz",
+      "integrity": "sha512-g1WLhpG8B6iuDyZJFRGsR+JKyZ94m5LEmY2f+duEJ9Xb4XRlLHrZvh6G34OH6GJ8iDHxfHb/sWjJ1ZpkI9yGMQ==",
       "dependencies": {
         "@opentelemetry/api": "^1.0.0"
       },
       "engines": {
-        "node": ">=8.12.0"
+        "node": ">=14"
       }
     },
     "node_modules/@opentelemetry/auto-instrumentations-node": {
-      "version": "0.31.0",
-      "integrity": "sha512-UQ4u3hVNGS5B2utNWWp2+R49H8xO7rXk4Q78V5cnnbmLjNtuI597Mm4dXiWGhpNm5LgYyBsxh2HLusQEAJo//A==",
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/auto-instrumentations-node/-/auto-instrumentations-node-0.32.0.tgz",
+      "integrity": "sha512-LTEJIkWXe6ERWfG1vxp34aVcWGaspUtM8wIyprpilI9iNLhKK8SvpDckhL3AZp3D6uWUk8OWM3U/LcOWwfIwqA==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.29.2",
-        "@opentelemetry/instrumentation-amqplib": "^0.30.0",
-        "@opentelemetry/instrumentation-aws-lambda": "^0.32.0",
-        "@opentelemetry/instrumentation-aws-sdk": "^0.8.0",
-        "@opentelemetry/instrumentation-bunyan": "^0.29.0",
-        "@opentelemetry/instrumentation-cassandra-driver": "^0.29.0",
-        "@opentelemetry/instrumentation-connect": "^0.29.0",
-        "@opentelemetry/instrumentation-dns": "^0.29.0",
-        "@opentelemetry/instrumentation-express": "^0.30.0",
-        "@opentelemetry/instrumentation-fastify": "^0.28.0",
-        "@opentelemetry/instrumentation-generic-pool": "^0.29.0",
-        "@opentelemetry/instrumentation-graphql": "^0.29.0",
-        "@opentelemetry/instrumentation-grpc": "^0.29.2",
-        "@opentelemetry/instrumentation-hapi": "^0.29.0",
-        "@opentelemetry/instrumentation-http": "^0.29.2",
-        "@opentelemetry/instrumentation-ioredis": "^0.30.0",
-        "@opentelemetry/instrumentation-knex": "^0.29.0",
-        "@opentelemetry/instrumentation-koa": "^0.30.0",
-        "@opentelemetry/instrumentation-memcached": "^0.29.0",
-        "@opentelemetry/instrumentation-mongodb": "^0.31.0",
-        "@opentelemetry/instrumentation-mysql": "^0.30.0",
-        "@opentelemetry/instrumentation-mysql2": "^0.31.0",
-        "@opentelemetry/instrumentation-nestjs-core": "^0.30.0",
-        "@opentelemetry/instrumentation-net": "^0.29.0",
-        "@opentelemetry/instrumentation-pg": "^0.30.0",
-        "@opentelemetry/instrumentation-pino": "^0.30.0",
-        "@opentelemetry/instrumentation-redis": "^0.32.0",
-        "@opentelemetry/instrumentation-redis-4": "^0.31.0",
-        "@opentelemetry/instrumentation-restify": "^0.29.0",
-        "@opentelemetry/instrumentation-winston": "^0.29.0"
+        "@opentelemetry/instrumentation": "^0.32.0",
+        "@opentelemetry/instrumentation-amqplib": "^0.31.0",
+        "@opentelemetry/instrumentation-aws-lambda": "^0.33.0",
+        "@opentelemetry/instrumentation-aws-sdk": "^0.9.0",
+        "@opentelemetry/instrumentation-bunyan": "^0.30.0",
+        "@opentelemetry/instrumentation-cassandra-driver": "^0.30.0",
+        "@opentelemetry/instrumentation-connect": "^0.30.0",
+        "@opentelemetry/instrumentation-dns": "^0.30.0",
+        "@opentelemetry/instrumentation-express": "^0.31.0",
+        "@opentelemetry/instrumentation-fastify": "^0.29.0",
+        "@opentelemetry/instrumentation-generic-pool": "^0.30.0",
+        "@opentelemetry/instrumentation-graphql": "^0.30.0",
+        "@opentelemetry/instrumentation-grpc": "^0.32.0",
+        "@opentelemetry/instrumentation-hapi": "^0.30.0",
+        "@opentelemetry/instrumentation-http": "^0.32.0",
+        "@opentelemetry/instrumentation-ioredis": "^0.32.0",
+        "@opentelemetry/instrumentation-knex": "^0.30.0",
+        "@opentelemetry/instrumentation-koa": "^0.32.0",
+        "@opentelemetry/instrumentation-lru-memoizer": "^0.31.0",
+        "@opentelemetry/instrumentation-memcached": "^0.30.0",
+        "@opentelemetry/instrumentation-mongodb": "^0.32.0",
+        "@opentelemetry/instrumentation-mysql": "^0.31.0",
+        "@opentelemetry/instrumentation-mysql2": "^0.32.0",
+        "@opentelemetry/instrumentation-nestjs-core": "^0.31.0",
+        "@opentelemetry/instrumentation-net": "^0.30.0",
+        "@opentelemetry/instrumentation-pg": "^0.31.0",
+        "@opentelemetry/instrumentation-pino": "^0.31.0",
+        "@opentelemetry/instrumentation-redis": "^0.33.0",
+        "@opentelemetry/instrumentation-redis-4": "^0.32.0",
+        "@opentelemetry/instrumentation-restify": "^0.30.0",
+        "@opentelemetry/instrumentation-winston": "^0.30.0"
       },
       "engines": {
         "node": ">=8.12.0"
@@ -1167,24 +1182,29 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation": {
-      "version": "0.29.2",
-      "integrity": "sha512-LXx5V0ONNATQFCE8C5uqnxWSm4rcXLssdLHdXjtGdxRmURqj/JO8jYefqXCD0LzsqEQ6yxOx2GZ0dgXvhBVdTw==",
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.32.0.tgz",
+      "integrity": "sha512-y6ADjHpkUz/v1nkyyYjsQa/zorhX+0qVGpFvXMcbjU4sHnBnC02c6wcc93sIgZfiQClIWo45TGku1KQxJ5UUbQ==",
       "dependencies": {
-        "@opentelemetry/api-metrics": "0.29.2",
+        "@opentelemetry/api-metrics": "0.32.0",
         "require-in-the-middle": "^5.0.3",
         "semver": "^7.3.2",
         "shimmer": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.0.0"
       }
     },
     "node_modules/@opentelemetry/instrumentation-amqplib": {
-      "version": "0.30.0",
-      "integrity": "sha512-aZZgi/O/kwrCIGSkf/7Sy7dB4ZzRTLcnU7A62SZWWU7f6C4KUXQ1TMizwJphF4P8QheqlgqJfoWrw+KDLheJbw==",
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-amqplib/-/instrumentation-amqplib-0.31.0.tgz",
+      "integrity": "sha512-XkWgChRpvI2bNH1Y0CeB92qepzSxIklVBM8MvYnbmMisOzBFlqhe8LMs5szba/78qR2UJ9w7vcrf0HwEK8qERw==",
       "dependencies": {
         "@opentelemetry/core": "^1.0.0",
-        "@opentelemetry/instrumentation": "^0.29.2",
+        "@opentelemetry/instrumentation": "^0.32.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/amqplib": "^0.5.17"
       },
@@ -1196,10 +1216,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-aws-lambda": {
-      "version": "0.32.0",
-      "integrity": "sha512-mVgd03G292DSkix5ARkTdp/dkPEhLwgwNDhEHsR1isOW2Lw3WKr4dCjMQKAYmbhhj3jg1/ovlwkhEQz6hIqXYQ==",
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-aws-lambda/-/instrumentation-aws-lambda-0.33.0.tgz",
+      "integrity": "sha512-mxWt0WEpTJW8OFfJ3wyD0iWGNmiLUCyLYsknouLe3WSDvYDvdGcvpRSy2qRf8weSXj3ZwFQDN/6YvmrU5BI0ZA==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.29.2",
+        "@opentelemetry/instrumentation": "^0.32.0",
         "@opentelemetry/propagator-aws-xray": "^1.1.0",
         "@opentelemetry/resources": "^1.0.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
@@ -1213,11 +1234,12 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-aws-sdk": {
-      "version": "0.8.0",
-      "integrity": "sha512-F29TmSsq8LWeZZXHV72b3B+QItZPVPsPx1DuQYPcKeCwAJUAg0huukXbf2U2XskA1fmw49+t9AM8fFPdytftyA==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-aws-sdk/-/instrumentation-aws-sdk-0.9.0.tgz",
+      "integrity": "sha512-dntHO3xyLRF8GP9vBXkNlHuMwlfj7FQdiL6H60nj1VelqhbdJoT8ArnbKfz4USRF8TFjcQ+LaDBSUdMdVF7e/g==",
       "dependencies": {
         "@opentelemetry/core": "^1.0.0",
-        "@opentelemetry/instrumentation": "^0.29.2",
+        "@opentelemetry/instrumentation": "^0.32.0",
         "@opentelemetry/propagation-utils": "^0.28.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       },
@@ -1229,10 +1251,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-bunyan": {
-      "version": "0.29.0",
-      "integrity": "sha512-i1FZ+W96vQCIpkMKPZW0HOA79ve9PLIcTAFH0adU/CvtRRMSxyKPTKzWMGHcWr6DueKIPEorpMG+nO2Z/yk9iQ==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-bunyan/-/instrumentation-bunyan-0.30.0.tgz",
+      "integrity": "sha512-7U4w5QA/i60AQ0LhX5AQH6L/pdE8UEhrDRGn0P7EcWUtKgHCaza6yroTsCaz7abXma7ha8SNx6IHIbAQGSYOBA==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.29.2",
+        "@opentelemetry/instrumentation": "^0.32.0",
         "@types/bunyan": "1.8.7"
       },
       "engines": {
@@ -1243,10 +1266,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-cassandra-driver": {
-      "version": "0.29.0",
-      "integrity": "sha512-Wp7ntJVHwI5wN/cTMnBJJeQ8PmgordnHbq+B1k+xzBLPz7Pro+6q8SFmiupZvrZmfzWsdSDaO2XM/6CIdtFB5Q==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-cassandra-driver/-/instrumentation-cassandra-driver-0.30.0.tgz",
+      "integrity": "sha512-xvTpn6nkrWECly0Bx0ktrJEzxu/NIFXYxKrhCtlzh1R/GswIqfeBiPA+tzWgS8hdpNDsQLhLXfQ82es2zPcp7Q==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.29.2",
+        "@opentelemetry/instrumentation": "^0.32.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "engines": {
@@ -1257,11 +1281,12 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-connect": {
-      "version": "0.29.0",
-      "integrity": "sha512-2BvdIdUCPIYNnROaMToLG76wZXvZXM2L9zOtEFlUnp8teI3Lu2mSPKRaSZ6XAmVVgTAtpfq2IuJMcZ5zAhJuCg==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-connect/-/instrumentation-connect-0.30.0.tgz",
+      "integrity": "sha512-+hjPA5CXyusUKclHhuzT2c47dDyjC7k5I8TjqSLx+SZqN3jvb9Pwae2S49Rd+TgMTrZG9Ip2MvGlalz1dWIHRQ==",
       "dependencies": {
         "@opentelemetry/core": "^1.0.0",
-        "@opentelemetry/instrumentation": "^0.29.2",
+        "@opentelemetry/instrumentation": "^0.32.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/connect": "3.4.35"
       },
@@ -1273,10 +1298,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-dns": {
-      "version": "0.29.0",
-      "integrity": "sha512-3WTC4m6JKviaABiR3a+56WUMvrUp9WW9EYC0+LRpqm7RK/1a5bYq2Cozc2SlFYX9ZfWKMqGS39/fU24mKQ5toA==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-dns/-/instrumentation-dns-0.30.0.tgz",
+      "integrity": "sha512-NzUSHn83HrvV2ph8V1KQERkrNpEEpqxHa3W8wepmr17jdmUU02/RwLxw7yWD9SLiKXwW29Iym3hj2x6TbuQ7QA==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.29.2",
+        "@opentelemetry/instrumentation": "^0.32.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "semver": "^7.3.2"
       },
@@ -1288,11 +1314,12 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-express": {
-      "version": "0.30.0",
-      "integrity": "sha512-OsCfM+ThAXh3wzsyHgXyA5HUoLMdLd6Asix2Jx8yxniruU/Gq8y4Cz7aLy/vXNckXHWO3fwwL5gb7K3dykTnAQ==",
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-express/-/instrumentation-express-0.31.0.tgz",
+      "integrity": "sha512-JvMF84qDr1XQ7cNvRr39T10H2Wz772kKG42Y5be514gwJNWqZkaFLcfCAXu8Vap9nwtqYqIvJPRkQ9RsOghTQA==",
       "dependencies": {
         "@opentelemetry/core": "^1.0.0",
-        "@opentelemetry/instrumentation": "^0.29.2",
+        "@opentelemetry/instrumentation": "^0.32.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/express": "4.17.13"
       },
@@ -1304,11 +1331,12 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-fastify": {
-      "version": "0.28.0",
-      "integrity": "sha512-HVvxTDgAhGZqp5k/JA/W4cMpHMy25CXy1pJDOoVB08gC6TKDBg/54iKgLr+g+nqV9RejIKfydt+35Xesynay/g==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fastify/-/instrumentation-fastify-0.29.0.tgz",
+      "integrity": "sha512-r18b/f5+gYrCqEMuxQOf+0ohhioIOMce7WxDGXxib3qGeFHvt71PM9wmJpj0jM4WxIrosmL1js0peqMEE8LRIQ==",
       "dependencies": {
         "@opentelemetry/core": "^1.0.0",
-        "@opentelemetry/instrumentation": "^0.29.2",
+        "@opentelemetry/instrumentation": "^0.32.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "fastify": "^3.19.2"
       },
@@ -1320,10 +1348,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-generic-pool": {
-      "version": "0.29.0",
-      "integrity": "sha512-tCVIVdGLS4bsFOwYGcbzuESh3XREfdhtMU9iXkULON1KoYi1c68HlWC9yyNQL7yTCBkbYSk2XjWKs6dHbcSf3A==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-generic-pool/-/instrumentation-generic-pool-0.30.0.tgz",
+      "integrity": "sha512-Q9VYMok7Qchlf+Q4s5TPCpmWvbxg4JMKZgkwTj25ZBGUlWWTfk1/oCctcQHok1Yvdvctczzr1DGrFw08cQDdCA==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.29.2",
+        "@opentelemetry/instrumentation": "^0.32.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/generic-pool": "^3.1.9"
       },
@@ -1335,10 +1364,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-graphql": {
-      "version": "0.29.0",
-      "integrity": "sha512-mAjz326UtWGQUAmmEY6VB4XV1kbgQGBmRWjh/QT0giLwcbKa9RdO0x0B+VbALbrth7ZtHuoyKaDjCWowuzUujw==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-graphql/-/instrumentation-graphql-0.30.0.tgz",
+      "integrity": "sha512-CCwTjDeRBWNtt6DbM8PsOQUsLnjpIf+PwK6hliCENfB5oWFC5nw4TkpuaGGHqgIOexae2CitlB2cLb5yWtxpdw==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.29.2",
+        "@opentelemetry/instrumentation": "^0.32.0",
         "graphql": "^15.5.1"
       },
       "engines": {
@@ -1349,33 +1379,36 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-grpc": {
-      "version": "0.29.2",
-      "integrity": "sha512-rWyx/a7CsEYopwxaND47z+I8SrTLTHEz9sm8sf30FkMviVyRzYqt2PJT+JMGInM7Om/IpZNEc29kSzUjLmqddQ==",
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-grpc/-/instrumentation-grpc-0.32.0.tgz",
+      "integrity": "sha512-Az6wdkPx/Mi26lT9LKFV6GhCA9prwQFPz5eCNSExTnSP49YhQ7XCjzPd2POPeLKt84ICitrBMdE1mj0zbPdLAQ==",
       "dependencies": {
-        "@opentelemetry/api-metrics": "0.29.2",
-        "@opentelemetry/instrumentation": "0.29.2",
-        "@opentelemetry/semantic-conventions": "1.3.1"
+        "@opentelemetry/api-metrics": "0.32.0",
+        "@opentelemetry/instrumentation": "0.32.0",
+        "@opentelemetry/semantic-conventions": "1.6.0"
       },
       "engines": {
-        "node": ">=8.12.0"
+        "node": ">=14"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.0.0"
       }
     },
     "node_modules/@opentelemetry/instrumentation-grpc/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.3.1",
-      "integrity": "sha512-wU5J8rUoo32oSef/rFpOT1HIjLjAv3qIDHkw1QIhODV3OpAVHi5oVzlouozg9obUmZKtbZ0qUe/m7FP0y0yBzA==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.6.0.tgz",
+      "integrity": "sha512-aPfcBeLErM/PPiAuAbNFLN5sNbZLc3KZlar27uohllN8Zs6jJbHyJU1y7cMA6W/zuq+thkaG8mujiS+3iD/FWQ==",
       "engines": {
-        "node": ">=8.12.0"
+        "node": ">=14"
       }
     },
     "node_modules/@opentelemetry/instrumentation-hapi": {
-      "version": "0.29.0",
-      "integrity": "sha512-yqfuKALO20Mx6F8GStnwTmD/JUhR9JGV3GJVH3UJ5TDAvz61hhoQWaBm0iAP5cJhrKRMD8mictAT2OiHSPUpLw==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-hapi/-/instrumentation-hapi-0.30.0.tgz",
+      "integrity": "sha512-tfX8P9g685JWpR4qFtZyK9aOT755n+0hSdCWe1iqGeuE8xI4gUsqPUFMCNbA8foTf+HauUPt9O6SaK1r7P24mA==",
       "dependencies": {
         "@opentelemetry/core": "^1.0.0",
-        "@opentelemetry/instrumentation": "^0.29.2",
+        "@opentelemetry/instrumentation": "^0.32.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/hapi__hapi": "20.0.9"
       },
@@ -1387,46 +1420,50 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-http": {
-      "version": "0.29.2",
-      "integrity": "sha512-XIF9WCH03rp3vQjwXXVdTxlsXT2AG6LYfFKO8r2QC+w4F4KFuZa4J3VPYJ0L/a/6dWt34DA67eBh3l6Z1rMZrg==",
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.32.0.tgz",
+      "integrity": "sha512-EbNdJl6IjouphbxPVGV8/utiqB2DhveyH5TD6vxjc2OXlQ3A/mKg3fYSSWB+rYQBuuli+jWQfBJe2ntOFZtTMw==",
       "dependencies": {
-        "@opentelemetry/core": "1.3.1",
-        "@opentelemetry/instrumentation": "0.29.2",
-        "@opentelemetry/semantic-conventions": "1.3.1",
+        "@opentelemetry/core": "1.6.0",
+        "@opentelemetry/instrumentation": "0.32.0",
+        "@opentelemetry/semantic-conventions": "1.6.0",
         "semver": "^7.3.5"
       },
       "engines": {
-        "node": ">=8.12.0"
+        "node": ">=14"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.0.0"
       }
     },
     "node_modules/@opentelemetry/instrumentation-http/node_modules/@opentelemetry/core": {
-      "version": "1.3.1",
-      "integrity": "sha512-k7lOC86N7WIyUZsUuSKZfFIrUtINtlauMGQsC1r7jNmcr0vVJGqK1ROBvt7WWMxLbpMnt1q2pXJO8tKu0b9auA==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.6.0.tgz",
+      "integrity": "sha512-MsEhsyCTfYme6frK8/AqEWwbS9SB3Ta5bjgz4jPQJjL7ijUM3JiLVvqh/kHo1UlUjbUbLmGG7jA5Nw4d7SMcLQ==",
       "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.3.1"
+        "@opentelemetry/semantic-conventions": "1.6.0"
       },
       "engines": {
-        "node": ">=8.12.0"
+        "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.2.0"
+        "@opentelemetry/api": ">=1.0.0 <1.3.0"
       }
     },
     "node_modules/@opentelemetry/instrumentation-http/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.3.1",
-      "integrity": "sha512-wU5J8rUoo32oSef/rFpOT1HIjLjAv3qIDHkw1QIhODV3OpAVHi5oVzlouozg9obUmZKtbZ0qUe/m7FP0y0yBzA==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.6.0.tgz",
+      "integrity": "sha512-aPfcBeLErM/PPiAuAbNFLN5sNbZLc3KZlar27uohllN8Zs6jJbHyJU1y7cMA6W/zuq+thkaG8mujiS+3iD/FWQ==",
       "engines": {
-        "node": ">=8.12.0"
+        "node": ">=14"
       }
     },
     "node_modules/@opentelemetry/instrumentation-ioredis": {
-      "version": "0.30.0",
-      "integrity": "sha512-iYdVWRz53kZ3DsEMt5es8KF+OrfRi4M6gSQYA7q6OcVXrucAUZA+juK8Rl3IgWjXG5wKCzr/liKs6HDAVJ9f/Q==",
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-ioredis/-/instrumentation-ioredis-0.32.0.tgz",
+      "integrity": "sha512-+L0XY3o6F++SK+QQLi7n0OkNf16IygWMutKT9WURRcIQCo6fjZJAuZLWzuXmrXY/W1Fcm2bLPQH9Vyo0OhvkCg==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.29.2",
+        "@opentelemetry/instrumentation": "^0.32.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/ioredis": "4.26.6"
       },
@@ -1438,10 +1475,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-knex": {
-      "version": "0.29.0",
-      "integrity": "sha512-M00bEYxl5VZV53jVxxnweGrEO9AMuSPIAz1mIzk/Z3bXU/KK9GxCBCZajwxdXv1SKj6KMQ+mOfXOOnY8Y0Wbcg==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-knex/-/instrumentation-knex-0.30.0.tgz",
+      "integrity": "sha512-H0d4IrjE/2eV3B9DAPYD0MRYvQgZygvOj1uq14m/ZxrQNCYQu7ntmz53/N0nqx0/DNfGlx7TAwr425sY/KJw2A==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.29.2",
+        "@opentelemetry/instrumentation": "^0.32.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "engines": {
@@ -1452,11 +1490,12 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-koa": {
-      "version": "0.30.0",
-      "integrity": "sha512-GWm8L8HzMK0f+ZpRhBQc+JVwNL7+7zAm9w/HVAzfCGJyushU/wWkso1xOlwumiJndfRaqYqxg9FW32Yw3vYrng==",
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-koa/-/instrumentation-koa-0.32.0.tgz",
+      "integrity": "sha512-IW8yywrw71B5+s/JKdDY1psbF5GyV6w4wuVB6YGo0qV/isE/naHYIV2SnBwGHzu9jGrWjjcmuiEqOn93V5CQaQ==",
       "dependencies": {
         "@opentelemetry/core": "^1.0.0",
-        "@opentelemetry/instrumentation": "^0.29.2",
+        "@opentelemetry/instrumentation": "^0.32.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/koa": "2.13.4",
         "@types/koa__router": "8.0.7"
@@ -1468,11 +1507,26 @@
         "@opentelemetry/api": "^1.0.0"
       }
     },
-    "node_modules/@opentelemetry/instrumentation-memcached": {
-      "version": "0.29.0",
-      "integrity": "sha512-th+zERg1/1DpCVZ3doKPmjVnbPFBZO5RHcteFkt28ibYTrPEL6K4EciTybdIyC10madFOJRydC9lfvDfgY857g==",
+    "node_modules/@opentelemetry/instrumentation-lru-memoizer": {
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-lru-memoizer/-/instrumentation-lru-memoizer-0.31.0.tgz",
+      "integrity": "sha512-eAUwYtTK7Tmb/ruXSBB5wW4lXW8HsmWmbmFDL8rmOo2eCCKTZocm9Mk79scKminA59Mb5vfZjn7r21KRlYFCSQ==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.29.2",
+        "@opentelemetry/instrumentation": "^0.32.0"
+      },
+      "engines": {
+        "node": ">=8.12.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-memcached": {
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-memcached/-/instrumentation-memcached-0.30.0.tgz",
+      "integrity": "sha512-1zEl7n+x1NG3gVpzQu92TonlAxRFM/Ng7b2CMQYqu4uqeAe0/k7BPmj4N1RW/g0+3mf2aCxnebRT5LMjRBSd4w==",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.32.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/memcached": "^2.2.6"
       },
@@ -1484,12 +1538,12 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-mongodb": {
-      "version": "0.31.0",
-      "integrity": "sha512-4pyjBeSZucUoKoQqqjwv693NmvvG7/HFCFUwN+f1wxliRq+2uuJoT/bp9wcrwLG4IW+8QvxVyN++Hn5LgQeSwQ==",
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongodb/-/instrumentation-mongodb-0.32.0.tgz",
+      "integrity": "sha512-EL5OzMWTuKpOKfOzQ6+xqNGUsQo70Wx62SSP7i4FIkW1PqLNDjqFhd+eHi98WqDjDQ4Yn69bb0Vzml3TYG68HA==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.29.2",
-        "@opentelemetry/semantic-conventions": "^1.0.0",
-        "@types/mongodb": "3.6.20"
+        "@opentelemetry/instrumentation": "^0.32.0",
+        "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -1499,10 +1553,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-mysql": {
-      "version": "0.30.0",
-      "integrity": "sha512-FdbZ2Yb15OTGa6HZYXxUL0yhcXNec2HHbUp9nn3x2B9YO9bJHJQoNVyHVd5gssMVYKFg4dgZodY/YXYu9xj2Ow==",
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql/-/instrumentation-mysql-0.31.0.tgz",
+      "integrity": "sha512-NGMc8MdkdKfnRPNanVbcH9L+UxbodMujuZa0jVw8CPF+9hRp7zcVSheVYo/mqc10p3DkjqibGKlBrLJ3c9e1sg==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.29.2",
+        "@opentelemetry/instrumentation": "^0.32.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/mysql": "2.15.19"
       },
@@ -1514,10 +1569,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-mysql2": {
-      "version": "0.31.0",
-      "integrity": "sha512-Pcm9i0dwLk5yvP11knL8z63Cu0djy9CYSE3ZDvIQinF/HcOmFTKUYqIeX+8XZkIupgDmeFEy6rWZEvvko8sanw==",
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql2/-/instrumentation-mysql2-0.32.0.tgz",
+      "integrity": "sha512-ApiDswZiaNR+JnGEPU7TtwHaGtGmnACc6pyKmeMEgEuB1VR7dRZLyztgiOz7NNFsCLSDkW24XMZ/wrBgJUvz4g==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.29.2",
+        "@opentelemetry/instrumentation": "^0.32.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "engines": {
@@ -1528,10 +1584,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-nestjs-core": {
-      "version": "0.30.0",
-      "integrity": "sha512-z9HSjL4Udx2tteqyjvzrmNk6mxhip4BkWSWWZKN0z7t+waIHKfTTgJiTn5/YxwGYLUIKVigmNlAoo987rmK+xA==",
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-nestjs-core/-/instrumentation-nestjs-core-0.31.0.tgz",
+      "integrity": "sha512-Un3uPLS8wZAMMiz1PAiSX7+QfWaEUF7ejTZEybanwHCROv2zMa4P/cCc2WFAMm6q82brV6f4OqPEYLP+AnombQ==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.29.2",
+        "@opentelemetry/instrumentation": "^0.32.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "engines": {
@@ -1542,10 +1599,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-net": {
-      "version": "0.29.0",
-      "integrity": "sha512-93acTBKvrzyTbQ5g+VItpCqxMn0lcLb8re7wOh7v+hnMAaKc431fcPuVbOcsNHdMZ7LF1qnOZfs0sooT/chIDA==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-net/-/instrumentation-net-0.30.0.tgz",
+      "integrity": "sha512-e7sgHfMf63ylo3FphhPD4+Ys70wTjrPeQFbh3GPMbnIN+7NTZXWIZFE0jkPimuVvw7jwyLDsaJoq03UArtc+/w==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.29.2",
+        "@opentelemetry/instrumentation": "^0.32.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "engines": {
@@ -1556,10 +1614,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-pg": {
-      "version": "0.30.0",
-      "integrity": "sha512-RQ3cTTJnCBE/9GagjSpaM+yzxN25MvEwOxDFes3y8c1cqrMgqxukQLm3MbcqCQ8e1g/8d18+oyiEeBUjZJ5jnw==",
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pg/-/instrumentation-pg-0.31.0.tgz",
+      "integrity": "sha512-wvvaaHJBjZ98WgQ/nj10InvUdNE0DPuuWTXsxTTkcTUD2lnOC4JgXsVQ7Gn+2NAcmjxOdiM32WZ+VpiMwQ2I7g==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.29.2",
+        "@opentelemetry/instrumentation": "^0.32.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/pg": "8.6.1",
         "@types/pg-pool": "2.0.3"
@@ -1572,10 +1631,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-pino": {
-      "version": "0.30.0",
-      "integrity": "sha512-ZbmRL58f3Qviwai/JunUZb/uKo1NYRLdCrKoss7seJ3mEvuTcgTIVeo93PSqxk2c4LMdvkTcNAcIAv1Ymw/PyQ==",
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pino/-/instrumentation-pino-0.31.0.tgz",
+      "integrity": "sha512-N25NCt6PQ6V4xdwfJa5WuYedJNv51JGMCyztjukWFj3guW2V3G5nZjsbSQNxsLiOJvQq5hx+EO2Wi/B/PSIq1g==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.29.2",
+        "@opentelemetry/instrumentation": "^0.32.0",
         "pino": "7.10.0",
         "semver": "^7.3.5"
       },
@@ -1587,10 +1647,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-redis": {
-      "version": "0.32.0",
-      "integrity": "sha512-KaZnYhz8dZ9gHkvrBo2U7bp/HABM2JXd3i6e8cUP8MyNA8x5P+EUbeSzzBMe6bAZH35S60dAQbBAhRji3ZlPRw==",
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis/-/instrumentation-redis-0.33.0.tgz",
+      "integrity": "sha512-wcPJ5tp4wspsr0uQ6WmEue83qlXzeF2EJzKR0Ye/8VQCJsRmSmOnEIEC33UPwlCzfssz/t8EdqU3ejx+uTa00Q==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.29.2",
+        "@opentelemetry/instrumentation": "^0.32.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/redis": "2.8.31"
       },
@@ -1602,10 +1663,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-redis-4": {
-      "version": "0.31.0",
-      "integrity": "sha512-3DY6bkqKnVlPc2WWHelb6DnU78ryYLQFqv0lqnVsoSkr7b6hnmw1Bzuwo/5YmS4C3XuTAD4/6dZVrQJ23g8HNA==",
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis-4/-/instrumentation-redis-4-0.32.0.tgz",
+      "integrity": "sha512-jkEedarX+Cx/JL1oV3s1Lvw2DHGJVNpM3fPDGHTbSudzDI0vr0+bgyMv+WW3U2vzc3WvLuCkzAkmRMPK2++nDA==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.29.2",
+        "@opentelemetry/instrumentation": "^0.32.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "engines": {
@@ -1616,11 +1678,12 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-restify": {
-      "version": "0.29.0",
-      "integrity": "sha512-jjXtzNut03FBernMrEjJnkX9SdUAjpGh04mauR2GhBjSrkQg73gS7jeMS/xyN6/ufphA0tyFygxNPOWFvjXM6g==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-restify/-/instrumentation-restify-0.30.0.tgz",
+      "integrity": "sha512-Qdin5XompOloj4c5y4vwfo3VN5K7SWrpC2PrA5aNR7VnYNM61AxMPtAhz4Bc0BPh/lylNa9tX1pAEEdg1FMRuQ==",
       "dependencies": {
         "@opentelemetry/core": "^1.0.0",
-        "@opentelemetry/instrumentation": "^0.29.2",
+        "@opentelemetry/instrumentation": "^0.32.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/restify": "4.3.8"
       },
@@ -1632,10 +1695,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-winston": {
-      "version": "0.29.0",
-      "integrity": "sha512-z48oitpODk5BkJXp4OlRLAQf5JLH0jcSmHvqhlgB9tHddNG+xQWa1Xb0kyBX4i4r0jGFR7cvImIb53wrEavUBA==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-winston/-/instrumentation-winston-0.30.0.tgz",
+      "integrity": "sha512-F4zFwSNY/wdg1I9pAZOvO2jIrPU1LGI6YeA8nVm6ImCFQVJYsccBudNPmfhjGT5ydRa/AtCRcnQ7MFDI94+p4w==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.29.2"
+        "@opentelemetry/instrumentation": "^0.32.0"
       },
       "engines": {
         "node": ">=8.12.0"
@@ -1646,6 +1710,7 @@
     },
     "node_modules/@opentelemetry/propagation-utils": {
       "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagation-utils/-/propagation-utils-0.28.0.tgz",
       "integrity": "sha512-IsBUTz110RB75Xg6dejSD8JSyiXll81zTu/2dph5VdPMSgMOGQTYhtv0Mv1BydJh4dZpR+Z9WHTiHdkp1IQOCw==",
       "engines": {
         "node": ">=8.12.0"
@@ -1656,6 +1721,7 @@
     },
     "node_modules/@opentelemetry/propagator-aws-xray": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-aws-xray/-/propagator-aws-xray-1.1.0.tgz",
       "integrity": "sha512-p8qSVJbhzxBu2Dl6nv5aqWSmUeqAxEr3jjZzB6Eg9CrZqCTJ7Ndl74dSOuEzC7CYmiNsu0v5K0rSdB8g6vm89g==",
       "dependencies": {
         "@opentelemetry/core": "^1.0.0"
@@ -1820,6 +1886,7 @@
     },
     "node_modules/@sideway/address": {
       "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.4.tgz",
       "integrity": "sha512-7vwq+rOHVWjyXxVlR76Agnvhy8I9rpzjosTESvmhNeXOXdZZB15Fl+TI9x1SiHZH5Jv2wTGduSxFDIaq0m3DUw==",
       "dependencies": {
         "@hapi/hoek": "^9.0.0"
@@ -1827,10 +1894,12 @@
     },
     "node_modules/@sideway/formula": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.0.tgz",
       "integrity": "sha512-vHe7wZ4NOXVfkoRb8T5otiENVlT7a3IAiw7H5M2+GO+9CDgcVUUsX1zalAztCmwyOr2RUTGJdgB+ZvSVqmdHmg=="
     },
     "node_modules/@sideway/pinpoint": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
       "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="
     },
     "node_modules/@sinonjs/commons": {
@@ -1858,6 +1927,7 @@
     },
     "node_modules/@types/accepts": {
       "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/accepts/-/accepts-1.3.5.tgz",
       "integrity": "sha512-jOdnI/3qTpHABjM5cx1Hc0sKsPoYCp+DP/GJRGtDlPd7fiV9oXGGIcjW/ZOxLIvjGz8MA+uMZI9metHlgqbgwQ==",
       "dependencies": {
         "@types/node": "*"
@@ -1865,6 +1935,7 @@
     },
     "node_modules/@types/amqplib": {
       "version": "0.5.17",
+      "resolved": "https://registry.npmjs.org/@types/amqplib/-/amqplib-0.5.17.tgz",
       "integrity": "sha512-RImqiLP1swDqWBW8UX9iBXVEOw6MYzNmxdXqfemDfdwtUvdTM/W0s2RlSuMVIGkRhaWvpkC9O/N81VzzQwfAbw==",
       "dependencies": {
         "@types/bluebird": "*",
@@ -1873,6 +1944,7 @@
     },
     "node_modules/@types/aws-lambda": {
       "version": "8.10.81",
+      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.81.tgz",
       "integrity": "sha512-C1rFKGVZ8KwqhwBOYlpoybTSRtxu2433ea6JaO3amc6ubEe08yQoFsPa9aU9YqvX7ppeZ25CnCtC4AH9mhtxsQ=="
     },
     "node_modules/@types/babel__core": {
@@ -1914,26 +1986,21 @@
     },
     "node_modules/@types/bluebird": {
       "version": "3.5.36",
+      "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.36.tgz",
       "integrity": "sha512-HBNx4lhkxN7bx6P0++W8E289foSu8kO8GCk2unhuVggO+cE7rh9DhZUyPhUxNRG9m+5B5BTKxZQ5ZP92x/mx9Q=="
     },
     "node_modules/@types/body-parser": {
       "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
       "integrity": "sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==",
       "dependencies": {
         "@types/connect": "*",
         "@types/node": "*"
       }
     },
-    "node_modules/@types/bson": {
-      "version": "4.2.0",
-      "integrity": "sha512-ELCPqAdroMdcuxqwMgUpifQyRoTpyYCNr1V9xKyF40VsBobsj+BbWNRvwGchMgBPGqkw655ypkjj2MEF5ywVwg==",
-      "deprecated": "This is a stub types definition. bson provides its own type definitions, so you do not need this installed.",
-      "dependencies": {
-        "bson": "*"
-      }
-    },
     "node_modules/@types/bunyan": {
       "version": "1.8.7",
+      "resolved": "https://registry.npmjs.org/@types/bunyan/-/bunyan-1.8.7.tgz",
       "integrity": "sha512-jaNt6xX5poSmXuDAkQrSqx2zkR66OrdRDuVnU8ldvn3k/Ci/7Sf5nooKspQWimDnw337Bzt/yirqSThTjvrHkg==",
       "dependencies": {
         "@types/node": "*"
@@ -1941,6 +2008,7 @@
     },
     "node_modules/@types/connect": {
       "version": "3.4.35",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
       "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
       "dependencies": {
         "@types/node": "*"
@@ -1948,10 +2016,12 @@
     },
     "node_modules/@types/content-disposition": {
       "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@types/content-disposition/-/content-disposition-0.5.5.tgz",
       "integrity": "sha512-v6LCdKfK6BwcqMo+wYW05rLS12S0ZO0Fl4w1h4aaZMD7bqT3gVUns6FvLJKGZHQmYn3SX55JWGpziwJRwVgutA=="
     },
     "node_modules/@types/cookies": {
       "version": "0.7.7",
+      "resolved": "https://registry.npmjs.org/@types/cookies/-/cookies-0.7.7.tgz",
       "integrity": "sha512-h7BcvPUogWbKCzBR2lY4oqaZbO3jXZksexYJVFvkrFeLgbZjQkU4x8pRq6eg2MHXQhY0McQdqmmsxRWlVAHooA==",
       "dependencies": {
         "@types/connect": "*",
@@ -1962,6 +2032,7 @@
     },
     "node_modules/@types/express": {
       "version": "4.17.13",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
       "integrity": "sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==",
       "dependencies": {
         "@types/body-parser": "*",
@@ -1971,8 +2042,9 @@
       }
     },
     "node_modules/@types/express-serve-static-core": {
-      "version": "4.17.28",
-      "integrity": "sha512-P1BJAEAW3E2DJUlkgq4tOL3RyMunoWXqbSCygWo5ZIWTjUgN1YnaXWW4VWl/oc8vs/XoYibEGBKP0uZyF4AHig==",
+      "version": "4.17.30",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.30.tgz",
+      "integrity": "sha512-gstzbTWro2/nFed1WXtf+TtrpwxH7Ggs4RLYTLbeVgIkUQOI3WG/JKjgeOU1zXDvezllupjrf8OPIdvTbIaVOQ==",
       "dependencies": {
         "@types/node": "*",
         "@types/qs": "*",
@@ -1981,6 +2053,7 @@
     },
     "node_modules/@types/generic-pool": {
       "version": "3.1.11",
+      "resolved": "https://registry.npmjs.org/@types/generic-pool/-/generic-pool-3.1.11.tgz",
       "integrity": "sha512-3mcD3ewmaKPbiAZglGj8We4ohlSMfw/xS+bbYUhTv/ALgqrrtJjyL4Ju9IgapXooBCTFEew5LAKQqzZV6/43xg==",
       "dependencies": {
         "@types/node": "*"
@@ -1996,10 +2069,12 @@
     },
     "node_modules/@types/hapi__catbox": {
       "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/@types/hapi__catbox/-/hapi__catbox-10.2.4.tgz",
       "integrity": "sha512-A6ivRrXD5glmnJna1UAGw87QNZRp/vdFO9U4GS+WhOMWzHnw+oTGkMvg0g6y1930CbeheGOCm7A1qHsqH7AXqg=="
     },
     "node_modules/@types/hapi__hapi": {
       "version": "20.0.9",
+      "resolved": "https://registry.npmjs.org/@types/hapi__hapi/-/hapi__hapi-20.0.9.tgz",
       "integrity": "sha512-fGpKScknCKZityRXdZgpCLGbm41R1ppFgnKHerfZlqOOlCX/jI129S6ghgBqkqCE8m9A0CIu1h7Ch04lD9KOoA==",
       "dependencies": {
         "@hapi/boom": "^9.0.0",
@@ -2014,6 +2089,7 @@
     },
     "node_modules/@types/hapi__mimos": {
       "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@types/hapi__mimos/-/hapi__mimos-4.1.4.tgz",
       "integrity": "sha512-i9hvJpFYTT/qzB5xKWvDYaSXrIiNqi4ephi+5Lo6+DoQdwqPXQgmVVOZR+s3MBiHoFqsCZCX9TmVWG3HczmTEQ==",
       "dependencies": {
         "@types/mime-db": "*"
@@ -2021,6 +2097,7 @@
     },
     "node_modules/@types/hapi__shot": {
       "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@types/hapi__shot/-/hapi__shot-4.1.2.tgz",
       "integrity": "sha512-8wWgLVP1TeGqgzZtCdt+F+k15DWQvLG1Yv6ZzPfb3D5WIo5/S+GGKtJBVo2uNEcqabP5Ifc71QnJTDnTmw1axA==",
       "dependencies": {
         "@types/node": "*"
@@ -2028,14 +2105,17 @@
     },
     "node_modules/@types/http-assert": {
       "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@types/http-assert/-/http-assert-1.5.3.tgz",
       "integrity": "sha512-FyAOrDuQmBi8/or3ns4rwPno7/9tJTijVW6aQQjK02+kOQ8zmoNg2XJtAuQhvQcy1ASJq38wirX5//9J1EqoUA=="
     },
     "node_modules/@types/http-errors": {
       "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-1.8.2.tgz",
       "integrity": "sha512-EqX+YQxINb+MeXaIqYDASb6U6FCHbWjkj4a1CKDBks3d/QiB2+PqBLyO72vLDgAO1wUI4O+9gweRcQK11bTL/w=="
     },
     "node_modules/@types/ioredis": {
       "version": "4.26.6",
+      "resolved": "https://registry.npmjs.org/@types/ioredis/-/ioredis-4.26.6.tgz",
       "integrity": "sha512-Q9ydXL/5Mot751i7WLCm9OGTj5jlW3XBdkdEW21SkXZ8Y03srbkluFGbM3q8c+vzPW30JOLJ+NsZWHoly0+13A==",
       "dependencies": {
         "@types/node": "*"
@@ -2078,10 +2158,12 @@
     },
     "node_modules/@types/keygrip": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@types/keygrip/-/keygrip-1.0.2.tgz",
       "integrity": "sha512-GJhpTepz2udxGexqos8wgaBx4I/zWIDPh/KOGEwAqtuGDkOUJu5eFvwmdBX4AmB8Odsr+9pHCQqiAqDL/yKMKw=="
     },
     "node_modules/@types/koa": {
       "version": "2.13.4",
+      "resolved": "https://registry.npmjs.org/@types/koa/-/koa-2.13.4.tgz",
       "integrity": "sha512-dfHYMfU+z/vKtQB7NUrthdAEiSvnLebvBjwHtfFmpZmB7em2N3WVQdHgnFq+xvyVgxW5jKDmjWfLD3lw4g4uTw==",
       "dependencies": {
         "@types/accepts": "*",
@@ -2096,6 +2178,7 @@
     },
     "node_modules/@types/koa__router": {
       "version": "8.0.7",
+      "resolved": "https://registry.npmjs.org/@types/koa__router/-/koa__router-8.0.7.tgz",
       "integrity": "sha512-OB3Ax75nmTP+WR9AgdzA42DI7YmBtiNKN2g1Wxl+d5Dyek9SWt740t+ukwXSmv/jMBCUPyV3YEI93vZHgdP7UQ==",
       "dependencies": {
         "@types/koa": "*"
@@ -2103,6 +2186,7 @@
     },
     "node_modules/@types/koa-compose": {
       "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/@types/koa-compose/-/koa-compose-3.2.5.tgz",
       "integrity": "sha512-B8nG/OoE1ORZqCkBVsup/AKcvjdgoHnfi4pZMn5UwAPCbhk/96xyv284eBYW8JlQbQ7zDmnpFr68I/40mFoIBQ==",
       "dependencies": {
         "@types/koa": "*"
@@ -2110,29 +2194,25 @@
     },
     "node_modules/@types/memcached": {
       "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/@types/memcached/-/memcached-2.2.7.tgz",
       "integrity": "sha512-ImJbz1i8pl+OnyhYdIDnHe8jAuM8TOwM/7VsciqhYX3IL0jPPUToAtVxklfcWFGYckahEYZxhd9FS0z3MM1dpA==",
       "dependencies": {
         "@types/node": "*"
       }
     },
     "node_modules/@types/mime": {
-      "version": "1.3.2",
-      "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw=="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-3.0.1.tgz",
+      "integrity": "sha512-Y4XFY5VJAuw0FgAqPNd6NNoV44jbq9Bz2L7Rh/J6jLTiHBSBJa9fxqQIvkIld4GsoDOcCbvzOUAbLPsSKKg+uA=="
     },
     "node_modules/@types/mime-db": {
       "version": "1.43.1",
+      "resolved": "https://registry.npmjs.org/@types/mime-db/-/mime-db-1.43.1.tgz",
       "integrity": "sha512-kGZJY+R+WnR5Rk+RPHUMERtb2qBRViIHCBdtUrY+NmwuGb8pQdfTqQiCKPrxpdoycl8KWm2DLdkpoSdt479XoQ=="
-    },
-    "node_modules/@types/mongodb": {
-      "version": "3.6.20",
-      "integrity": "sha512-WcdpPJCakFzcWWD9juKoZbRtQxKIMYF/JIAM4JrNHrMcnJL6/a2NWjXxW7fo9hxboxxkg+icff8d7+WIEvKgYQ==",
-      "dependencies": {
-        "@types/bson": "*",
-        "@types/node": "*"
-      }
     },
     "node_modules/@types/mysql": {
       "version": "2.15.19",
+      "resolved": "https://registry.npmjs.org/@types/mysql/-/mysql-2.15.19.tgz",
       "integrity": "sha512-wSRg2QZv14CWcZXkgdvHbbV2ACufNy5EgI8mBBxnJIptchv7DBy/h53VMa2jDhyo0C9MO4iowE6z9vF8Ja1DkQ==",
       "dependencies": {
         "@types/node": "*"
@@ -2154,6 +2234,7 @@
     },
     "node_modules/@types/pg": {
       "version": "8.6.1",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.6.1.tgz",
       "integrity": "sha512-1Kc4oAGzAl7uqUStZCDvaLFqZrW9qWSjXOmBfdgyBP5La7Us6Mg4GBvRlSoaZMhQF/zSj1C8CtKMBkoiT8eL8w==",
       "dependencies": {
         "@types/node": "*",
@@ -2163,6 +2244,7 @@
     },
     "node_modules/@types/pg-pool": {
       "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/pg-pool/-/pg-pool-2.0.3.tgz",
       "integrity": "sha512-fwK5WtG42Yb5RxAwxm3Cc2dJ39FlgcaNiXKvtTLAwtCn642X7dgel+w1+cLWwpSOFImR3YjsZtbkfjxbHtFAeg==",
       "dependencies": {
         "@types/pg": "*"
@@ -2175,14 +2257,17 @@
     },
     "node_modules/@types/qs": {
       "version": "6.9.7",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
       "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw=="
     },
     "node_modules/@types/range-parser": {
       "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
       "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw=="
     },
     "node_modules/@types/redis": {
       "version": "2.8.31",
+      "resolved": "https://registry.npmjs.org/@types/redis/-/redis-2.8.31.tgz",
       "integrity": "sha512-daWrrTDYaa5iSDFbgzZ9gOOzyp2AJmYK59OlG/2KGBgYWF3lfs8GDKm1c//tik5Uc93hDD36O+qLPvzDolChbA==",
       "dependencies": {
         "@types/node": "*"
@@ -2190,6 +2275,7 @@
     },
     "node_modules/@types/restify": {
       "version": "4.3.8",
+      "resolved": "https://registry.npmjs.org/@types/restify/-/restify-4.3.8.tgz",
       "integrity": "sha512-BdpKcY4mnbdd7RNLfVRutkUtI1tGKMbQVKm7YgWi4kTlRm3Z4hh+F+1R1va/PZmkkk0AEt7kP82qi1jcF6Hshg==",
       "dependencies": {
         "@types/bunyan": "*",
@@ -2197,10 +2283,11 @@
       }
     },
     "node_modules/@types/serve-static": {
-      "version": "1.13.10",
-      "integrity": "sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.0.tgz",
+      "integrity": "sha512-z5xyF6uh8CbjAu9760KDKsH2FcDxZ2tFCsA4HIMWE6IkiYMXfVoa+4f9KX+FN0ZLsaMw1WNG2ETLA6N+/YA+cg==",
       "dependencies": {
-        "@types/mime": "^1",
+        "@types/mime": "*",
         "@types/node": "*"
       }
     },
@@ -2409,6 +2496,7 @@
     },
     "node_modules/abstract-logging": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/abstract-logging/-/abstract-logging-2.0.1.tgz",
       "integrity": "sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA=="
     },
     "node_modules/acorn": {
@@ -2577,6 +2665,7 @@
     },
     "node_modules/archy": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
       "integrity": "sha512-Xg+9RwCg/0p32teKdGMPTPnVXKD0w3DfHnFTficozsAgsvq2XenPJq/MYpzzQ/v8zrOyJn6Ds39VA4JIDwFfqw=="
     },
     "node_modules/are-we-there-yet": {
@@ -2673,6 +2762,7 @@
     },
     "node_modules/atomic-sleep": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
       "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
       "engines": {
         "node": ">=8.0.0"
@@ -2680,6 +2770,7 @@
     },
     "node_modules/avvio": {
       "version": "7.2.5",
+      "resolved": "https://registry.npmjs.org/avvio/-/avvio-7.2.5.tgz",
       "integrity": "sha512-AOhBxyLVdpOad3TujtC9kL/9r3HnTkxwQ5ggOsYrvvZP1cCFvzHWJd5XxZDFuTn+IN8vkKSG5SEJrd27vCSbeA==",
       "dependencies": {
         "archy": "^1.0.0",
@@ -2830,24 +2921,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/base64-js": {
-      "version": "1.5.1",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
-    },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
@@ -2917,38 +2990,6 @@
       "dev": true,
       "dependencies": {
         "node-int64": "^0.4.0"
-      }
-    },
-    "node_modules/bson": {
-      "version": "4.6.5",
-      "integrity": "sha512-uqrgcjyOaZsHfz7ea8zLRCLe1u+QGUSzMZmvXqO24CDW7DWoW1qiN9folSwa7hSneTSgM2ykDIzF5kcQQ8cwNw==",
-      "dependencies": {
-        "buffer": "^5.6.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/buffer": {
-      "version": "5.7.1",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
       }
     },
     "node_modules/buffer-from": {
@@ -3384,6 +3425,7 @@
     },
     "node_modules/cookie": {
       "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
       "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
       "engines": {
         "node": ">= 0.6"
@@ -3625,6 +3667,7 @@
     },
     "node_modules/duplexify": {
       "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.2.tgz",
       "integrity": "sha512-fz3OjcNCHmRP12MJoZMPglx8m4rrFP8rovnk4vT8Fs+aonZoCwGg10dSsQsfP/E62eZcPTMSMP6686fu9Qlqtw==",
       "dependencies": {
         "end-of-stream": "^1.4.1",
@@ -4347,6 +4390,7 @@
     },
     "node_modules/fast-decode-uri-component": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fast-decode-uri-component/-/fast-decode-uri-component-1.0.1.tgz",
       "integrity": "sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg=="
     },
     "node_modules/fast-deep-equal": {
@@ -4390,6 +4434,7 @@
     },
     "node_modules/fast-json-stringify": {
       "version": "2.7.13",
+      "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-2.7.13.tgz",
       "integrity": "sha512-ar+hQ4+OIurUGjSJD1anvYSDcUflywhKjfxnsW4TBTD7+u0tJufv6DKRWoQk3vI6YBOWMoz0TQtfbe7dxbQmvA==",
       "dependencies": {
         "ajv": "^6.11.0",
@@ -4407,19 +4452,22 @@
       "dev": true
     },
     "node_modules/fast-redact": {
-      "version": "3.1.1",
-      "integrity": "sha512-odVmjC8x8jNeMZ3C+rPMESzXVSEU8tSWSHv9HFxP2mm89G/1WwqhrerJDQm9Zus8X6aoRgQDThKqptdNA6bt+A==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.1.2.tgz",
+      "integrity": "sha512-+0em+Iya9fKGfEQGcd62Yv6onjBmmhV1uh86XVfOU8VwAe6kaFdQCWI9s0/Nnugx5Vd9tdbZ7e6gE2tR9dzXdw==",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/fast-safe-stringify": {
       "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="
     },
     "node_modules/fastify": {
-      "version": "3.29.1",
-      "integrity": "sha512-UhGmh0/J0YQetqULYfv/utvut0R6ICQvO6Oh81JvG75UbjVgueqoE6EPChB3gR5aF3dVKpT/qFTgc7zvpGTYNg==",
+      "version": "3.29.2",
+      "resolved": "https://registry.npmjs.org/fastify/-/fastify-3.29.2.tgz",
+      "integrity": "sha512-XFuIF4T9IdkCVtV0amWQZg50w8iPn8MoAV4yK1DP88dU7YEwxDOOpVgKLWZS4YJA8RU001KUfg2b/2L6kEwJWA==",
       "dependencies": {
         "@fastify/ajv-compiler": "^1.0.0",
         "@fastify/error": "^2.0.0",
@@ -4440,6 +4488,7 @@
     },
     "node_modules/fastify/node_modules/pino": {
       "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-6.14.0.tgz",
       "integrity": "sha512-iuhEDel3Z3hF9Jfe44DPXR8l07bhjuFY3GMHIXbjnY9XcafbyDDwl2sN2vw2GjMPf5Nkoe+OFao7ffn9SXaKDg==",
       "dependencies": {
         "fast-redact": "^3.0.0",
@@ -4456,10 +4505,12 @@
     },
     "node_modules/fastify/node_modules/pino-std-serializers": {
       "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-3.2.0.tgz",
       "integrity": "sha512-EqX4pwDPrt3MuOAAUBMU0Tk5kR/YcCM5fNPEzgCO2zJ5HfX0vbiH9HbJglnyeQsN96Kznae6MWD47pZB5avTrg=="
     },
     "node_modules/fastify/node_modules/sonic-boom": {
       "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-1.4.1.tgz",
       "integrity": "sha512-LRHh/A8tpW7ru89lrlkU4AszXt1dbwSjVWguGrmlxE7tawVmDBlI1PILMkXAxJTwqhgsEeTHzj36D5CmHgQmNg==",
       "dependencies": {
         "atomic-sleep": "^1.0.0",
@@ -4509,6 +4560,7 @@
     },
     "node_modules/find-my-way": {
       "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-4.5.1.tgz",
       "integrity": "sha512-kE0u7sGoUFbMXcOG/xpkmz4sRLCklERnBcg7Ftuu1iAxsfEt2S46RLJ3Sq7vshsEy2wJT2hZxE58XZK27qa8kg==",
       "dependencies": {
         "fast-decode-uri-component": "^1.0.1",
@@ -4560,6 +4612,7 @@
     },
     "node_modules/flatstr": {
       "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/flatstr/-/flatstr-1.0.12.tgz",
       "integrity": "sha512-4zPxDyhCyiN2wIAtSLI6gc82/EjqZc1onI4Mz/l0pWrAlsSfYH/2ZIcU+e3oA2wDwbzIWNKwa23F8rh6+DRWkw=="
     },
     "node_modules/flatted": {
@@ -4594,6 +4647,7 @@
     },
     "node_modules/forwarded": {
       "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
       "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
       "engines": {
         "node": ">= 0.6"
@@ -4843,6 +4897,7 @@
     },
     "node_modules/graphql": {
       "version": "15.8.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.8.0.tgz",
       "integrity": "sha512-5gghUc24tP9HRznNpV2+FIoq3xKkj5dTQqf4v0CpdPbFVwFkWoxOM+o+2OC9ZSvjEMTjfmG9QT+gcvggTwW1zw==",
       "engines": {
         "node": ">= 10.x"
@@ -5081,24 +5136,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/ieee754": {
-      "version": "1.2.1",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
-    },
     "node_modules/ignore": {
       "version": "5.2.0",
       "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
@@ -5200,6 +5237,7 @@
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
       "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
       "engines": {
         "node": ">= 0.10"
@@ -6173,6 +6211,7 @@
     },
     "node_modules/joi": {
       "version": "17.6.0",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.6.0.tgz",
       "integrity": "sha512-OX5dG6DTbcr/kbMFj0KGYxuew69HPcAE3K/sZpEV2nP6e/j/C0HV+HNiBPCASxdx5T7DMoa0s8UeHWMnb6n2zw==",
       "dependencies": {
         "@hapi/hoek": "^9.0.0",
@@ -6351,8 +6390,9 @@
       }
     },
     "node_modules/light-my-request": {
-      "version": "4.10.1",
-      "integrity": "sha512-l+zWk0HXGhGzY7IYTZnYEqIpj3Mpcyk2f8+FkKUyREywvaiWCf2jyQVxpasKRsploY/nVpoqTlxx72CIeQNcIQ==",
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/light-my-request/-/light-my-request-4.12.0.tgz",
+      "integrity": "sha512-0y+9VIfJEsPVzK5ArSIJ8Dkxp8QMP7/aCuxCUtG/tr9a2NoOf/snATE/OUc05XUplJCEnRh6gTkH7xh9POt1DQ==",
       "dependencies": {
         "ajv": "^8.1.0",
         "cookie": "^0.5.0",
@@ -6362,6 +6402,7 @@
     },
     "node_modules/light-my-request/node_modules/ajv": {
       "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
       "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -6376,6 +6417,7 @@
     },
     "node_modules/light-my-request/node_modules/json-schema-traverse": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
     },
     "node_modules/lines-and-columns": {
@@ -7358,6 +7400,7 @@
     },
     "node_modules/on-exit-leak-free": {
       "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-0.2.0.tgz",
       "integrity": "sha512-dqaz3u44QbRXQooZLTUKU41ZrzYrcvLISVgbrzbyCMxpmSLJvZ3ZamIJIZ29P6OhZIkNIQKosdeM6t1LYbA9hg=="
     },
     "node_modules/once": {
@@ -7555,6 +7598,7 @@
     },
     "node_modules/pg-int8": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
       "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
       "engines": {
         "node": ">=4.0.0"
@@ -7562,10 +7606,12 @@
     },
     "node_modules/pg-protocol": {
       "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.5.0.tgz",
       "integrity": "sha512-muRttij7H8TqRNu/DxrAJQITO4Ac7RmX3Klyr/9mJEOBeIpgnF8f9jAfRz5d3XwQZl5qBjF9gLsUtMPJE0vezQ=="
     },
     "node_modules/pg-types": {
       "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
       "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
       "dependencies": {
         "pg-int8": "1.0.1",
@@ -7615,6 +7661,7 @@
     },
     "node_modules/pino": {
       "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-7.10.0.tgz",
       "integrity": "sha512-T6R92jy/APDElEuOk0gqa4nds3ZgqFbHde2X0g8XorlyPlVGlr9T5KQphtp72a3ByKOdZMg/gM/0IprpGQfTWg==",
       "dependencies": {
         "atomic-sleep": "^1.0.0",
@@ -7635,6 +7682,7 @@
     },
     "node_modules/pino-abstract-transport": {
       "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-0.5.0.tgz",
       "integrity": "sha512-+KAgmVeqXYbTtU2FScx1XS3kNyfZ5TrXY07V96QnUSFqo2gAqlvmaxH67Lj7SWazqsMabf+58ctdTcBgnOLUOQ==",
       "dependencies": {
         "duplexify": "^4.1.2",
@@ -7643,6 +7691,7 @@
     },
     "node_modules/pino-std-serializers": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-4.0.0.tgz",
       "integrity": "sha512-cK0pekc1Kjy5w9V2/n+8MkZwusa6EyyxfeQCB799CQRhRt/CqYKiWs5adeu8Shve2ZNffvfC/7J64A2PJo1W/Q=="
     },
     "node_modules/pirates": {
@@ -7739,6 +7788,7 @@
     },
     "node_modules/postgres-array": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
       "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
       "engines": {
         "node": ">=4"
@@ -7746,6 +7796,7 @@
     },
     "node_modules/postgres-bytea": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
       "integrity": "sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w==",
       "engines": {
         "node": ">=0.10.0"
@@ -7753,6 +7804,7 @@
     },
     "node_modules/postgres-date": {
       "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
       "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
       "engines": {
         "node": ">=0.10.0"
@@ -7760,6 +7812,7 @@
     },
     "node_modules/postgres-interval": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
       "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
       "dependencies": {
         "xtend": "^4.0.0"
@@ -7817,6 +7870,7 @@
     },
     "node_modules/process-warning": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-1.0.0.tgz",
       "integrity": "sha512-du4wfLyj4yCZq1VupnVSZmRsPJsNuxoDQFdCFHLaYiEbFBD7QE0a+I4D7hOxrVnh78QE/YipFAj9lXHiXocV+Q=="
     },
     "node_modules/promise-inflight": {
@@ -7856,6 +7910,7 @@
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
       "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
       "dependencies": {
         "forwarded": "0.2.0",
@@ -7911,6 +7966,7 @@
     },
     "node_modules/quick-format-unescaped": {
       "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
       "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="
     },
     "node_modules/react-is": {
@@ -8002,6 +8058,7 @@
     },
     "node_modules/real-require": {
       "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.1.0.tgz",
       "integrity": "sha512-r/H9MzAWtrv8aSVjPCMFpDMl5q66GqtmmRkRjpHTsp4zBAa+snZyiQNlMONiUmEJcsnaw0wCauJ2GWODr/aFkg==",
       "engines": {
         "node": ">= 12.13.0"
@@ -8077,6 +8134,7 @@
     },
     "node_modules/require-from-string": {
       "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "engines": {
         "node": ">=0.10.0"
@@ -8248,6 +8306,7 @@
     },
     "node_modules/safe-regex2": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/safe-regex2/-/safe-regex2-2.0.0.tgz",
       "integrity": "sha512-PaUSFsUaNNuKwkBijoAPHAK6/eM6VirvyPWlZ7BAQy4D+hCvh4B6lIG+nPdhbFfIbP+gTGBcrdsOaUs0F+ZBOQ==",
       "dependencies": {
         "ret": "~0.2.0"
@@ -8255,6 +8314,7 @@
     },
     "node_modules/safe-regex2/node_modules/ret": {
       "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.2.2.tgz",
       "integrity": "sha512-M0b3YWQs7R3Z917WRQy1HHA7Ba7D8hvZg6UE5mLykJxQVE2ju0IXbGlaHPPlkY+WN7wFP+wUMXmBFA0aV6vYGQ==",
       "engines": {
         "node": ">=4"
@@ -8556,8 +8616,9 @@
       }
     },
     "node_modules/secure-json-parse": {
-      "version": "2.4.0",
-      "integrity": "sha512-Q5Z/97nbON5t/L/sH6mY2EacfjVGwrCcSi5D3btRO2GZ8pf1K1UN7Z9H5J57hjVU2Qzxr1xO+FmBhOvEkzCMmg=="
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.5.0.tgz",
+      "integrity": "sha512-ZQruFgZnIWH+WyO9t5rWt4ZEGqCKPwhiw+YbzTwpmT9elgLrLcfuyUiSnwwjUiVy9r4VM3urtbNF1xmEh9IL2w=="
     },
     "node_modules/semver": {
       "version": "7.3.7",
@@ -8590,6 +8651,7 @@
     },
     "node_modules/semver-store": {
       "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/semver-store/-/semver-store-0.3.0.tgz",
       "integrity": "sha512-TcZvGMMy9vodEFSse30lWinkj+JgOBvPn8wRItpQRSayhc+4ssDs335uklkfvQQJgL/WvmHLVj4Ycv2s7QCQMg=="
     },
     "node_modules/seq-queue": {
@@ -8602,8 +8664,9 @@
       "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw=="
     },
     "node_modules/set-cookie-parser": {
-      "version": "2.5.0",
-      "integrity": "sha512-cHMAtSXilfyBePduZEBVPTCftTQWz6ehWJD5YNUg4mqvRosrrjKbo4WS8JkB0/RxonMoohHm7cOGH60mDkRQ9w=="
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.5.1.tgz",
+      "integrity": "sha512-1jeBGaKNGdEq4FgIrORu/N570dwoPYio8lSoYLWmX7sQ//0JY08Xh9o5pBcgmHQ/MbsYp/aZnOe1s1lIsbLprQ=="
     },
     "node_modules/set-value": {
       "version": "2.0.1",
@@ -8940,6 +9003,7 @@
     },
     "node_modules/sonic-boom": {
       "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-2.8.0.tgz",
       "integrity": "sha512-kuonw1YOYYNOve5iHdSahXPOK49GqwA+LZhI6Wz/l0rP57iKyXXIHaRagOBHAPmGwJC6od2Z9zgvZ5loSgMlVg==",
       "dependencies": {
         "atomic-sleep": "^1.0.0"
@@ -9022,6 +9086,7 @@
     },
     "node_modules/split2": {
       "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.1.0.tgz",
       "integrity": "sha512-VBiJxFkxiXRlUIeyMQi8s4hgvKCSjtknJv/LVYbrgALPwf5zSKmEwV9Lst25AkvMDnvxODugjdl6KZgwKM1WYQ==",
       "engines": {
         "node": ">= 10.x"
@@ -9166,6 +9231,7 @@
     },
     "node_modules/stream-shift": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
       "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="
     },
     "node_modules/string_decoder": {
@@ -9197,6 +9263,7 @@
     },
     "node_modules/string-similarity": {
       "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/string-similarity/-/string-similarity-4.0.4.tgz",
       "integrity": "sha512-/q/8Q4Bl4ZKAPjj8WerIBJWALKkaPRfrvhfF8k/B23i4nzrlRj2/go1m90In7nG/3XDSbOo0+pu6RvCTM9RGMQ=="
     },
     "node_modules/string-width": {
@@ -9403,6 +9470,7 @@
     },
     "node_modules/thread-stream": {
       "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-0.15.2.tgz",
       "integrity": "sha512-UkEhKIg2pD+fjkHQKyJO3yoIvAP3N6RlNFt2dUhcS1FGvCD1cQa1M/PGknCLFIyZdtJOWQjejp7bdNqmN7zwdA==",
       "dependencies": {
         "real-require": "^0.1.0"
@@ -9420,6 +9488,7 @@
     },
     "node_modules/tiny-lru": {
       "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/tiny-lru/-/tiny-lru-8.0.2.tgz",
       "integrity": "sha512-ApGvZ6vVvTNdsmt676grvCkUCGwzG9IqXma5Z07xJgiC5L7akUMof5U8G2JTI9Rz/ovtVhJBlY6mNhEvtjzOIg==",
       "engines": {
         "node": ">=6"
@@ -9995,6 +10064,7 @@
     },
     "node_modules/xtend": {
       "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
       "engines": {
         "node": ">=0.4"
@@ -10498,6 +10568,7 @@
     },
     "@fastify/ajv-compiler": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@fastify/ajv-compiler/-/ajv-compiler-1.1.0.tgz",
       "integrity": "sha512-gvCOUNpXsWrIQ3A4aXCLIdblL0tDq42BG/2Xw7oxbil9h11uow10ztS2GuFazNBfjbrsZ5nl+nPl5jDSjj5TSg==",
       "requires": {
         "ajv": "^6.12.6"
@@ -10505,6 +10576,7 @@
     },
     "@fastify/error": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@fastify/error/-/error-2.0.0.tgz",
       "integrity": "sha512-wI3fpfDT0t7p8E6dA2eTECzzOd+bZsZCJ2Hcv+Onn2b7ZwK3RwD27uW2QDaMtQhAfWQQP+WNK7nKf0twLsBf9w=="
     },
     "@gar/promisify": {
@@ -10513,6 +10585,7 @@
     },
     "@hapi/b64": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/b64/-/b64-5.0.0.tgz",
       "integrity": "sha512-ngu0tSEmrezoiIaNGG6rRvKOUkUuDdf4XTPnONHGYfSGRmDqPZX5oJL6HAdKTo1UQHECbdB4OzhWrfgVppjHUw==",
       "requires": {
         "@hapi/hoek": "9.x.x"
@@ -10520,6 +10593,7 @@
     },
     "@hapi/boom": {
       "version": "9.1.4",
+      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-9.1.4.tgz",
       "integrity": "sha512-Ls1oH8jaN1vNsqcaHVYJrKmgMcKsC1wcp8bujvXrHaAqD2iDYq3HoOwsxwo09Cuda5R5nC0o0IxlrlTuvPuzSw==",
       "requires": {
         "@hapi/hoek": "9.x.x"
@@ -10527,10 +10601,12 @@
     },
     "@hapi/bourne": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-2.1.0.tgz",
       "integrity": "sha512-i1BpaNDVLJdRBEKeJWkVO6tYX6DMFBuwMhSuWqLsY4ufeTKGVuV5rBsUhxPayXqnnWHgXUAmWK16H/ykO5Wj4Q=="
     },
     "@hapi/cryptiles": {
       "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/cryptiles/-/cryptiles-5.1.0.tgz",
       "integrity": "sha512-fo9+d1Ba5/FIoMySfMqPBR/7Pa29J2RsiPrl7bkwo5W5o+AN1dAYQRi4SPrPwwVxVGKjgLOEWrsvt1BonJSfLA==",
       "requires": {
         "@hapi/boom": "9.x.x"
@@ -10538,10 +10614,12 @@
     },
     "@hapi/hoek": {
       "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
       "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="
     },
     "@hapi/iron": {
       "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/iron/-/iron-6.0.0.tgz",
       "integrity": "sha512-zvGvWDufiTGpTJPG1Y/McN8UqWBu0k/xs/7l++HVU535NLHXsHhy54cfEMdW7EjwKfbBfM9Xy25FmTiobb7Hvw==",
       "requires": {
         "@hapi/b64": "5.x.x",
@@ -10553,6 +10631,7 @@
     },
     "@hapi/podium": {
       "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@hapi/podium/-/podium-4.1.3.tgz",
       "integrity": "sha512-ljsKGQzLkFqnQxE7qeanvgGj4dejnciErYd30dbrYzUOF/FyS/DOF97qcrT3bhoVwCYmxa6PEMhxfCPlnUcD2g==",
       "requires": {
         "@hapi/hoek": "9.x.x",
@@ -10562,10 +10641,12 @@
     },
     "@hapi/teamwork": {
       "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/teamwork/-/teamwork-5.1.1.tgz",
       "integrity": "sha512-1oPx9AE5TIv+V6Ih54RP9lTZBso3rP8j4Xhb6iSVwPXtAM+sDopl5TFMv5Paw73UnpZJ9gjcrTE1BXrWt9eQrg=="
     },
     "@hapi/topo": {
       "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
       "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
       "requires": {
         "@hapi/hoek": "^9.0.0"
@@ -10573,6 +10654,7 @@
     },
     "@hapi/validate": {
       "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@hapi/validate/-/validate-1.1.3.tgz",
       "integrity": "sha512-/XMR0N0wjw0Twzq2pQOzPBZlDzkekGcoCtzO314BpIEsbXdYGthQUbxgkGDf4nhk1+IPDAsXqWjMohRQYO06UA==",
       "requires": {
         "@hapi/hoek": "^9.0.0",
@@ -10893,46 +10975,49 @@
       "integrity": "sha512-hf+3bwuBwtXsugA2ULBc95qxrOqP2pOekLz34BJhcAKawt94vfeNyUKpYc0lZQ/3sCP6LqRa7UAdHA7i5UODzQ=="
     },
     "@opentelemetry/api-metrics": {
-      "version": "0.29.2",
-      "integrity": "sha512-yRdF5beqKuEdsPNoO7ijWCQ9HcyN0Tlgicf8RS6gzGOI54d6Hj7yKquJ6+X9XV+CSRbRWJYb+lOsXyso7uyX2g==",
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-metrics/-/api-metrics-0.32.0.tgz",
+      "integrity": "sha512-g1WLhpG8B6iuDyZJFRGsR+JKyZ94m5LEmY2f+duEJ9Xb4XRlLHrZvh6G34OH6GJ8iDHxfHb/sWjJ1ZpkI9yGMQ==",
       "requires": {
         "@opentelemetry/api": "^1.0.0"
       }
     },
     "@opentelemetry/auto-instrumentations-node": {
-      "version": "0.31.0",
-      "integrity": "sha512-UQ4u3hVNGS5B2utNWWp2+R49H8xO7rXk4Q78V5cnnbmLjNtuI597Mm4dXiWGhpNm5LgYyBsxh2HLusQEAJo//A==",
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/auto-instrumentations-node/-/auto-instrumentations-node-0.32.0.tgz",
+      "integrity": "sha512-LTEJIkWXe6ERWfG1vxp34aVcWGaspUtM8wIyprpilI9iNLhKK8SvpDckhL3AZp3D6uWUk8OWM3U/LcOWwfIwqA==",
       "requires": {
-        "@opentelemetry/instrumentation": "^0.29.2",
-        "@opentelemetry/instrumentation-amqplib": "^0.30.0",
-        "@opentelemetry/instrumentation-aws-lambda": "^0.32.0",
-        "@opentelemetry/instrumentation-aws-sdk": "^0.8.0",
-        "@opentelemetry/instrumentation-bunyan": "^0.29.0",
-        "@opentelemetry/instrumentation-cassandra-driver": "^0.29.0",
-        "@opentelemetry/instrumentation-connect": "^0.29.0",
-        "@opentelemetry/instrumentation-dns": "^0.29.0",
-        "@opentelemetry/instrumentation-express": "^0.30.0",
-        "@opentelemetry/instrumentation-fastify": "^0.28.0",
-        "@opentelemetry/instrumentation-generic-pool": "^0.29.0",
-        "@opentelemetry/instrumentation-graphql": "^0.29.0",
-        "@opentelemetry/instrumentation-grpc": "^0.29.2",
-        "@opentelemetry/instrumentation-hapi": "^0.29.0",
-        "@opentelemetry/instrumentation-http": "^0.29.2",
-        "@opentelemetry/instrumentation-ioredis": "^0.30.0",
-        "@opentelemetry/instrumentation-knex": "^0.29.0",
-        "@opentelemetry/instrumentation-koa": "^0.30.0",
-        "@opentelemetry/instrumentation-memcached": "^0.29.0",
-        "@opentelemetry/instrumentation-mongodb": "^0.31.0",
-        "@opentelemetry/instrumentation-mysql": "^0.30.0",
-        "@opentelemetry/instrumentation-mysql2": "^0.31.0",
-        "@opentelemetry/instrumentation-nestjs-core": "^0.30.0",
-        "@opentelemetry/instrumentation-net": "^0.29.0",
-        "@opentelemetry/instrumentation-pg": "^0.30.0",
-        "@opentelemetry/instrumentation-pino": "^0.30.0",
-        "@opentelemetry/instrumentation-redis": "^0.32.0",
-        "@opentelemetry/instrumentation-redis-4": "^0.31.0",
-        "@opentelemetry/instrumentation-restify": "^0.29.0",
-        "@opentelemetry/instrumentation-winston": "^0.29.0"
+        "@opentelemetry/instrumentation": "^0.32.0",
+        "@opentelemetry/instrumentation-amqplib": "^0.31.0",
+        "@opentelemetry/instrumentation-aws-lambda": "^0.33.0",
+        "@opentelemetry/instrumentation-aws-sdk": "^0.9.0",
+        "@opentelemetry/instrumentation-bunyan": "^0.30.0",
+        "@opentelemetry/instrumentation-cassandra-driver": "^0.30.0",
+        "@opentelemetry/instrumentation-connect": "^0.30.0",
+        "@opentelemetry/instrumentation-dns": "^0.30.0",
+        "@opentelemetry/instrumentation-express": "^0.31.0",
+        "@opentelemetry/instrumentation-fastify": "^0.29.0",
+        "@opentelemetry/instrumentation-generic-pool": "^0.30.0",
+        "@opentelemetry/instrumentation-graphql": "^0.30.0",
+        "@opentelemetry/instrumentation-grpc": "^0.32.0",
+        "@opentelemetry/instrumentation-hapi": "^0.30.0",
+        "@opentelemetry/instrumentation-http": "^0.32.0",
+        "@opentelemetry/instrumentation-ioredis": "^0.32.0",
+        "@opentelemetry/instrumentation-knex": "^0.30.0",
+        "@opentelemetry/instrumentation-koa": "^0.32.0",
+        "@opentelemetry/instrumentation-lru-memoizer": "^0.31.0",
+        "@opentelemetry/instrumentation-memcached": "^0.30.0",
+        "@opentelemetry/instrumentation-mongodb": "^0.32.0",
+        "@opentelemetry/instrumentation-mysql": "^0.31.0",
+        "@opentelemetry/instrumentation-mysql2": "^0.32.0",
+        "@opentelemetry/instrumentation-nestjs-core": "^0.31.0",
+        "@opentelemetry/instrumentation-net": "^0.30.0",
+        "@opentelemetry/instrumentation-pg": "^0.31.0",
+        "@opentelemetry/instrumentation-pino": "^0.31.0",
+        "@opentelemetry/instrumentation-redis": "^0.33.0",
+        "@opentelemetry/instrumentation-redis-4": "^0.32.0",
+        "@opentelemetry/instrumentation-restify": "^0.30.0",
+        "@opentelemetry/instrumentation-winston": "^0.30.0"
       }
     },
     "@opentelemetry/context-async-hooks": {
@@ -10948,30 +11033,33 @@
       }
     },
     "@opentelemetry/instrumentation": {
-      "version": "0.29.2",
-      "integrity": "sha512-LXx5V0ONNATQFCE8C5uqnxWSm4rcXLssdLHdXjtGdxRmURqj/JO8jYefqXCD0LzsqEQ6yxOx2GZ0dgXvhBVdTw==",
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.32.0.tgz",
+      "integrity": "sha512-y6ADjHpkUz/v1nkyyYjsQa/zorhX+0qVGpFvXMcbjU4sHnBnC02c6wcc93sIgZfiQClIWo45TGku1KQxJ5UUbQ==",
       "requires": {
-        "@opentelemetry/api-metrics": "0.29.2",
+        "@opentelemetry/api-metrics": "0.32.0",
         "require-in-the-middle": "^5.0.3",
         "semver": "^7.3.2",
         "shimmer": "^1.2.1"
       }
     },
     "@opentelemetry/instrumentation-amqplib": {
-      "version": "0.30.0",
-      "integrity": "sha512-aZZgi/O/kwrCIGSkf/7Sy7dB4ZzRTLcnU7A62SZWWU7f6C4KUXQ1TMizwJphF4P8QheqlgqJfoWrw+KDLheJbw==",
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-amqplib/-/instrumentation-amqplib-0.31.0.tgz",
+      "integrity": "sha512-XkWgChRpvI2bNH1Y0CeB92qepzSxIklVBM8MvYnbmMisOzBFlqhe8LMs5szba/78qR2UJ9w7vcrf0HwEK8qERw==",
       "requires": {
         "@opentelemetry/core": "^1.0.0",
-        "@opentelemetry/instrumentation": "^0.29.2",
+        "@opentelemetry/instrumentation": "^0.32.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/amqplib": "^0.5.17"
       }
     },
     "@opentelemetry/instrumentation-aws-lambda": {
-      "version": "0.32.0",
-      "integrity": "sha512-mVgd03G292DSkix5ARkTdp/dkPEhLwgwNDhEHsR1isOW2Lw3WKr4dCjMQKAYmbhhj3jg1/ovlwkhEQz6hIqXYQ==",
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-aws-lambda/-/instrumentation-aws-lambda-0.33.0.tgz",
+      "integrity": "sha512-mxWt0WEpTJW8OFfJ3wyD0iWGNmiLUCyLYsknouLe3WSDvYDvdGcvpRSy2qRf8weSXj3ZwFQDN/6YvmrU5BI0ZA==",
       "requires": {
-        "@opentelemetry/instrumentation": "^0.29.2",
+        "@opentelemetry/instrumentation": "^0.32.0",
         "@opentelemetry/propagator-aws-xray": "^1.1.0",
         "@opentelemetry/resources": "^1.0.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
@@ -10979,274 +11067,313 @@
       }
     },
     "@opentelemetry/instrumentation-aws-sdk": {
-      "version": "0.8.0",
-      "integrity": "sha512-F29TmSsq8LWeZZXHV72b3B+QItZPVPsPx1DuQYPcKeCwAJUAg0huukXbf2U2XskA1fmw49+t9AM8fFPdytftyA==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-aws-sdk/-/instrumentation-aws-sdk-0.9.0.tgz",
+      "integrity": "sha512-dntHO3xyLRF8GP9vBXkNlHuMwlfj7FQdiL6H60nj1VelqhbdJoT8ArnbKfz4USRF8TFjcQ+LaDBSUdMdVF7e/g==",
       "requires": {
         "@opentelemetry/core": "^1.0.0",
-        "@opentelemetry/instrumentation": "^0.29.2",
+        "@opentelemetry/instrumentation": "^0.32.0",
         "@opentelemetry/propagation-utils": "^0.28.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       }
     },
     "@opentelemetry/instrumentation-bunyan": {
-      "version": "0.29.0",
-      "integrity": "sha512-i1FZ+W96vQCIpkMKPZW0HOA79ve9PLIcTAFH0adU/CvtRRMSxyKPTKzWMGHcWr6DueKIPEorpMG+nO2Z/yk9iQ==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-bunyan/-/instrumentation-bunyan-0.30.0.tgz",
+      "integrity": "sha512-7U4w5QA/i60AQ0LhX5AQH6L/pdE8UEhrDRGn0P7EcWUtKgHCaza6yroTsCaz7abXma7ha8SNx6IHIbAQGSYOBA==",
       "requires": {
-        "@opentelemetry/instrumentation": "^0.29.2",
+        "@opentelemetry/instrumentation": "^0.32.0",
         "@types/bunyan": "1.8.7"
       }
     },
     "@opentelemetry/instrumentation-cassandra-driver": {
-      "version": "0.29.0",
-      "integrity": "sha512-Wp7ntJVHwI5wN/cTMnBJJeQ8PmgordnHbq+B1k+xzBLPz7Pro+6q8SFmiupZvrZmfzWsdSDaO2XM/6CIdtFB5Q==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-cassandra-driver/-/instrumentation-cassandra-driver-0.30.0.tgz",
+      "integrity": "sha512-xvTpn6nkrWECly0Bx0ktrJEzxu/NIFXYxKrhCtlzh1R/GswIqfeBiPA+tzWgS8hdpNDsQLhLXfQ82es2zPcp7Q==",
       "requires": {
-        "@opentelemetry/instrumentation": "^0.29.2",
+        "@opentelemetry/instrumentation": "^0.32.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       }
     },
     "@opentelemetry/instrumentation-connect": {
-      "version": "0.29.0",
-      "integrity": "sha512-2BvdIdUCPIYNnROaMToLG76wZXvZXM2L9zOtEFlUnp8teI3Lu2mSPKRaSZ6XAmVVgTAtpfq2IuJMcZ5zAhJuCg==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-connect/-/instrumentation-connect-0.30.0.tgz",
+      "integrity": "sha512-+hjPA5CXyusUKclHhuzT2c47dDyjC7k5I8TjqSLx+SZqN3jvb9Pwae2S49Rd+TgMTrZG9Ip2MvGlalz1dWIHRQ==",
       "requires": {
         "@opentelemetry/core": "^1.0.0",
-        "@opentelemetry/instrumentation": "^0.29.2",
+        "@opentelemetry/instrumentation": "^0.32.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/connect": "3.4.35"
       }
     },
     "@opentelemetry/instrumentation-dns": {
-      "version": "0.29.0",
-      "integrity": "sha512-3WTC4m6JKviaABiR3a+56WUMvrUp9WW9EYC0+LRpqm7RK/1a5bYq2Cozc2SlFYX9ZfWKMqGS39/fU24mKQ5toA==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-dns/-/instrumentation-dns-0.30.0.tgz",
+      "integrity": "sha512-NzUSHn83HrvV2ph8V1KQERkrNpEEpqxHa3W8wepmr17jdmUU02/RwLxw7yWD9SLiKXwW29Iym3hj2x6TbuQ7QA==",
       "requires": {
-        "@opentelemetry/instrumentation": "^0.29.2",
+        "@opentelemetry/instrumentation": "^0.32.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "semver": "^7.3.2"
       }
     },
     "@opentelemetry/instrumentation-express": {
-      "version": "0.30.0",
-      "integrity": "sha512-OsCfM+ThAXh3wzsyHgXyA5HUoLMdLd6Asix2Jx8yxniruU/Gq8y4Cz7aLy/vXNckXHWO3fwwL5gb7K3dykTnAQ==",
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-express/-/instrumentation-express-0.31.0.tgz",
+      "integrity": "sha512-JvMF84qDr1XQ7cNvRr39T10H2Wz772kKG42Y5be514gwJNWqZkaFLcfCAXu8Vap9nwtqYqIvJPRkQ9RsOghTQA==",
       "requires": {
         "@opentelemetry/core": "^1.0.0",
-        "@opentelemetry/instrumentation": "^0.29.2",
+        "@opentelemetry/instrumentation": "^0.32.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/express": "4.17.13"
       }
     },
     "@opentelemetry/instrumentation-fastify": {
-      "version": "0.28.0",
-      "integrity": "sha512-HVvxTDgAhGZqp5k/JA/W4cMpHMy25CXy1pJDOoVB08gC6TKDBg/54iKgLr+g+nqV9RejIKfydt+35Xesynay/g==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fastify/-/instrumentation-fastify-0.29.0.tgz",
+      "integrity": "sha512-r18b/f5+gYrCqEMuxQOf+0ohhioIOMce7WxDGXxib3qGeFHvt71PM9wmJpj0jM4WxIrosmL1js0peqMEE8LRIQ==",
       "requires": {
         "@opentelemetry/core": "^1.0.0",
-        "@opentelemetry/instrumentation": "^0.29.2",
+        "@opentelemetry/instrumentation": "^0.32.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "fastify": "^3.19.2"
       }
     },
     "@opentelemetry/instrumentation-generic-pool": {
-      "version": "0.29.0",
-      "integrity": "sha512-tCVIVdGLS4bsFOwYGcbzuESh3XREfdhtMU9iXkULON1KoYi1c68HlWC9yyNQL7yTCBkbYSk2XjWKs6dHbcSf3A==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-generic-pool/-/instrumentation-generic-pool-0.30.0.tgz",
+      "integrity": "sha512-Q9VYMok7Qchlf+Q4s5TPCpmWvbxg4JMKZgkwTj25ZBGUlWWTfk1/oCctcQHok1Yvdvctczzr1DGrFw08cQDdCA==",
       "requires": {
-        "@opentelemetry/instrumentation": "^0.29.2",
+        "@opentelemetry/instrumentation": "^0.32.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/generic-pool": "^3.1.9"
       }
     },
     "@opentelemetry/instrumentation-graphql": {
-      "version": "0.29.0",
-      "integrity": "sha512-mAjz326UtWGQUAmmEY6VB4XV1kbgQGBmRWjh/QT0giLwcbKa9RdO0x0B+VbALbrth7ZtHuoyKaDjCWowuzUujw==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-graphql/-/instrumentation-graphql-0.30.0.tgz",
+      "integrity": "sha512-CCwTjDeRBWNtt6DbM8PsOQUsLnjpIf+PwK6hliCENfB5oWFC5nw4TkpuaGGHqgIOexae2CitlB2cLb5yWtxpdw==",
       "requires": {
-        "@opentelemetry/instrumentation": "^0.29.2",
+        "@opentelemetry/instrumentation": "^0.32.0",
         "graphql": "^15.5.1"
       }
     },
     "@opentelemetry/instrumentation-grpc": {
-      "version": "0.29.2",
-      "integrity": "sha512-rWyx/a7CsEYopwxaND47z+I8SrTLTHEz9sm8sf30FkMviVyRzYqt2PJT+JMGInM7Om/IpZNEc29kSzUjLmqddQ==",
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-grpc/-/instrumentation-grpc-0.32.0.tgz",
+      "integrity": "sha512-Az6wdkPx/Mi26lT9LKFV6GhCA9prwQFPz5eCNSExTnSP49YhQ7XCjzPd2POPeLKt84ICitrBMdE1mj0zbPdLAQ==",
       "requires": {
-        "@opentelemetry/api-metrics": "0.29.2",
-        "@opentelemetry/instrumentation": "0.29.2",
-        "@opentelemetry/semantic-conventions": "1.3.1"
+        "@opentelemetry/api-metrics": "0.32.0",
+        "@opentelemetry/instrumentation": "0.32.0",
+        "@opentelemetry/semantic-conventions": "1.6.0"
       },
       "dependencies": {
         "@opentelemetry/semantic-conventions": {
-          "version": "1.3.1",
-          "integrity": "sha512-wU5J8rUoo32oSef/rFpOT1HIjLjAv3qIDHkw1QIhODV3OpAVHi5oVzlouozg9obUmZKtbZ0qUe/m7FP0y0yBzA=="
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.6.0.tgz",
+          "integrity": "sha512-aPfcBeLErM/PPiAuAbNFLN5sNbZLc3KZlar27uohllN8Zs6jJbHyJU1y7cMA6W/zuq+thkaG8mujiS+3iD/FWQ=="
         }
       }
     },
     "@opentelemetry/instrumentation-hapi": {
-      "version": "0.29.0",
-      "integrity": "sha512-yqfuKALO20Mx6F8GStnwTmD/JUhR9JGV3GJVH3UJ5TDAvz61hhoQWaBm0iAP5cJhrKRMD8mictAT2OiHSPUpLw==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-hapi/-/instrumentation-hapi-0.30.0.tgz",
+      "integrity": "sha512-tfX8P9g685JWpR4qFtZyK9aOT755n+0hSdCWe1iqGeuE8xI4gUsqPUFMCNbA8foTf+HauUPt9O6SaK1r7P24mA==",
       "requires": {
         "@opentelemetry/core": "^1.0.0",
-        "@opentelemetry/instrumentation": "^0.29.2",
+        "@opentelemetry/instrumentation": "^0.32.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/hapi__hapi": "20.0.9"
       }
     },
     "@opentelemetry/instrumentation-http": {
-      "version": "0.29.2",
-      "integrity": "sha512-XIF9WCH03rp3vQjwXXVdTxlsXT2AG6LYfFKO8r2QC+w4F4KFuZa4J3VPYJ0L/a/6dWt34DA67eBh3l6Z1rMZrg==",
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.32.0.tgz",
+      "integrity": "sha512-EbNdJl6IjouphbxPVGV8/utiqB2DhveyH5TD6vxjc2OXlQ3A/mKg3fYSSWB+rYQBuuli+jWQfBJe2ntOFZtTMw==",
       "requires": {
-        "@opentelemetry/core": "1.3.1",
-        "@opentelemetry/instrumentation": "0.29.2",
-        "@opentelemetry/semantic-conventions": "1.3.1",
+        "@opentelemetry/core": "1.6.0",
+        "@opentelemetry/instrumentation": "0.32.0",
+        "@opentelemetry/semantic-conventions": "1.6.0",
         "semver": "^7.3.5"
       },
       "dependencies": {
         "@opentelemetry/core": {
-          "version": "1.3.1",
-          "integrity": "sha512-k7lOC86N7WIyUZsUuSKZfFIrUtINtlauMGQsC1r7jNmcr0vVJGqK1ROBvt7WWMxLbpMnt1q2pXJO8tKu0b9auA==",
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.6.0.tgz",
+          "integrity": "sha512-MsEhsyCTfYme6frK8/AqEWwbS9SB3Ta5bjgz4jPQJjL7ijUM3JiLVvqh/kHo1UlUjbUbLmGG7jA5Nw4d7SMcLQ==",
           "requires": {
-            "@opentelemetry/semantic-conventions": "1.3.1"
+            "@opentelemetry/semantic-conventions": "1.6.0"
           }
         },
         "@opentelemetry/semantic-conventions": {
-          "version": "1.3.1",
-          "integrity": "sha512-wU5J8rUoo32oSef/rFpOT1HIjLjAv3qIDHkw1QIhODV3OpAVHi5oVzlouozg9obUmZKtbZ0qUe/m7FP0y0yBzA=="
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.6.0.tgz",
+          "integrity": "sha512-aPfcBeLErM/PPiAuAbNFLN5sNbZLc3KZlar27uohllN8Zs6jJbHyJU1y7cMA6W/zuq+thkaG8mujiS+3iD/FWQ=="
         }
       }
     },
     "@opentelemetry/instrumentation-ioredis": {
-      "version": "0.30.0",
-      "integrity": "sha512-iYdVWRz53kZ3DsEMt5es8KF+OrfRi4M6gSQYA7q6OcVXrucAUZA+juK8Rl3IgWjXG5wKCzr/liKs6HDAVJ9f/Q==",
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-ioredis/-/instrumentation-ioredis-0.32.0.tgz",
+      "integrity": "sha512-+L0XY3o6F++SK+QQLi7n0OkNf16IygWMutKT9WURRcIQCo6fjZJAuZLWzuXmrXY/W1Fcm2bLPQH9Vyo0OhvkCg==",
       "requires": {
-        "@opentelemetry/instrumentation": "^0.29.2",
+        "@opentelemetry/instrumentation": "^0.32.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/ioredis": "4.26.6"
       }
     },
     "@opentelemetry/instrumentation-knex": {
-      "version": "0.29.0",
-      "integrity": "sha512-M00bEYxl5VZV53jVxxnweGrEO9AMuSPIAz1mIzk/Z3bXU/KK9GxCBCZajwxdXv1SKj6KMQ+mOfXOOnY8Y0Wbcg==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-knex/-/instrumentation-knex-0.30.0.tgz",
+      "integrity": "sha512-H0d4IrjE/2eV3B9DAPYD0MRYvQgZygvOj1uq14m/ZxrQNCYQu7ntmz53/N0nqx0/DNfGlx7TAwr425sY/KJw2A==",
       "requires": {
-        "@opentelemetry/instrumentation": "^0.29.2",
+        "@opentelemetry/instrumentation": "^0.32.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       }
     },
     "@opentelemetry/instrumentation-koa": {
-      "version": "0.30.0",
-      "integrity": "sha512-GWm8L8HzMK0f+ZpRhBQc+JVwNL7+7zAm9w/HVAzfCGJyushU/wWkso1xOlwumiJndfRaqYqxg9FW32Yw3vYrng==",
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-koa/-/instrumentation-koa-0.32.0.tgz",
+      "integrity": "sha512-IW8yywrw71B5+s/JKdDY1psbF5GyV6w4wuVB6YGo0qV/isE/naHYIV2SnBwGHzu9jGrWjjcmuiEqOn93V5CQaQ==",
       "requires": {
         "@opentelemetry/core": "^1.0.0",
-        "@opentelemetry/instrumentation": "^0.29.2",
+        "@opentelemetry/instrumentation": "^0.32.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/koa": "2.13.4",
         "@types/koa__router": "8.0.7"
       }
     },
-    "@opentelemetry/instrumentation-memcached": {
-      "version": "0.29.0",
-      "integrity": "sha512-th+zERg1/1DpCVZ3doKPmjVnbPFBZO5RHcteFkt28ibYTrPEL6K4EciTybdIyC10madFOJRydC9lfvDfgY857g==",
+    "@opentelemetry/instrumentation-lru-memoizer": {
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-lru-memoizer/-/instrumentation-lru-memoizer-0.31.0.tgz",
+      "integrity": "sha512-eAUwYtTK7Tmb/ruXSBB5wW4lXW8HsmWmbmFDL8rmOo2eCCKTZocm9Mk79scKminA59Mb5vfZjn7r21KRlYFCSQ==",
       "requires": {
-        "@opentelemetry/instrumentation": "^0.29.2",
+        "@opentelemetry/instrumentation": "^0.32.0"
+      }
+    },
+    "@opentelemetry/instrumentation-memcached": {
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-memcached/-/instrumentation-memcached-0.30.0.tgz",
+      "integrity": "sha512-1zEl7n+x1NG3gVpzQu92TonlAxRFM/Ng7b2CMQYqu4uqeAe0/k7BPmj4N1RW/g0+3mf2aCxnebRT5LMjRBSd4w==",
+      "requires": {
+        "@opentelemetry/instrumentation": "^0.32.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/memcached": "^2.2.6"
       }
     },
     "@opentelemetry/instrumentation-mongodb": {
-      "version": "0.31.0",
-      "integrity": "sha512-4pyjBeSZucUoKoQqqjwv693NmvvG7/HFCFUwN+f1wxliRq+2uuJoT/bp9wcrwLG4IW+8QvxVyN++Hn5LgQeSwQ==",
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongodb/-/instrumentation-mongodb-0.32.0.tgz",
+      "integrity": "sha512-EL5OzMWTuKpOKfOzQ6+xqNGUsQo70Wx62SSP7i4FIkW1PqLNDjqFhd+eHi98WqDjDQ4Yn69bb0Vzml3TYG68HA==",
       "requires": {
-        "@opentelemetry/instrumentation": "^0.29.2",
-        "@opentelemetry/semantic-conventions": "^1.0.0",
-        "@types/mongodb": "3.6.20"
+        "@opentelemetry/instrumentation": "^0.32.0",
+        "@opentelemetry/semantic-conventions": "^1.0.0"
       }
     },
     "@opentelemetry/instrumentation-mysql": {
-      "version": "0.30.0",
-      "integrity": "sha512-FdbZ2Yb15OTGa6HZYXxUL0yhcXNec2HHbUp9nn3x2B9YO9bJHJQoNVyHVd5gssMVYKFg4dgZodY/YXYu9xj2Ow==",
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql/-/instrumentation-mysql-0.31.0.tgz",
+      "integrity": "sha512-NGMc8MdkdKfnRPNanVbcH9L+UxbodMujuZa0jVw8CPF+9hRp7zcVSheVYo/mqc10p3DkjqibGKlBrLJ3c9e1sg==",
       "requires": {
-        "@opentelemetry/instrumentation": "^0.29.2",
+        "@opentelemetry/instrumentation": "^0.32.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/mysql": "2.15.19"
       }
     },
     "@opentelemetry/instrumentation-mysql2": {
-      "version": "0.31.0",
-      "integrity": "sha512-Pcm9i0dwLk5yvP11knL8z63Cu0djy9CYSE3ZDvIQinF/HcOmFTKUYqIeX+8XZkIupgDmeFEy6rWZEvvko8sanw==",
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql2/-/instrumentation-mysql2-0.32.0.tgz",
+      "integrity": "sha512-ApiDswZiaNR+JnGEPU7TtwHaGtGmnACc6pyKmeMEgEuB1VR7dRZLyztgiOz7NNFsCLSDkW24XMZ/wrBgJUvz4g==",
       "requires": {
-        "@opentelemetry/instrumentation": "^0.29.2",
+        "@opentelemetry/instrumentation": "^0.32.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       }
     },
     "@opentelemetry/instrumentation-nestjs-core": {
-      "version": "0.30.0",
-      "integrity": "sha512-z9HSjL4Udx2tteqyjvzrmNk6mxhip4BkWSWWZKN0z7t+waIHKfTTgJiTn5/YxwGYLUIKVigmNlAoo987rmK+xA==",
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-nestjs-core/-/instrumentation-nestjs-core-0.31.0.tgz",
+      "integrity": "sha512-Un3uPLS8wZAMMiz1PAiSX7+QfWaEUF7ejTZEybanwHCROv2zMa4P/cCc2WFAMm6q82brV6f4OqPEYLP+AnombQ==",
       "requires": {
-        "@opentelemetry/instrumentation": "^0.29.2",
+        "@opentelemetry/instrumentation": "^0.32.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       }
     },
     "@opentelemetry/instrumentation-net": {
-      "version": "0.29.0",
-      "integrity": "sha512-93acTBKvrzyTbQ5g+VItpCqxMn0lcLb8re7wOh7v+hnMAaKc431fcPuVbOcsNHdMZ7LF1qnOZfs0sooT/chIDA==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-net/-/instrumentation-net-0.30.0.tgz",
+      "integrity": "sha512-e7sgHfMf63ylo3FphhPD4+Ys70wTjrPeQFbh3GPMbnIN+7NTZXWIZFE0jkPimuVvw7jwyLDsaJoq03UArtc+/w==",
       "requires": {
-        "@opentelemetry/instrumentation": "^0.29.2",
+        "@opentelemetry/instrumentation": "^0.32.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       }
     },
     "@opentelemetry/instrumentation-pg": {
-      "version": "0.30.0",
-      "integrity": "sha512-RQ3cTTJnCBE/9GagjSpaM+yzxN25MvEwOxDFes3y8c1cqrMgqxukQLm3MbcqCQ8e1g/8d18+oyiEeBUjZJ5jnw==",
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pg/-/instrumentation-pg-0.31.0.tgz",
+      "integrity": "sha512-wvvaaHJBjZ98WgQ/nj10InvUdNE0DPuuWTXsxTTkcTUD2lnOC4JgXsVQ7Gn+2NAcmjxOdiM32WZ+VpiMwQ2I7g==",
       "requires": {
-        "@opentelemetry/instrumentation": "^0.29.2",
+        "@opentelemetry/instrumentation": "^0.32.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/pg": "8.6.1",
         "@types/pg-pool": "2.0.3"
       }
     },
     "@opentelemetry/instrumentation-pino": {
-      "version": "0.30.0",
-      "integrity": "sha512-ZbmRL58f3Qviwai/JunUZb/uKo1NYRLdCrKoss7seJ3mEvuTcgTIVeo93PSqxk2c4LMdvkTcNAcIAv1Ymw/PyQ==",
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pino/-/instrumentation-pino-0.31.0.tgz",
+      "integrity": "sha512-N25NCt6PQ6V4xdwfJa5WuYedJNv51JGMCyztjukWFj3guW2V3G5nZjsbSQNxsLiOJvQq5hx+EO2Wi/B/PSIq1g==",
       "requires": {
-        "@opentelemetry/instrumentation": "^0.29.2",
+        "@opentelemetry/instrumentation": "^0.32.0",
         "pino": "7.10.0",
         "semver": "^7.3.5"
       }
     },
     "@opentelemetry/instrumentation-redis": {
-      "version": "0.32.0",
-      "integrity": "sha512-KaZnYhz8dZ9gHkvrBo2U7bp/HABM2JXd3i6e8cUP8MyNA8x5P+EUbeSzzBMe6bAZH35S60dAQbBAhRji3ZlPRw==",
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis/-/instrumentation-redis-0.33.0.tgz",
+      "integrity": "sha512-wcPJ5tp4wspsr0uQ6WmEue83qlXzeF2EJzKR0Ye/8VQCJsRmSmOnEIEC33UPwlCzfssz/t8EdqU3ejx+uTa00Q==",
       "requires": {
-        "@opentelemetry/instrumentation": "^0.29.2",
+        "@opentelemetry/instrumentation": "^0.32.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/redis": "2.8.31"
       }
     },
     "@opentelemetry/instrumentation-redis-4": {
-      "version": "0.31.0",
-      "integrity": "sha512-3DY6bkqKnVlPc2WWHelb6DnU78ryYLQFqv0lqnVsoSkr7b6hnmw1Bzuwo/5YmS4C3XuTAD4/6dZVrQJ23g8HNA==",
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis-4/-/instrumentation-redis-4-0.32.0.tgz",
+      "integrity": "sha512-jkEedarX+Cx/JL1oV3s1Lvw2DHGJVNpM3fPDGHTbSudzDI0vr0+bgyMv+WW3U2vzc3WvLuCkzAkmRMPK2++nDA==",
       "requires": {
-        "@opentelemetry/instrumentation": "^0.29.2",
+        "@opentelemetry/instrumentation": "^0.32.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       }
     },
     "@opentelemetry/instrumentation-restify": {
-      "version": "0.29.0",
-      "integrity": "sha512-jjXtzNut03FBernMrEjJnkX9SdUAjpGh04mauR2GhBjSrkQg73gS7jeMS/xyN6/ufphA0tyFygxNPOWFvjXM6g==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-restify/-/instrumentation-restify-0.30.0.tgz",
+      "integrity": "sha512-Qdin5XompOloj4c5y4vwfo3VN5K7SWrpC2PrA5aNR7VnYNM61AxMPtAhz4Bc0BPh/lylNa9tX1pAEEdg1FMRuQ==",
       "requires": {
         "@opentelemetry/core": "^1.0.0",
-        "@opentelemetry/instrumentation": "^0.29.2",
+        "@opentelemetry/instrumentation": "^0.32.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/restify": "4.3.8"
       }
     },
     "@opentelemetry/instrumentation-winston": {
-      "version": "0.29.0",
-      "integrity": "sha512-z48oitpODk5BkJXp4OlRLAQf5JLH0jcSmHvqhlgB9tHddNG+xQWa1Xb0kyBX4i4r0jGFR7cvImIb53wrEavUBA==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-winston/-/instrumentation-winston-0.30.0.tgz",
+      "integrity": "sha512-F4zFwSNY/wdg1I9pAZOvO2jIrPU1LGI6YeA8nVm6ImCFQVJYsccBudNPmfhjGT5ydRa/AtCRcnQ7MFDI94+p4w==",
       "requires": {
-        "@opentelemetry/instrumentation": "^0.29.2"
+        "@opentelemetry/instrumentation": "^0.32.0"
       }
     },
     "@opentelemetry/propagation-utils": {
       "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagation-utils/-/propagation-utils-0.28.0.tgz",
       "integrity": "sha512-IsBUTz110RB75Xg6dejSD8JSyiXll81zTu/2dph5VdPMSgMOGQTYhtv0Mv1BydJh4dZpR+Z9WHTiHdkp1IQOCw==",
       "requires": {}
     },
     "@opentelemetry/propagator-aws-xray": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-aws-xray/-/propagator-aws-xray-1.1.0.tgz",
       "integrity": "sha512-p8qSVJbhzxBu2Dl6nv5aqWSmUeqAxEr3jjZzB6Eg9CrZqCTJ7Ndl74dSOuEzC7CYmiNsu0v5K0rSdB8g6vm89g==",
       "requires": {
         "@opentelemetry/core": "^1.0.0"
@@ -11352,6 +11479,7 @@
     },
     "@sideway/address": {
       "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.4.tgz",
       "integrity": "sha512-7vwq+rOHVWjyXxVlR76Agnvhy8I9rpzjosTESvmhNeXOXdZZB15Fl+TI9x1SiHZH5Jv2wTGduSxFDIaq0m3DUw==",
       "requires": {
         "@hapi/hoek": "^9.0.0"
@@ -11359,10 +11487,12 @@
     },
     "@sideway/formula": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.0.tgz",
       "integrity": "sha512-vHe7wZ4NOXVfkoRb8T5otiENVlT7a3IAiw7H5M2+GO+9CDgcVUUsX1zalAztCmwyOr2RUTGJdgB+ZvSVqmdHmg=="
     },
     "@sideway/pinpoint": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
       "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="
     },
     "@sinonjs/commons": {
@@ -11387,6 +11517,7 @@
     },
     "@types/accepts": {
       "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/accepts/-/accepts-1.3.5.tgz",
       "integrity": "sha512-jOdnI/3qTpHABjM5cx1Hc0sKsPoYCp+DP/GJRGtDlPd7fiV9oXGGIcjW/ZOxLIvjGz8MA+uMZI9metHlgqbgwQ==",
       "requires": {
         "@types/node": "*"
@@ -11394,6 +11525,7 @@
     },
     "@types/amqplib": {
       "version": "0.5.17",
+      "resolved": "https://registry.npmjs.org/@types/amqplib/-/amqplib-0.5.17.tgz",
       "integrity": "sha512-RImqiLP1swDqWBW8UX9iBXVEOw6MYzNmxdXqfemDfdwtUvdTM/W0s2RlSuMVIGkRhaWvpkC9O/N81VzzQwfAbw==",
       "requires": {
         "@types/bluebird": "*",
@@ -11402,6 +11534,7 @@
     },
     "@types/aws-lambda": {
       "version": "8.10.81",
+      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.81.tgz",
       "integrity": "sha512-C1rFKGVZ8KwqhwBOYlpoybTSRtxu2433ea6JaO3amc6ubEe08yQoFsPa9aU9YqvX7ppeZ25CnCtC4AH9mhtxsQ=="
     },
     "@types/babel__core": {
@@ -11443,25 +11576,21 @@
     },
     "@types/bluebird": {
       "version": "3.5.36",
+      "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.36.tgz",
       "integrity": "sha512-HBNx4lhkxN7bx6P0++W8E289foSu8kO8GCk2unhuVggO+cE7rh9DhZUyPhUxNRG9m+5B5BTKxZQ5ZP92x/mx9Q=="
     },
     "@types/body-parser": {
       "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
       "integrity": "sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==",
       "requires": {
         "@types/connect": "*",
         "@types/node": "*"
       }
     },
-    "@types/bson": {
-      "version": "4.2.0",
-      "integrity": "sha512-ELCPqAdroMdcuxqwMgUpifQyRoTpyYCNr1V9xKyF40VsBobsj+BbWNRvwGchMgBPGqkw655ypkjj2MEF5ywVwg==",
-      "requires": {
-        "bson": "*"
-      }
-    },
     "@types/bunyan": {
       "version": "1.8.7",
+      "resolved": "https://registry.npmjs.org/@types/bunyan/-/bunyan-1.8.7.tgz",
       "integrity": "sha512-jaNt6xX5poSmXuDAkQrSqx2zkR66OrdRDuVnU8ldvn3k/Ci/7Sf5nooKspQWimDnw337Bzt/yirqSThTjvrHkg==",
       "requires": {
         "@types/node": "*"
@@ -11469,6 +11598,7 @@
     },
     "@types/connect": {
       "version": "3.4.35",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
       "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
       "requires": {
         "@types/node": "*"
@@ -11476,10 +11606,12 @@
     },
     "@types/content-disposition": {
       "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@types/content-disposition/-/content-disposition-0.5.5.tgz",
       "integrity": "sha512-v6LCdKfK6BwcqMo+wYW05rLS12S0ZO0Fl4w1h4aaZMD7bqT3gVUns6FvLJKGZHQmYn3SX55JWGpziwJRwVgutA=="
     },
     "@types/cookies": {
       "version": "0.7.7",
+      "resolved": "https://registry.npmjs.org/@types/cookies/-/cookies-0.7.7.tgz",
       "integrity": "sha512-h7BcvPUogWbKCzBR2lY4oqaZbO3jXZksexYJVFvkrFeLgbZjQkU4x8pRq6eg2MHXQhY0McQdqmmsxRWlVAHooA==",
       "requires": {
         "@types/connect": "*",
@@ -11490,6 +11622,7 @@
     },
     "@types/express": {
       "version": "4.17.13",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
       "integrity": "sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==",
       "requires": {
         "@types/body-parser": "*",
@@ -11499,8 +11632,9 @@
       }
     },
     "@types/express-serve-static-core": {
-      "version": "4.17.28",
-      "integrity": "sha512-P1BJAEAW3E2DJUlkgq4tOL3RyMunoWXqbSCygWo5ZIWTjUgN1YnaXWW4VWl/oc8vs/XoYibEGBKP0uZyF4AHig==",
+      "version": "4.17.30",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.30.tgz",
+      "integrity": "sha512-gstzbTWro2/nFed1WXtf+TtrpwxH7Ggs4RLYTLbeVgIkUQOI3WG/JKjgeOU1zXDvezllupjrf8OPIdvTbIaVOQ==",
       "requires": {
         "@types/node": "*",
         "@types/qs": "*",
@@ -11509,6 +11643,7 @@
     },
     "@types/generic-pool": {
       "version": "3.1.11",
+      "resolved": "https://registry.npmjs.org/@types/generic-pool/-/generic-pool-3.1.11.tgz",
       "integrity": "sha512-3mcD3ewmaKPbiAZglGj8We4ohlSMfw/xS+bbYUhTv/ALgqrrtJjyL4Ju9IgapXooBCTFEew5LAKQqzZV6/43xg==",
       "requires": {
         "@types/node": "*"
@@ -11524,10 +11659,12 @@
     },
     "@types/hapi__catbox": {
       "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/@types/hapi__catbox/-/hapi__catbox-10.2.4.tgz",
       "integrity": "sha512-A6ivRrXD5glmnJna1UAGw87QNZRp/vdFO9U4GS+WhOMWzHnw+oTGkMvg0g6y1930CbeheGOCm7A1qHsqH7AXqg=="
     },
     "@types/hapi__hapi": {
       "version": "20.0.9",
+      "resolved": "https://registry.npmjs.org/@types/hapi__hapi/-/hapi__hapi-20.0.9.tgz",
       "integrity": "sha512-fGpKScknCKZityRXdZgpCLGbm41R1ppFgnKHerfZlqOOlCX/jI129S6ghgBqkqCE8m9A0CIu1h7Ch04lD9KOoA==",
       "requires": {
         "@hapi/boom": "^9.0.0",
@@ -11542,6 +11679,7 @@
     },
     "@types/hapi__mimos": {
       "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@types/hapi__mimos/-/hapi__mimos-4.1.4.tgz",
       "integrity": "sha512-i9hvJpFYTT/qzB5xKWvDYaSXrIiNqi4ephi+5Lo6+DoQdwqPXQgmVVOZR+s3MBiHoFqsCZCX9TmVWG3HczmTEQ==",
       "requires": {
         "@types/mime-db": "*"
@@ -11549,6 +11687,7 @@
     },
     "@types/hapi__shot": {
       "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@types/hapi__shot/-/hapi__shot-4.1.2.tgz",
       "integrity": "sha512-8wWgLVP1TeGqgzZtCdt+F+k15DWQvLG1Yv6ZzPfb3D5WIo5/S+GGKtJBVo2uNEcqabP5Ifc71QnJTDnTmw1axA==",
       "requires": {
         "@types/node": "*"
@@ -11556,14 +11695,17 @@
     },
     "@types/http-assert": {
       "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@types/http-assert/-/http-assert-1.5.3.tgz",
       "integrity": "sha512-FyAOrDuQmBi8/or3ns4rwPno7/9tJTijVW6aQQjK02+kOQ8zmoNg2XJtAuQhvQcy1ASJq38wirX5//9J1EqoUA=="
     },
     "@types/http-errors": {
       "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-1.8.2.tgz",
       "integrity": "sha512-EqX+YQxINb+MeXaIqYDASb6U6FCHbWjkj4a1CKDBks3d/QiB2+PqBLyO72vLDgAO1wUI4O+9gweRcQK11bTL/w=="
     },
     "@types/ioredis": {
       "version": "4.26.6",
+      "resolved": "https://registry.npmjs.org/@types/ioredis/-/ioredis-4.26.6.tgz",
       "integrity": "sha512-Q9ydXL/5Mot751i7WLCm9OGTj5jlW3XBdkdEW21SkXZ8Y03srbkluFGbM3q8c+vzPW30JOLJ+NsZWHoly0+13A==",
       "requires": {
         "@types/node": "*"
@@ -11606,10 +11748,12 @@
     },
     "@types/keygrip": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@types/keygrip/-/keygrip-1.0.2.tgz",
       "integrity": "sha512-GJhpTepz2udxGexqos8wgaBx4I/zWIDPh/KOGEwAqtuGDkOUJu5eFvwmdBX4AmB8Odsr+9pHCQqiAqDL/yKMKw=="
     },
     "@types/koa": {
       "version": "2.13.4",
+      "resolved": "https://registry.npmjs.org/@types/koa/-/koa-2.13.4.tgz",
       "integrity": "sha512-dfHYMfU+z/vKtQB7NUrthdAEiSvnLebvBjwHtfFmpZmB7em2N3WVQdHgnFq+xvyVgxW5jKDmjWfLD3lw4g4uTw==",
       "requires": {
         "@types/accepts": "*",
@@ -11624,6 +11768,7 @@
     },
     "@types/koa__router": {
       "version": "8.0.7",
+      "resolved": "https://registry.npmjs.org/@types/koa__router/-/koa__router-8.0.7.tgz",
       "integrity": "sha512-OB3Ax75nmTP+WR9AgdzA42DI7YmBtiNKN2g1Wxl+d5Dyek9SWt740t+ukwXSmv/jMBCUPyV3YEI93vZHgdP7UQ==",
       "requires": {
         "@types/koa": "*"
@@ -11631,6 +11776,7 @@
     },
     "@types/koa-compose": {
       "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/@types/koa-compose/-/koa-compose-3.2.5.tgz",
       "integrity": "sha512-B8nG/OoE1ORZqCkBVsup/AKcvjdgoHnfi4pZMn5UwAPCbhk/96xyv284eBYW8JlQbQ7zDmnpFr68I/40mFoIBQ==",
       "requires": {
         "@types/koa": "*"
@@ -11638,29 +11784,25 @@
     },
     "@types/memcached": {
       "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/@types/memcached/-/memcached-2.2.7.tgz",
       "integrity": "sha512-ImJbz1i8pl+OnyhYdIDnHe8jAuM8TOwM/7VsciqhYX3IL0jPPUToAtVxklfcWFGYckahEYZxhd9FS0z3MM1dpA==",
       "requires": {
         "@types/node": "*"
       }
     },
     "@types/mime": {
-      "version": "1.3.2",
-      "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw=="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-3.0.1.tgz",
+      "integrity": "sha512-Y4XFY5VJAuw0FgAqPNd6NNoV44jbq9Bz2L7Rh/J6jLTiHBSBJa9fxqQIvkIld4GsoDOcCbvzOUAbLPsSKKg+uA=="
     },
     "@types/mime-db": {
       "version": "1.43.1",
+      "resolved": "https://registry.npmjs.org/@types/mime-db/-/mime-db-1.43.1.tgz",
       "integrity": "sha512-kGZJY+R+WnR5Rk+RPHUMERtb2qBRViIHCBdtUrY+NmwuGb8pQdfTqQiCKPrxpdoycl8KWm2DLdkpoSdt479XoQ=="
-    },
-    "@types/mongodb": {
-      "version": "3.6.20",
-      "integrity": "sha512-WcdpPJCakFzcWWD9juKoZbRtQxKIMYF/JIAM4JrNHrMcnJL6/a2NWjXxW7fo9hxboxxkg+icff8d7+WIEvKgYQ==",
-      "requires": {
-        "@types/bson": "*",
-        "@types/node": "*"
-      }
     },
     "@types/mysql": {
       "version": "2.15.19",
+      "resolved": "https://registry.npmjs.org/@types/mysql/-/mysql-2.15.19.tgz",
       "integrity": "sha512-wSRg2QZv14CWcZXkgdvHbbV2ACufNy5EgI8mBBxnJIptchv7DBy/h53VMa2jDhyo0C9MO4iowE6z9vF8Ja1DkQ==",
       "requires": {
         "@types/node": "*"
@@ -11682,6 +11824,7 @@
     },
     "@types/pg": {
       "version": "8.6.1",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.6.1.tgz",
       "integrity": "sha512-1Kc4oAGzAl7uqUStZCDvaLFqZrW9qWSjXOmBfdgyBP5La7Us6Mg4GBvRlSoaZMhQF/zSj1C8CtKMBkoiT8eL8w==",
       "requires": {
         "@types/node": "*",
@@ -11691,6 +11834,7 @@
     },
     "@types/pg-pool": {
       "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/pg-pool/-/pg-pool-2.0.3.tgz",
       "integrity": "sha512-fwK5WtG42Yb5RxAwxm3Cc2dJ39FlgcaNiXKvtTLAwtCn642X7dgel+w1+cLWwpSOFImR3YjsZtbkfjxbHtFAeg==",
       "requires": {
         "@types/pg": "*"
@@ -11703,14 +11847,17 @@
     },
     "@types/qs": {
       "version": "6.9.7",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
       "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw=="
     },
     "@types/range-parser": {
       "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
       "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw=="
     },
     "@types/redis": {
       "version": "2.8.31",
+      "resolved": "https://registry.npmjs.org/@types/redis/-/redis-2.8.31.tgz",
       "integrity": "sha512-daWrrTDYaa5iSDFbgzZ9gOOzyp2AJmYK59OlG/2KGBgYWF3lfs8GDKm1c//tik5Uc93hDD36O+qLPvzDolChbA==",
       "requires": {
         "@types/node": "*"
@@ -11718,6 +11865,7 @@
     },
     "@types/restify": {
       "version": "4.3.8",
+      "resolved": "https://registry.npmjs.org/@types/restify/-/restify-4.3.8.tgz",
       "integrity": "sha512-BdpKcY4mnbdd7RNLfVRutkUtI1tGKMbQVKm7YgWi4kTlRm3Z4hh+F+1R1va/PZmkkk0AEt7kP82qi1jcF6Hshg==",
       "requires": {
         "@types/bunyan": "*",
@@ -11725,10 +11873,11 @@
       }
     },
     "@types/serve-static": {
-      "version": "1.13.10",
-      "integrity": "sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.0.tgz",
+      "integrity": "sha512-z5xyF6uh8CbjAu9760KDKsH2FcDxZ2tFCsA4HIMWE6IkiYMXfVoa+4f9KX+FN0ZLsaMw1WNG2ETLA6N+/YA+cg==",
       "requires": {
-        "@types/mime": "^1",
+        "@types/mime": "*",
         "@types/node": "*"
       }
     },
@@ -11848,6 +11997,7 @@
     },
     "abstract-logging": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/abstract-logging/-/abstract-logging-2.0.1.tgz",
       "integrity": "sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA=="
     },
     "acorn": {
@@ -11963,6 +12113,7 @@
     },
     "archy": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
       "integrity": "sha512-Xg+9RwCg/0p32teKdGMPTPnVXKD0w3DfHnFTficozsAgsvq2XenPJq/MYpzzQ/v8zrOyJn6Ds39VA4JIDwFfqw=="
     },
     "are-we-there-yet": {
@@ -12029,10 +12180,12 @@
     },
     "atomic-sleep": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
       "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ=="
     },
     "avvio": {
       "version": "7.2.5",
+      "resolved": "https://registry.npmjs.org/avvio/-/avvio-7.2.5.tgz",
       "integrity": "sha512-AOhBxyLVdpOad3TujtC9kL/9r3HnTkxwQ5ggOsYrvvZP1cCFvzHWJd5XxZDFuTn+IN8vkKSG5SEJrd27vCSbeA==",
       "requires": {
         "archy": "^1.0.0",
@@ -12154,10 +12307,6 @@
         }
       }
     },
-    "base64-js": {
-      "version": "1.5.1",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
-    },
     "brace-expansion": {
       "version": "1.1.11",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
@@ -12205,21 +12354,6 @@
       "dev": true,
       "requires": {
         "node-int64": "^0.4.0"
-      }
-    },
-    "bson": {
-      "version": "4.6.5",
-      "integrity": "sha512-uqrgcjyOaZsHfz7ea8zLRCLe1u+QGUSzMZmvXqO24CDW7DWoW1qiN9folSwa7hSneTSgM2ykDIzF5kcQQ8cwNw==",
-      "requires": {
-        "buffer": "^5.6.0"
-      }
-    },
-    "buffer": {
-      "version": "5.7.1",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "requires": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
       }
     },
     "buffer-from": {
@@ -12566,6 +12700,7 @@
     },
     "cookie": {
       "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
       "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw=="
     },
     "copy-descriptor": {
@@ -12740,6 +12875,7 @@
     },
     "duplexify": {
       "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.2.tgz",
       "integrity": "sha512-fz3OjcNCHmRP12MJoZMPglx8m4rrFP8rovnk4vT8Fs+aonZoCwGg10dSsQsfP/E62eZcPTMSMP6686fu9Qlqtw==",
       "requires": {
         "end-of-stream": "^1.4.1",
@@ -13272,6 +13408,7 @@
     },
     "fast-decode-uri-component": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fast-decode-uri-component/-/fast-decode-uri-component-1.0.1.tgz",
       "integrity": "sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg=="
     },
     "fast-deep-equal": {
@@ -13311,6 +13448,7 @@
     },
     "fast-json-stringify": {
       "version": "2.7.13",
+      "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-2.7.13.tgz",
       "integrity": "sha512-ar+hQ4+OIurUGjSJD1anvYSDcUflywhKjfxnsW4TBTD7+u0tJufv6DKRWoQk3vI6YBOWMoz0TQtfbe7dxbQmvA==",
       "requires": {
         "ajv": "^6.11.0",
@@ -13325,16 +13463,19 @@
       "dev": true
     },
     "fast-redact": {
-      "version": "3.1.1",
-      "integrity": "sha512-odVmjC8x8jNeMZ3C+rPMESzXVSEU8tSWSHv9HFxP2mm89G/1WwqhrerJDQm9Zus8X6aoRgQDThKqptdNA6bt+A=="
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.1.2.tgz",
+      "integrity": "sha512-+0em+Iya9fKGfEQGcd62Yv6onjBmmhV1uh86XVfOU8VwAe6kaFdQCWI9s0/Nnugx5Vd9tdbZ7e6gE2tR9dzXdw=="
     },
     "fast-safe-stringify": {
       "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="
     },
     "fastify": {
-      "version": "3.29.1",
-      "integrity": "sha512-UhGmh0/J0YQetqULYfv/utvut0R6ICQvO6Oh81JvG75UbjVgueqoE6EPChB3gR5aF3dVKpT/qFTgc7zvpGTYNg==",
+      "version": "3.29.2",
+      "resolved": "https://registry.npmjs.org/fastify/-/fastify-3.29.2.tgz",
+      "integrity": "sha512-XFuIF4T9IdkCVtV0amWQZg50w8iPn8MoAV4yK1DP88dU7YEwxDOOpVgKLWZS4YJA8RU001KUfg2b/2L6kEwJWA==",
       "requires": {
         "@fastify/ajv-compiler": "^1.0.0",
         "@fastify/error": "^2.0.0",
@@ -13355,6 +13496,7 @@
       "dependencies": {
         "pino": {
           "version": "6.14.0",
+          "resolved": "https://registry.npmjs.org/pino/-/pino-6.14.0.tgz",
           "integrity": "sha512-iuhEDel3Z3hF9Jfe44DPXR8l07bhjuFY3GMHIXbjnY9XcafbyDDwl2sN2vw2GjMPf5Nkoe+OFao7ffn9SXaKDg==",
           "requires": {
             "fast-redact": "^3.0.0",
@@ -13368,10 +13510,12 @@
         },
         "pino-std-serializers": {
           "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-3.2.0.tgz",
           "integrity": "sha512-EqX4pwDPrt3MuOAAUBMU0Tk5kR/YcCM5fNPEzgCO2zJ5HfX0vbiH9HbJglnyeQsN96Kznae6MWD47pZB5avTrg=="
         },
         "sonic-boom": {
           "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-1.4.1.tgz",
           "integrity": "sha512-LRHh/A8tpW7ru89lrlkU4AszXt1dbwSjVWguGrmlxE7tawVmDBlI1PILMkXAxJTwqhgsEeTHzj36D5CmHgQmNg==",
           "requires": {
             "atomic-sleep": "^1.0.0",
@@ -13417,6 +13561,7 @@
     },
     "find-my-way": {
       "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-4.5.1.tgz",
       "integrity": "sha512-kE0u7sGoUFbMXcOG/xpkmz4sRLCklERnBcg7Ftuu1iAxsfEt2S46RLJ3Sq7vshsEy2wJT2hZxE58XZK27qa8kg==",
       "requires": {
         "fast-decode-uri-component": "^1.0.1",
@@ -13453,6 +13598,7 @@
     },
     "flatstr": {
       "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/flatstr/-/flatstr-1.0.12.tgz",
       "integrity": "sha512-4zPxDyhCyiN2wIAtSLI6gc82/EjqZc1onI4Mz/l0pWrAlsSfYH/2ZIcU+e3oA2wDwbzIWNKwa23F8rh6+DRWkw=="
     },
     "flatted": {
@@ -13481,6 +13627,7 @@
     },
     "forwarded": {
       "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
       "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="
     },
     "fragment-cache": {
@@ -13654,6 +13801,7 @@
     },
     "graphql": {
       "version": "15.8.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.8.0.tgz",
       "integrity": "sha512-5gghUc24tP9HRznNpV2+FIoq3xKkj5dTQqf4v0CpdPbFVwFkWoxOM+o+2OC9ZSvjEMTjfmG9QT+gcvggTwW1zw=="
     },
     "growly": {
@@ -13827,10 +13975,6 @@
         "safer-buffer": ">= 2.1.2 < 3"
       }
     },
-    "ieee754": {
-      "version": "1.2.1",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
-    },
     "ignore": {
       "version": "5.2.0",
       "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
@@ -13904,6 +14048,7 @@
     },
     "ipaddr.js": {
       "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
       "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
     },
     "is-accessor-descriptor": {
@@ -14615,6 +14760,7 @@
     },
     "joi": {
       "version": "17.6.0",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.6.0.tgz",
       "integrity": "sha512-OX5dG6DTbcr/kbMFj0KGYxuew69HPcAE3K/sZpEV2nP6e/j/C0HV+HNiBPCASxdx5T7DMoa0s8UeHWMnb6n2zw==",
       "requires": {
         "@hapi/hoek": "^9.0.0",
@@ -14751,8 +14897,9 @@
       }
     },
     "light-my-request": {
-      "version": "4.10.1",
-      "integrity": "sha512-l+zWk0HXGhGzY7IYTZnYEqIpj3Mpcyk2f8+FkKUyREywvaiWCf2jyQVxpasKRsploY/nVpoqTlxx72CIeQNcIQ==",
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/light-my-request/-/light-my-request-4.12.0.tgz",
+      "integrity": "sha512-0y+9VIfJEsPVzK5ArSIJ8Dkxp8QMP7/aCuxCUtG/tr9a2NoOf/snATE/OUc05XUplJCEnRh6gTkH7xh9POt1DQ==",
       "requires": {
         "ajv": "^8.1.0",
         "cookie": "^0.5.0",
@@ -14762,6 +14909,7 @@
       "dependencies": {
         "ajv": {
           "version": "8.11.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
           "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
           "requires": {
             "fast-deep-equal": "^3.1.1",
@@ -14772,6 +14920,7 @@
         },
         "json-schema-traverse": {
           "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
           "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
         }
       }
@@ -15529,6 +15678,7 @@
     },
     "on-exit-leak-free": {
       "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-0.2.0.tgz",
       "integrity": "sha512-dqaz3u44QbRXQooZLTUKU41ZrzYrcvLISVgbrzbyCMxpmSLJvZ3ZamIJIZ29P6OhZIkNIQKosdeM6t1LYbA9hg=="
     },
     "once": {
@@ -15663,14 +15813,17 @@
     },
     "pg-int8": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
       "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw=="
     },
     "pg-protocol": {
       "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.5.0.tgz",
       "integrity": "sha512-muRttij7H8TqRNu/DxrAJQITO4Ac7RmX3Klyr/9mJEOBeIpgnF8f9jAfRz5d3XwQZl5qBjF9gLsUtMPJE0vezQ=="
     },
     "pg-types": {
       "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
       "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
       "requires": {
         "pg-int8": "1.0.1",
@@ -15702,6 +15855,7 @@
     },
     "pino": {
       "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-7.10.0.tgz",
       "integrity": "sha512-T6R92jy/APDElEuOk0gqa4nds3ZgqFbHde2X0g8XorlyPlVGlr9T5KQphtp72a3ByKOdZMg/gM/0IprpGQfTWg==",
       "requires": {
         "atomic-sleep": "^1.0.0",
@@ -15719,6 +15873,7 @@
     },
     "pino-abstract-transport": {
       "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-0.5.0.tgz",
       "integrity": "sha512-+KAgmVeqXYbTtU2FScx1XS3kNyfZ5TrXY07V96QnUSFqo2gAqlvmaxH67Lj7SWazqsMabf+58ctdTcBgnOLUOQ==",
       "requires": {
         "duplexify": "^4.1.2",
@@ -15727,6 +15882,7 @@
     },
     "pino-std-serializers": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-4.0.0.tgz",
       "integrity": "sha512-cK0pekc1Kjy5w9V2/n+8MkZwusa6EyyxfeQCB799CQRhRt/CqYKiWs5adeu8Shve2ZNffvfC/7J64A2PJo1W/Q=="
     },
     "pirates": {
@@ -15792,18 +15948,22 @@
     },
     "postgres-array": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
       "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA=="
     },
     "postgres-bytea": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
       "integrity": "sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w=="
     },
     "postgres-date": {
       "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
       "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q=="
     },
     "postgres-interval": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
       "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
       "requires": {
         "xtend": "^4.0.0"
@@ -15840,6 +16000,7 @@
     },
     "process-warning": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-1.0.0.tgz",
       "integrity": "sha512-du4wfLyj4yCZq1VupnVSZmRsPJsNuxoDQFdCFHLaYiEbFBD7QE0a+I4D7hOxrVnh78QE/YipFAj9lXHiXocV+Q=="
     },
     "promise-inflight": {
@@ -15870,6 +16031,7 @@
     },
     "proxy-addr": {
       "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
       "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
       "requires": {
         "forwarded": "0.2.0",
@@ -15905,6 +16067,7 @@
     },
     "quick-format-unescaped": {
       "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
       "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="
     },
     "react-is": {
@@ -15978,6 +16141,7 @@
     },
     "real-require": {
       "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.1.0.tgz",
       "integrity": "sha512-r/H9MzAWtrv8aSVjPCMFpDMl5q66GqtmmRkRjpHTsp4zBAa+snZyiQNlMONiUmEJcsnaw0wCauJ2GWODr/aFkg=="
     },
     "regex-not": {
@@ -16026,6 +16190,7 @@
     },
     "require-from-string": {
       "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
     },
     "require-in-the-middle": {
@@ -16144,6 +16309,7 @@
     },
     "safe-regex2": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/safe-regex2/-/safe-regex2-2.0.0.tgz",
       "integrity": "sha512-PaUSFsUaNNuKwkBijoAPHAK6/eM6VirvyPWlZ7BAQy4D+hCvh4B6lIG+nPdhbFfIbP+gTGBcrdsOaUs0F+ZBOQ==",
       "requires": {
         "ret": "~0.2.0"
@@ -16151,6 +16317,7 @@
       "dependencies": {
         "ret": {
           "version": "0.2.2",
+          "resolved": "https://registry.npmjs.org/ret/-/ret-0.2.2.tgz",
           "integrity": "sha512-M0b3YWQs7R3Z917WRQy1HHA7Ba7D8hvZg6UE5mLykJxQVE2ju0IXbGlaHPPlkY+WN7wFP+wUMXmBFA0aV6vYGQ=="
         }
       }
@@ -16386,8 +16553,9 @@
       }
     },
     "secure-json-parse": {
-      "version": "2.4.0",
-      "integrity": "sha512-Q5Z/97nbON5t/L/sH6mY2EacfjVGwrCcSi5D3btRO2GZ8pf1K1UN7Z9H5J57hjVU2Qzxr1xO+FmBhOvEkzCMmg=="
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.5.0.tgz",
+      "integrity": "sha512-ZQruFgZnIWH+WyO9t5rWt4ZEGqCKPwhiw+YbzTwpmT9elgLrLcfuyUiSnwwjUiVy9r4VM3urtbNF1xmEh9IL2w=="
     },
     "semver": {
       "version": "7.3.7",
@@ -16408,6 +16576,7 @@
     },
     "semver-store": {
       "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/semver-store/-/semver-store-0.3.0.tgz",
       "integrity": "sha512-TcZvGMMy9vodEFSse30lWinkj+JgOBvPn8wRItpQRSayhc+4ssDs335uklkfvQQJgL/WvmHLVj4Ycv2s7QCQMg=="
     },
     "seq-queue": {
@@ -16420,8 +16589,9 @@
       "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw=="
     },
     "set-cookie-parser": {
-      "version": "2.5.0",
-      "integrity": "sha512-cHMAtSXilfyBePduZEBVPTCftTQWz6ehWJD5YNUg4mqvRosrrjKbo4WS8JkB0/RxonMoohHm7cOGH60mDkRQ9w=="
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.5.1.tgz",
+      "integrity": "sha512-1jeBGaKNGdEq4FgIrORu/N570dwoPYio8lSoYLWmX7sQ//0JY08Xh9o5pBcgmHQ/MbsYp/aZnOe1s1lIsbLprQ=="
     },
     "set-value": {
       "version": "2.0.1",
@@ -16692,6 +16862,7 @@
     },
     "sonic-boom": {
       "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-2.8.0.tgz",
       "integrity": "sha512-kuonw1YOYYNOve5iHdSahXPOK49GqwA+LZhI6Wz/l0rP57iKyXXIHaRagOBHAPmGwJC6od2Z9zgvZ5loSgMlVg==",
       "requires": {
         "atomic-sleep": "^1.0.0"
@@ -16766,6 +16937,7 @@
     },
     "split2": {
       "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.1.0.tgz",
       "integrity": "sha512-VBiJxFkxiXRlUIeyMQi8s4hgvKCSjtknJv/LVYbrgALPwf5zSKmEwV9Lst25AkvMDnvxODugjdl6KZgwKM1WYQ=="
     },
     "sprintf-js": {
@@ -16876,6 +17048,7 @@
     },
     "stream-shift": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
       "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="
     },
     "string_decoder": {
@@ -16901,6 +17074,7 @@
     },
     "string-similarity": {
       "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/string-similarity/-/string-similarity-4.0.4.tgz",
       "integrity": "sha512-/q/8Q4Bl4ZKAPjj8WerIBJWALKkaPRfrvhfF8k/B23i4nzrlRj2/go1m90In7nG/3XDSbOo0+pu6RvCTM9RGMQ=="
     },
     "string-width": {
@@ -17047,6 +17221,7 @@
     },
     "thread-stream": {
       "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-0.15.2.tgz",
       "integrity": "sha512-UkEhKIg2pD+fjkHQKyJO3yoIvAP3N6RlNFt2dUhcS1FGvCD1cQa1M/PGknCLFIyZdtJOWQjejp7bdNqmN7zwdA==",
       "requires": {
         "real-require": "^0.1.0"
@@ -17064,6 +17239,7 @@
     },
     "tiny-lru": {
       "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/tiny-lru/-/tiny-lru-8.0.2.tgz",
       "integrity": "sha512-ApGvZ6vVvTNdsmt676grvCkUCGwzG9IqXma5Z07xJgiC5L7akUMof5U8G2JTI9Rz/ovtVhJBlY6mNhEvtjzOIg=="
     },
     "tmpl": {
@@ -17505,6 +17681,7 @@
     },
     "xtend": {
       "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
     },
     "y18n": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@opentelemetry/api": "^1.1.0",
-    "@opentelemetry/auto-instrumentations-node": "^0.31.0",
+    "@opentelemetry/auto-instrumentations-node": "^0.32.0",
     "@opentelemetry/sdk-node": "^0.30.0",
     "@opentelemetry/sdk-trace-base": "^1.4.0",
     "node-addon-api": "^3.1.0",

--- a/src/client.ts
+++ b/src/client.ts
@@ -207,7 +207,17 @@ export class Client {
           }
         }),
         new GraphQLInstrumentation(),
-        new KoaInstrumentation(),
+        new KoaInstrumentation({
+          requestHook: function (span: OtelSpan, info) {
+            // Request parameters to magic attributes
+            const queryParams = info.context.request.query
+
+            span.setAttribute(
+              "appsignal.request.parameters",
+              JSON.stringify(queryParams)
+            )
+          }
+        }),
         new MySQLInstrumentation(),
         new MySQL2Instrumentation(),
         new PgInstrumentation(),

--- a/test/express-redis/app/package-lock.json
+++ b/test/express-redis/app/package-lock.json
@@ -29,7 +29,7 @@
       "license": "MIT",
       "dependencies": {
         "@opentelemetry/api": "^1.1.0",
-        "@opentelemetry/auto-instrumentations-node": "^0.31.0",
+        "@opentelemetry/auto-instrumentations-node": "^0.32.0",
         "@opentelemetry/sdk-node": "^0.30.0",
         "@opentelemetry/sdk-trace-base": "^1.4.0",
         "node-addon-api": "^3.1.0",
@@ -10864,7 +10864,7 @@
       "version": "file:../integration",
       "requires": {
         "@opentelemetry/api": "^1.1.0",
-        "@opentelemetry/auto-instrumentations-node": "^0.31.0",
+        "@opentelemetry/auto-instrumentations-node": "^0.32.0",
         "@opentelemetry/sdk-node": "^0.30.0",
         "@opentelemetry/sdk-trace-base": "^1.4.0",
         "@types/jest": "^26.0.19",


### PR DESCRIPTION
## [Add Express params and session data to spans](https://github.com/appsignal/appsignal-nodejs/commit/436dcdef79ebaab41fb6d33b2dba3238828162e0)

Thanks to the recently added `requestHook` config option to the
OpenTelemetry request instrumentation, we can get request parameters and
session data from request and add them as magic attributes so they can
be filtered in the agent and displayed in the UI.

## [Add Koa params to spans](https://github.com/appsignal/appsignal-nodejs/commit/aed03af9f13a549ce329f973fb573fa43c716b1a)

Thanks to the recently added `requestHook` config option to the
OpenTelemetry KOA instrumentation, we can get information from the
requests and contexts and add them as magic attributes.

Note that session data is not added as it depends on a specific
middleware and the info should be added from the application, not the
request hook

[skip changeset]
[skip blogpost]

---

_Span structure tests will be added after the suite refactor._