### PR TITLE
Use sendSessionData config option properly

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -180,6 +180,7 @@ export class Client {
    */
   private initOpenTelemetry() {
     const sendParams = this.config.data.sendParams
+    const sendSessionData = this.config.data.sendSessionData
     const sdk = new NodeSDK({
       instrumentations: [
         new HttpInstrumentation({
@@ -189,24 +190,25 @@ export class Client {
         }),
         new ExpressInstrumentation({
           requestHook: function (span: OtelSpan, info) {
-            if (
-              info.layerType === ExpressLayerType.REQUEST_HANDLER &&
-              sendParams
-            ) {
-              // Request parameters to magic attributes
-              const queryParams = info.request.query
-              const requestBody = info.request.body
-              const params = { ...queryParams, ...requestBody }
-              span.setAttribute(
-                "appsignal.request.parameters",
-                JSON.stringify(params)
-              )
+            if (info.layerType === ExpressLayerType.REQUEST_HANDLER) {
+              if (sendParams) {
+                // Request parameters to magic attributes
+                const queryParams = info.request.query
+                const requestBody = info.request.body
+                const params = { ...queryParams, ...requestBody }
+                span.setAttribute(
+                  "appsignal.request.parameters",
+                  JSON.stringify(params)
+                )
+              }
 
-              // Session data to magic attributes
-              span.setAttribute(
-                "appsignal.request.session_data",
-                JSON.stringify(info.request.cookies)
-              )
+              if (sendSessionData) {
+                // Session data to magic attributes
+                span.setAttribute(
+                  "appsignal.request.session_data",
+                  JSON.stringify(info.request.cookies)
+                )
+              }
             }
           }
         }),

--- a/src/config/options.ts
+++ b/src/config/options.ts
@@ -29,7 +29,7 @@ export type AppsignalOptions = {
   revision: string
   runningInContainer: boolean
   sendParams: boolean
-  skipSessionData: boolean
+  sendSessionData: boolean
   workingDirPath: string
   workingDirectoryPath: string
   [key: string]: string | string[] | boolean

--- a/src/interfaces/options.ts
+++ b/src/interfaces/options.ts
@@ -29,7 +29,7 @@ export interface AppsignalOptions {
   revision: string
   runningInContainer: boolean
   sendParams: boolean
-  skipSessionData: boolean
+  sendSessionData: boolean
   workingDirPath: string
   workingDirectoryPath: string
   [key: string]: string | string[] | boolean


### PR DESCRIPTION
Session data addition to the span was based on the `sendParams` config option. This commit changes that so it works with the `sendSessionData` config option instead.

[skip changeset]