### PR TITLE
Clean the build dir upon `clean:ext` script

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "build:watch": "tsc -p tsconfig.json -w --preserveWatchOutput",
     "postclean": "npm run clean:ext",
     "clean": "rimraf dist coverage build",
-    "clean:ext": "rimraf ext/appsignal-agent ext/libappsignal.a ext/appsignal.* ext/*.tar.gz ext/*.report",
+    "clean:ext": "rimraf ext/appsignal-agent ext/libappsignal.a ext/appsignal.* ext/*.tar.gz ext/*.report build/",
     "preinstall": "node scripts/extension/prebuild.js",
     "install": "node scripts/extension/extension.js",
     "link:npm": "npm link",


### PR DESCRIPTION
I was testing the agent's integration tests in the agent repository. Locally I kept running into the issue that I was testing with the wrong build of the agent. Removing the `build/` directory seems to help test against the latest locally compiled version of the agent.

This may need another fix on the agent's side to call this task.

[skip changeset]