### PR TITLE
Run Prisma integration test app on CI

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -82,6 +82,9 @@ blocks:
     - name: Express + Yoga
       commands:
       - script/integration_test_app express-yoga
+    - name: Express + Prisma
+      commands:
+      - script/integration_test_app express-prisma
 - name: Node.js 18 - Build
   dependencies:
   - Validation

--- a/build_matrix.yml
+++ b/build_matrix.yml
@@ -78,6 +78,9 @@ semaphore: # Default `.semaphore/semaphore.yml` contents
         - name: Express + Yoga
           commands:
             - script/integration_test_app express-yoga
+        - name: Express + Prisma
+          commands:
+            - script/integration_test_app express-prisma
 
 matrix:
   nodejs:

--- a/test/express-prisma/app/package.json
+++ b/test/express-prisma/app/package.json
@@ -6,7 +6,6 @@
   "main": "dist/app.js",
   "scripts": {
     "build": "tsc --version; tsc -p tsconfig.json",
-    "preserver": "npm run build",
     "server": "node --require ./dist/appsignal.js dist/app.js"
   },
   "prisma": {

--- a/test/express-prisma/app/run.sh
+++ b/test/express-prisma/app/run.sh
@@ -33,6 +33,9 @@ npm link @appsignal/nodejs
 echo "Running Prisma migrations"
 npx prisma migrate dev
 
+echo "Building the app"
+npm run build
+
 echo "Running prisma seeds"
 npx prisma db seed
 


### PR DESCRIPTION
Actually run the Prisma integration test app on CI, and fix an issue with the run script where it would try to run the database seed script before compiling it.

[skip changeset]