### PR TITLE
Add error helpers

### DIFF
--- a/src/__tests__/helpers.test.ts
+++ b/src/__tests__/helpers.test.ts
@@ -1,6 +1,12 @@
 import { NodeSDK } from "@opentelemetry/sdk-node"
-import { ReadableSpan, SpanProcessor } from "@opentelemetry/sdk-trace-base"
+import {
+  ReadableSpan,
+  SpanProcessor,
+  TimedEvent
+} from "@opentelemetry/sdk-trace-base"
 import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node"
+import { Client } from "../client"
+import { trace } from "@opentelemetry/api"
 
 import {
   setBody,
@@ -11,8 +17,14 @@ import {
   setParams,
   setSessionData,
   setTag,
-  setNamespace
+  setNamespace,
+  setError,
+  sendError
 } from "../helpers"
+
+function throwError() {
+  throw new Error("Whoopsie!")
+}
 
 describe("Helpers", () => {
   let spans: ReadableSpan[] = []
@@ -95,6 +107,80 @@ describe("Helpers", () => {
     expect(spans.length).toEqual(1)
     expect(spans[0].attributes).toMatchObject({
       "appsignal.custom_data": '{"nested":"[cyclic value: root object]"}'
+    })
+  })
+
+  describe("setError", () => {
+    function expectErrorEvent(event: TimedEvent) {
+      expect(event).toMatchObject({
+        name: "exception",
+        attributes: {
+          "exception.message": "Whoopsie!",
+          "exception.type": "Error",
+          "exception.stacktrace": expect.stringContaining("at throwError (")
+        }
+      })
+    }
+
+    it("sets an error", () => {
+      tracerProvider.getTracer("test").startActiveSpan("Some span", span => {
+        try {
+          throwError()
+        } catch (err) {
+          setError(err)
+        }
+
+        span.end()
+      })
+
+      expect(spans.length).toEqual(1)
+      expect(spans[0].events.length).toEqual(1)
+      expectErrorEvent(spans[0].events[0])
+    })
+
+    it("sends an error as a separate span", () => {
+      tracerProvider.getTracer("test").startActiveSpan("Some span", span => {
+        try {
+          throwError()
+        } catch (err) {
+          sendError(err)
+        }
+
+        expect(trace.getActiveSpan()).toBe(span)
+
+        span.end()
+      })
+
+      expect(spans.length).toEqual(2)
+
+      const activeSpan = spans.find(span => span.name == "Some span")
+      if (!activeSpan) throw new Error("No active span")
+
+      expect(activeSpan.events.length).toEqual(0)
+
+      const errorSpan = spans.find(span => span.name == "Error")
+      if (!errorSpan) throw new Error("No error span")
+
+      expect(errorSpan.events.length).toEqual(1)
+      expectErrorEvent(spans[0].events[0])
+    })
+
+    it("sends an error span with additional data", () => {
+      try {
+        throwError()
+      } catch (err) {
+        sendError(err, () => {
+          setCustomData({ chunky: "bacon" })
+        })
+      }
+
+      expect(spans.length).toEqual(1)
+      expect(spans[0].events.length).toEqual(1)
+      expectErrorEvent(spans[0].events[0])
+
+      expect(spans[0].attributes).toMatchObject({
+        "appsignal.custom_data": '{"chunky":"bacon"}'
+      })
     })
   })
 })

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,9 +1,16 @@
 import { SpanStatusCode, AttributeValue, trace } from "@opentelemetry/api"
+import { Client } from "./client"
 
 function setAttribute(attribute: string, value: AttributeValue) {
   const activeSpan = trace.getActiveSpan()
   if (activeSpan) {
     activeSpan.setAttribute(attribute, value)
+  } else {
+    const splitAttributes = attribute.split(".")
+    const attributeSuffix = splitAttributes[splitAttributes.length - 1]
+    Client.logger.debug(
+      `There is no active span, cannot set \`${attributeSuffix}\``
+    )
   }
 }
 
@@ -87,7 +94,13 @@ export function setError(error: Error) {
         code: SpanStatusCode.ERROR,
         message: error.message
       })
+    } else {
+      Client.logger.debug(
+        `There is no active span, cannot set \`${error.name}\``
+      )
     }
+  } else {
+    Client.logger.debug("Cannot set error, it is not an `Error`-like object")
   }
 }
 
@@ -100,5 +113,7 @@ export function sendError(error: Error, fn: () => void = () => {}) {
         fn()
         span.end()
       })
+  } else {
+    Client.logger.debug("Cannot send error, it is not an `Error`-like object")
   }
 }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,4 +1,4 @@
-import { SpanStatusCode, AttributeValue, trace, Span } from "@opentelemetry/api"
+import { SpanStatusCode, AttributeValue, trace } from "@opentelemetry/api"
 
 function setAttribute(attribute: string, value: AttributeValue) {
   const activeSpan = trace.getActiveSpan()

--- a/src/instrumentation/express/error_handler.ts
+++ b/src/instrumentation/express/error_handler.ts
@@ -1,5 +1,5 @@
 import { Request, Response, NextFunction, ErrorRequestHandler } from "express"
-import * as opentelemetry from "@opentelemetry/api"
+import { setError } from "../../helpers"
 
 export function expressErrorHandler(): ErrorRequestHandler {
   return function (
@@ -8,24 +8,10 @@ export function expressErrorHandler(): ErrorRequestHandler {
     res: Response,
     next: NextFunction
   ) {
-    const activeSpan = opentelemetry.trace.getSpan(
-      opentelemetry.context.active()
-    )
-    // if there's no `status` property, forward the error
-    // we also ignore client errors here
-    if (
-      activeSpan &&
-      err &&
-      (!err.status || (err.status && err.status >= 500))
-    ) {
-      if (activeSpan) {
-        activeSpan.recordException(err)
-        activeSpan.setStatus({
-          code: opentelemetry.SpanStatusCode.ERROR,
-          message: err.message
-        })
-      }
+    if (!err.status || err.status >= 500) {
+      setError(err)
     }
+
     return next(err)
   }
 }

--- a/test/express-apollo/tests/spec/spec_helper.rb
+++ b/test/express-apollo/tests/spec/spec_helper.rb
@@ -19,6 +19,10 @@ RSpec.configure do |config|
     IntegrationHelper.clean_spans
   end
 
+  config.after(:each) do |example|
+    IntegrationHelper.print_spans if example.exception
+  end
+
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true
   end

--- a/test/express-postgres/tests/spec/spec_helper.rb
+++ b/test/express-postgres/tests/spec/spec_helper.rb
@@ -19,6 +19,10 @@ RSpec.configure do |config|
     IntegrationHelper.clean_spans
   end
 
+  config.after(:each) do |example|
+    IntegrationHelper.print_spans if example.exception
+  end
+
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true
   end

--- a/test/express-prisma/tests/spec/spec_helper.rb
+++ b/test/express-prisma/tests/spec/spec_helper.rb
@@ -19,6 +19,10 @@ RSpec.configure do |config|
     IntegrationHelper.clean_spans
   end
 
+  config.after(:each) do |example|
+    IntegrationHelper.print_spans if example.exception
+  end
+
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true
   end

--- a/test/express-redis/app/package-lock.json
+++ b/test/express-redis/app/package-lock.json
@@ -10,12 +10,15 @@
       "license": "ISC",
       "dependencies": {
         "@appsignal/nodejs": "^2.4.2",
+        "@opentelemetry/api": "^1.2.0",
+        "cookie-parser": "^1.4.6",
         "express": "^4.17.2",
         "ioredis": "^4.28.5",
         "redis": "^4",
         "tslib": "^2.4.0"
       },
       "devDependencies": {
+        "@types/cookie-parser": "^1.4.3",
         "@types/express": "4.17.13",
         "@types/ioredis": "4.28.10",
         "@types/node": "18.6.3",
@@ -10068,6 +10071,14 @@
       "resolved": "../integration",
       "link": true
     },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.2.0.tgz",
+      "integrity": "sha512-0nBr+VZNKm9tvNDZFstI3Pq1fCTEDK5OZTnVKNvBNAKgd0yIvmwsP4m61rEv7ZP+tOUjWJhROpxK5MsnlF911g==",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/@redis/bloom": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-1.0.2.tgz",
@@ -10136,6 +10147,15 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/cookie-parser": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@types/cookie-parser/-/cookie-parser-1.4.3.tgz",
+      "integrity": "sha512-CqSKwFwefj4PzZ5n/iwad/bow2hTCh0FlNAeWLtQM3JA/NX/iYagIpWG2cf1bQKQ2c9gU2log5VUCrn7LDOs0w==",
+      "dev": true,
+      "dependencies": {
+        "@types/express": "*"
       }
     },
     "node_modules/@types/express": {
@@ -10278,6 +10298,26 @@
     "node_modules/cookie": {
       "version": "0.5.0",
       "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-parser": {
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
+      "integrity": "sha512-z3IzaNjdwUC2olLIB5/ITd0/setiaFMLYiZJle7xg5Fe9KWAceil7xszYfHHBtDFYLSgJduS2Ty0P1uJdPDJeA==",
+      "dependencies": {
+        "cookie": "0.4.1",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cookie-parser/node_modules/cookie": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
       "engines": {
         "node": ">= 0.6"
       }
@@ -17420,6 +17460,11 @@
         }
       }
     },
+    "@opentelemetry/api": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.2.0.tgz",
+      "integrity": "sha512-0nBr+VZNKm9tvNDZFstI3Pq1fCTEDK5OZTnVKNvBNAKgd0yIvmwsP4m61rEv7ZP+tOUjWJhROpxK5MsnlF911g=="
+    },
     "@redis/bloom": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-1.0.2.tgz",
@@ -17473,6 +17518,15 @@
       "dev": true,
       "requires": {
         "@types/node": "*"
+      }
+    },
+    "@types/cookie-parser": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@types/cookie-parser/-/cookie-parser-1.4.3.tgz",
+      "integrity": "sha512-CqSKwFwefj4PzZ5n/iwad/bow2hTCh0FlNAeWLtQM3JA/NX/iYagIpWG2cf1bQKQ2c9gU2log5VUCrn7LDOs0w==",
+      "dev": true,
+      "requires": {
+        "@types/express": "*"
       }
     },
     "@types/express": {
@@ -17576,6 +17630,22 @@
     },
     "cookie": {
       "version": "0.5.0"
+    },
+    "cookie-parser": {
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
+      "integrity": "sha512-z3IzaNjdwUC2olLIB5/ITd0/setiaFMLYiZJle7xg5Fe9KWAceil7xszYfHHBtDFYLSgJduS2Ty0P1uJdPDJeA==",
+      "requires": {
+        "cookie": "0.4.1",
+        "cookie-signature": "1.0.6"
+      },
+      "dependencies": {
+        "cookie": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+          "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA=="
+        }
+      }
     },
     "cookie-signature": {
       "version": "1.0.6"

--- a/test/express-redis/app/package.json
+++ b/test/express-redis/app/package.json
@@ -13,15 +13,18 @@
   "license": "ISC",
   "dependencies": {
     "@appsignal/nodejs": "^2.4.2",
+    "@opentelemetry/api": "^1.2.0",
+    "cookie-parser": "^1.4.6",
     "express": "^4.17.2",
     "ioredis": "^4.28.5",
     "redis": "^4",
     "tslib": "^2.4.0"
   },
   "devDependencies": {
-    "typescript": "4.7.4",
-    "@types/node": "18.6.3",
+    "@types/cookie-parser": "^1.4.3",
+    "@types/express": "4.17.13",
     "@types/ioredis": "4.28.10",
-    "@types/express": "4.17.13"
+    "@types/node": "18.6.3",
+    "typescript": "4.7.4"
   }
 }

--- a/test/express-redis/app/src/app.ts
+++ b/test/express-redis/app/src/app.ts
@@ -1,18 +1,26 @@
 import express from "express"
 import { createClient } from "redis"
 import ioredis from "ioredis"
+import { setTag, setCustomData, expressErrorHandler } from "@appsignal/nodejs"
+import { trace } from "@opentelemetry/api"
+import cookieParser from "cookie-parser"
 
 const redisHost = "redis://redis:6379"
 const port = process.env.PORT
 
 const app = express()
 app.use(express.urlencoded({ extended: true }))
+app.use(cookieParser())
 
-app.get("/", (req: any, res: any) => {
+app.get("/", (_req: any, res: any) => {
   res.send("200 OK")
 })
 
-app.get("/redis", async (req: any, res: any, next: any) => {
+app.get("/error", (_req: any, _res: any) => {
+  throw new Error("Expected test error!")
+})
+
+app.get("/redis", async (_req: any, res: any, next: any) => {
   try {
     const client = createClient({ url: redisHost })
     client.once("error", (error: Error) => {
@@ -31,7 +39,7 @@ app.get("/redis", async (req: any, res: any, next: any) => {
   }
 })
 
-app.get("/ioredis", async (req: any, res: any, next: any) => {
+app.get("/ioredis", async (_req: any, res: any, next: any) => {
   try {
     const client = new ioredis(redisHost)
     await client.set("test_key", "Test value")
@@ -44,6 +52,20 @@ app.get("/ioredis", async (req: any, res: any, next: any) => {
     next(e)
   }
 })
+
+app.get("/custom", (_req: any, res: any) => {
+  setCustomData({ custom: "data" })
+
+  trace.getTracer("custom").startActiveSpan("Custom span", span => {
+    setTag("custom", "tag")
+
+    span.end()
+  })
+
+  res.send("200 OK")
+})
+
+app.use(expressErrorHandler())
 
 app.listen(port, () => {
   console.log(`Example app listening on port ${port}`)

--- a/test/express-redis/tests/spec/spec_helper.rb
+++ b/test/express-redis/tests/spec/spec_helper.rb
@@ -20,6 +20,10 @@ RSpec.configure do |config|
     IntegrationHelper.clean_spans
   end
 
+  config.after(:each) do |example|
+    IntegrationHelper.print_spans if example.exception
+  end
+
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true
   end

--- a/test/express-redis/tests/spec/spec_helper.rb
+++ b/test/express-redis/tests/spec/spec_helper.rb
@@ -5,6 +5,8 @@ require "json"
 require "/helpers/span"
 require "/helpers/integration_helper"
 require "/helpers/http_helper"
+require "/helpers/error_helper"
+require "/helpers/magic_helper"
 require "/helpers/express_helper"
 require "/helpers/redis_helper"
 

--- a/test/express-yoga/tests/spec/spec_helper.rb
+++ b/test/express-yoga/tests/spec/spec_helper.rb
@@ -19,6 +19,10 @@ RSpec.configure do |config|
     IntegrationHelper.clean_spans
   end
 
+  config.after(:each) do |example|
+    IntegrationHelper.print_spans if example.exception
+  end
+
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true
   end

--- a/test/helpers/http_helper.rb
+++ b/test/helpers/http_helper.rb
@@ -9,11 +9,3 @@ RSpec::Matchers.define :be_http_span_with_route do |expected|
       actual.instrumentation_library_name == "@opentelemetry/instrumentation-http"
   end
 end
-
-RSpec::Matchers.define :match_request_parameters do |expected|
-  match do |actual|
-    parsed_params = JSON[actual.attributes["appsignal.request.parameters"]]
-
-    parsed_params == expected
-  end
-end

--- a/test/helpers/integration_helper.rb
+++ b/test/helpers/integration_helper.rb
@@ -30,4 +30,8 @@ module IntegrationHelper
   def self.clean_spans
     Span.clear_all
   end
+
+  def self.print_spans
+    puts Span.all.inspect
+  end
 end

--- a/test/helpers/magic_helper.rb
+++ b/test/helpers/magic_helper.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "rspec/expectations"
+require "json"
+
+RSpec::Matchers.define :match_request_parameters do |expected|
+  match do |actual|
+    parsed_params = JSON[actual.attributes["appsignal.request.parameters"]]
+
+    parsed_params == expected
+  end
+end
+
+RSpec::Matchers.define :match_request_session_data do |expected|
+  match do |actual|
+    parsed_session_data = JSON[actual.attributes["appsignal.request.session_data"]]
+
+    parsed_session_data == expected
+  end
+end
+
+RSpec::Matchers.define :match_custom_data do |expected|
+  match do |actual|
+    parsed_custom_data = JSON[actual.attributes["appsignal.custom_data"]]
+
+    parsed_custom_data == expected
+  end
+end

--- a/test/koa-mysql/tests/spec/app_spec.rb
+++ b/test/koa-mysql/tests/spec/app_spec.rb
@@ -16,18 +16,17 @@ RSpec.describe "Koa + MySQL app" do
   end
 
   describe "GET /get with params" do
-    it "adds params to the Koa router span" do
+    it "adds params to the HTTP root span" do
       response = HTTP.get("#{@test_app_url}/get?param1=user&param2=password")
       expect(response.status).to eq(200)
       expect(Span.root!).to be_http_span_with_route("GET /get")
 
-      koa_router_span = Span.find_by_name!("router - /get")
       expected_request_parameters = {
         "param1" => "user",
         "param2" => "password"
       }
 
-      expect(koa_router_span).to match_request_parameters(expected_request_parameters)
+      expect(Span.root!).to match_request_parameters(expected_request_parameters)
     end
   end
 

--- a/test/koa-mysql/tests/spec/spec_helper.rb
+++ b/test/koa-mysql/tests/spec/spec_helper.rb
@@ -20,6 +20,10 @@ RSpec.configure do |config|
     IntegrationHelper.clean_spans
   end
 
+  config.after(:each) do |example|
+    IntegrationHelper.print_spans if example.exception
+  end
+
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true
   end

--- a/test/koa-mysql/tests/spec/spec_helper.rb
+++ b/test/koa-mysql/tests/spec/spec_helper.rb
@@ -5,6 +5,7 @@ require "json"
 require "/helpers/span"
 require "/helpers/integration_helper"
 require "/helpers/http_helper"
+require "/helpers/magic_helper"
 require "/helpers/koa_helper"
 require "/helpers/error_helper"
 


### PR DESCRIPTION
### [Add `{set,send}Error` helpers](https://github.com/appsignal/appsignal-nodejs/pull/744/commits/e7f80f4e796d96049431681da06e61bb3f0baf6d)

Adds the `setError` and `sendError` helpers, as described in https://github.com/appsignal/appsignal-nodejs/issues/741.

Note that the `sendError` callback does not receive a span as an
argument. It creates an active span and runs your callback inside
it. As the other helpers do not require a span as an argument, you
can use those helpers from the callback without having a span
passed as an argument.

### [Print all spans on failure](https://github.com/appsignal/appsignal-nodejs/pull/744/commits/25dc929f1a08d6d282e388458df015981a801d39)

When the integration tests fail, they should print all the spans
they have seen, to help with debugging.

### [Use helpers to set magic attributes](https://github.com/appsignal/appsignal-nodejs/pull/744/commits/3932265f5e65fddde37648cf52ae6c322e970a38)

Use our helpers internally when setting errors, params or magic
attributes for the Express and Koa instrumentations. As a result,
magic attributes for Express params and cookies are now set in the
root span, not in the request handler span.

Fix existing tests for the params and add tests for the session and
the error in Express, as well as a test for custom instrumentation.

###  [Warn if there is no active span](https://github.com/appsignal/appsignal-nodejs/pull/744/commits/13359068c5d950e131b5019c08a56338c60408ef)

Instead of silently failing, emit a debug-level warning to the logs
when a helper attempts to set an attribute, but there is no active
span to set it on.

Also emit a debug-level warning to the logs when a helper that takes
an Error-like object as argument receives an value which is not
Error-like, as it is common to throw non-Error values.

---

Fixes #741.

Moved the "Remove tracer provider" bit from the draft to a separate PR.
[skip changeset]