### PR TITLE
Send params and session data for the extension

### DIFF
--- a/src/config/configmap.ts
+++ b/src/config/configmap.ts
@@ -56,6 +56,8 @@ export const PRIVATE_ENV_MAPPING: { [key: string]: string } = {
   _APPSIGNAL_PUSH_API_KEY: "pushApiKey",
   _APPSIGNAL_RUNNING_IN_CONTAINER: "runningInContainer",
   _APPSIGNAL_SEND_ENVIRONMENT_METADATA: "sendEnvironmentMetadata",
+  _APPSIGNAL_SEND_PARAMS: "sendParams",
+  _APPSIGNAL_SEND_SESSION_DATA: "sendSessionData",
   _APPSIGNAL_WORKING_DIRECTORY_PATH: "workingDirectoryPath",
   _APP_REVISION: "revision"
 }


### PR DESCRIPTION
The extension needs to know the value of `sendParams` and `sendSessionData` to filter out these attributes on the extension's end. The changes to read these environment variables are implemented in the extension repository.

Part of https://github.com/appsignal/opentelemetry/issues/48  
Part of https://github.com/appsignal/opentelemetry/issues/49
Related https://github.com/appsignal/appsignal-agent/pull/824

[skip changeset]