### PR TITLE
Remove deprecated config options

### DIFF
--- a/.changesets/remove--debug--config-option.md
+++ b/.changesets/remove--debug--config-option.md
@@ -1,0 +1,6 @@
+---
+bump: "major"
+type: "remove"
+---
+
+Remove `debug` config option. This has been replaced with `logLevel` set to `debug`.

--- a/.changesets/remove-apikey-config-option.md
+++ b/.changesets/remove-apikey-config-option.md
@@ -1,0 +1,6 @@
+---
+bump: "major"
+type: "remove"
+---
+
+Remove the `apiKey` config option. This has been renamed to `pushApiKey`.

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -140,22 +140,6 @@ describe("Configuration", () => {
     })
   })
 
-  describe("apiKey option", () => {
-    it("sets the pushApiKey config option with the apiKey value", () => {
-      const warnMock = jest.spyOn(console, "warn").mockImplementation(() => {})
-      const apiKey = "my key"
-      config = new Configuration({ apiKey })
-
-      expect(config.data.pushApiKey).toEqual(apiKey)
-      expect(config.data.apiKey).toBeUndefined()
-      expect(config.sources.initial.pushApiKey).toEqual(apiKey)
-      expect(config.sources.initial.apiKey).toBeUndefined()
-      expect(warnMock).toBeCalledWith(
-        "DEPRECATED: The `apiKey` config option was renamed to `pushApiKey`. Please rename the config option given to the Appsignal module."
-      )
-    })
-  })
-
   describe("logFilePath", () => {
     it("uses the default log file path", () => {
       jest.spyOn(fs, "accessSync").mockImplementation(() => {})

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -14,7 +14,6 @@ describe("Configuration", () => {
   const expectedDefaultConfig = {
     active: false,
     caFilePath: path.join(__dirname, "../../cert/cacert.pem"),
-    debug: false,
     disableDefaultInstrumentations: false,
     dnsServers: [],
     enableHostMetrics: true,
@@ -41,8 +40,7 @@ describe("Configuration", () => {
     ],
     sendEnvironmentMetadata: true,
     sendParams: true,
-    sendSessionData: true,
-    transactionDebugMode: false
+    sendSessionData: true
   }
 
   function resetEnv() {
@@ -102,7 +100,6 @@ describe("Configuration", () => {
   describe("with initial config options", () => {
     it("loads initial config options", () => {
       const initialOptions = {
-        debug: true,
         enableStatsd: true
       }
       const options = {
@@ -124,10 +121,8 @@ describe("Configuration", () => {
 
   describe("with config in the environment", () => {
     it("loads configuration from the environment", () => {
-      process.env["APPSIGNAL_DEBUG"] = "true"
       process.env["APPSIGNAL_ENABLE_STATSD"] = "true"
       const envOptions = {
-        debug: true,
         enableStatsd: true
       }
       const expectedConfig = {
@@ -244,7 +239,6 @@ describe("Configuration", () => {
       expect(env("_APPSIGNAL_ACTIVE")).toBeUndefined()
       expect(env("_APPSIGNAL_APP_NAME")).toBeUndefined()
       expect(env("_APPSIGNAL_CA_FILE_PATH")).toMatch(/cert\/cacert\.pem$/)
-      expect(env("_APPSIGNAL_DEBUG_LOGGING")).toBeUndefined()
       expect(env("_APPSIGNAL_DNS_SERVERS")).toBeUndefined()
       expect(env("_APPSIGNAL_ENABLE_HOST_METRICS")).toEqual("true")
       expect(env("_APPSIGNAL_ENABLE_STATSD")).toBeUndefined()
@@ -264,7 +258,6 @@ describe("Configuration", () => {
       )
       expect(env("_APPSIGNAL_PUSH_API_KEY")).toBeUndefined()
       expect(env("_APPSIGNAL_RUNNING_IN_CONTAINER")).toBeUndefined()
-      expect(env("_APPSIGNAL_TRANSACTION_DEBUG_MODE")).toBeUndefined()
       expect(env("_APPSIGNAL_WORKING_DIRECTORY_PATH")).toBeUndefined()
       expect(env("_APPSIGNAL_WORKING_DIR_PATH")).toBeUndefined()
       expect(env("_APP_REVISION")).toBeUndefined()
@@ -287,7 +280,6 @@ describe("Configuration", () => {
           name,
           active: true,
           pushApiKey,
-          debug: true,
           dnsServers: ["8.8.8.8", "8.8.4.4"],
           enableHostMetrics: false,
           enableMinutelyProbes: false,
@@ -311,7 +303,6 @@ describe("Configuration", () => {
       it("writes configuration values to the environment", () => {
         expect(env("_APPSIGNAL_ACTIVE")).toEqual("true")
         expect(env("_APPSIGNAL_APP_NAME")).toEqual(name)
-        expect(env("_APPSIGNAL_DEBUG_LOGGING")).toEqual("true")
         expect(env("_APPSIGNAL_DNS_SERVERS")).toEqual("8.8.8.8,8.8.4.4")
         expect(env("_APPSIGNAL_ENABLE_HOST_METRICS")).toEqual("true")
         expect(env("_APPSIGNAL_ENABLE_STATSD")).toEqual("true")
@@ -340,9 +331,6 @@ describe("Configuration", () => {
         expect(env("_APPSIGNAL_PUSH_API_KEY")).toEqual(pushApiKey)
         expect(env("_APPSIGNAL_RUNNING_IN_CONTAINER")).toEqual("true")
         expect(env("_APPSIGNAL_SEND_ENVIRONMENT_METADATA")).toEqual("true")
-        // Only set because `debug` is set to true
-        // @TODO: https://github.com/appsignal/appsignal-nodejs/issues/379
-        expect(env("_APPSIGNAL_TRANSACTION_DEBUG_MODE")).toEqual("true")
         expect(env("_APPSIGNAL_WORKING_DIRECTORY_PATH")).toEqual("/my/path")
         expect(env("_APPSIGNAL_WORKING_DIR_PATH")).toBeUndefined()
         expect(env("_APP_REVISION")).toEqual("my-revision")

--- a/src/__tests__/diagnose.test.ts
+++ b/src/__tests__/diagnose.test.ts
@@ -20,7 +20,6 @@ describe("DiagnoseTool", () => {
     expect(output.host.architecture).toEqual(process.arch)
     expect(output.host.os).toEqual(process.platform)
 
-    expect(output.config.options).toHaveProperty("debug")
     expect(output.config.options).toHaveProperty("log")
     expect(output.config.options).toHaveProperty("caFilePath")
     expect(output.config.options).toHaveProperty("endpoint")

--- a/src/config.ts
+++ b/src/config.ts
@@ -41,13 +41,6 @@ export class Configuration {
   }
 
   /**
-   * Returns `true` if the client is in debug mode
-   */
-  public get debug(): boolean {
-    return this.data.debug || false
-  }
-
-  /**
    * Returns `true` if the current configuration is valid.
    */
   public get isValid(): boolean {
@@ -113,7 +106,6 @@ export class Configuration {
     return {
       active: false,
       caFilePath: path.join(__dirname, "../cert/cacert.pem"),
-      debug: false,
       disableDefaultInstrumentations: false,
       dnsServers: [],
       enableHostMetrics: true,
@@ -140,8 +132,7 @@ export class Configuration {
       ],
       sendEnvironmentMetadata: true,
       sendParams: true,
-      sendSessionData: true,
-      transactionDebugMode: false
+      sendSessionData: true
     }
   }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -19,13 +19,6 @@ export class Configuration {
   sources: Record<string, Partial<AppsignalOptions>>
 
   constructor(options: Partial<AppsignalOptions>) {
-    if (options.apiKey) {
-      console.warn(
-        "DEPRECATED: The `apiKey` config option was renamed to `pushApiKey`. Please rename the config option given to the Appsignal module."
-      )
-      options.pushApiKey = options.apiKey
-      delete options.apiKey
-    }
     this.sources = {
       default: this._defaultValues(),
       system: this._systemValues(),

--- a/src/config/configmap.ts
+++ b/src/config/configmap.ts
@@ -31,7 +31,6 @@ export const ENV_TO_KEY_MAPPING: { [key: string]: string } = {
   APPSIGNAL_SEND_PARAMS: "sendParams",
   APPSIGNAL_SEND_SESSION_DATA: "sendSessionData",
   APPSIGNAL_WORKING_DIRECTORY_PATH: "workingDirectoryPath",
-  APPSIGNAL_WORKING_DIR_PATH: "workingDirPath",
   APP_REVISION: "revision"
 }
 
@@ -58,7 +57,6 @@ export const PRIVATE_ENV_MAPPING: { [key: string]: string } = {
   _APPSIGNAL_RUNNING_IN_CONTAINER: "runningInContainer",
   _APPSIGNAL_SEND_ENVIRONMENT_METADATA: "sendEnvironmentMetadata",
   _APPSIGNAL_WORKING_DIRECTORY_PATH: "workingDirectoryPath",
-  _APPSIGNAL_WORKING_DIR_PATH: "workingDirPath",
   _APP_REVISION: "revision"
 }
 
@@ -90,6 +88,5 @@ export const JS_TO_RUBY_MAPPING: { [key: string]: string } = {
   sendEnvironmentMetadata: "send_environment_metadata",
   sendParams: "send_params",
   sendSessionData: "send_session_data",
-  workingDirPath: "working_dir_path",
   workingDirectoryPath: "working_directory_path"
 }

--- a/src/config/configmap.ts
+++ b/src/config/configmap.ts
@@ -3,7 +3,6 @@ export const ENV_TO_KEY_MAPPING: { [key: string]: string } = {
   APPSIGNAL_APP_ENV: "environment",
   APPSIGNAL_APP_NAME: "name",
   APPSIGNAL_CA_FILE_PATH: "caFilePath",
-  APPSIGNAL_DEBUG: "debug",
   APPSIGNAL_DISABLE_DEFAULT_INSTRUMENTATIONS: "disableDefaultInstrumentations",
   APPSIGNAL_DNS_SERVERS: "dnsServers",
   APPSIGNAL_ENABLE_HOST_METRICS: "enableHostMetrics",
@@ -31,7 +30,6 @@ export const ENV_TO_KEY_MAPPING: { [key: string]: string } = {
   APPSIGNAL_SEND_ENVIRONMENT_METADATA: "sendEnvironmentMetadata",
   APPSIGNAL_SEND_PARAMS: "sendParams",
   APPSIGNAL_SEND_SESSION_DATA: "sendSessionData",
-  APPSIGNAL_TRANSACTION_DEBUG_MODE: "transactionDebugMode",
   APPSIGNAL_WORKING_DIRECTORY_PATH: "workingDirectoryPath",
   APPSIGNAL_WORKING_DIR_PATH: "workingDirPath",
   APP_REVISION: "revision"
@@ -41,7 +39,6 @@ export const PRIVATE_ENV_MAPPING: { [key: string]: string } = {
   _APPSIGNAL_ACTIVE: "active",
   _APPSIGNAL_APP_NAME: "name",
   _APPSIGNAL_CA_FILE_PATH: "caFilePath",
-  _APPSIGNAL_DEBUG_LOGGING: "debug",
   _APPSIGNAL_DNS_SERVERS: "dnsServers",
   _APPSIGNAL_ENABLE_HOST_METRICS: "enableHostMetrics",
   _APPSIGNAL_ENABLE_STATSD: "enableStatsd",
@@ -60,7 +57,6 @@ export const PRIVATE_ENV_MAPPING: { [key: string]: string } = {
   _APPSIGNAL_PUSH_API_KEY: "pushApiKey",
   _APPSIGNAL_RUNNING_IN_CONTAINER: "runningInContainer",
   _APPSIGNAL_SEND_ENVIRONMENT_METADATA: "sendEnvironmentMetadata",
-  _APPSIGNAL_TRANSACTION_DEBUG_MODE: "debug",
   _APPSIGNAL_WORKING_DIRECTORY_PATH: "workingDirectoryPath",
   _APPSIGNAL_WORKING_DIR_PATH: "workingDirPath",
   _APP_REVISION: "revision"
@@ -70,7 +66,6 @@ export const JS_TO_RUBY_MAPPING: { [key: string]: string } = {
   active: "active",
   pushApiKey: "push_api_key",
   caFilePath: "ca_file_path",
-  debug: "debug",
   disableDefaultInstrumentations: "disable_default_instrumentations",
   dnsServers: "dns_servers",
   enableHostMetrics: "enable_host_metrics",
@@ -95,7 +90,6 @@ export const JS_TO_RUBY_MAPPING: { [key: string]: string } = {
   sendEnvironmentMetadata: "send_environment_metadata",
   sendParams: "send_params",
   sendSessionData: "send_session_data",
-  transactionDebugMode: "transaction_debug_mode",
   workingDirPath: "working_dir_path",
   workingDirectoryPath: "working_directory_path"
 }

--- a/src/config/options.ts
+++ b/src/config/options.ts
@@ -4,7 +4,6 @@ export type AppsignalOptions = {
   active: boolean
   apiKey: string
   caFilePath: string
-  debug: boolean
   disableDefaultInstrumentations: DefaultInstrumentationName[] | boolean
   dnsServers: string[]
   enableHostMetrics: boolean

--- a/src/config/options.ts
+++ b/src/config/options.ts
@@ -2,7 +2,6 @@ import type { DefaultInstrumentationName } from "../client"
 
 export type AppsignalOptions = {
   active: boolean
-  apiKey: string
   caFilePath: string
   disableDefaultInstrumentations: DefaultInstrumentationName[] | boolean
   dnsServers: string[]

--- a/src/config/options.ts
+++ b/src/config/options.ts
@@ -29,6 +29,5 @@ export type AppsignalOptions = {
   runningInContainer: boolean
   sendParams: boolean
   sendSessionData: boolean
-  workingDirPath: string
   workingDirectoryPath: string
 }


### PR DESCRIPTION
## Remove the debug config options

Remove `debug` and `transactionDebugMode` config options. They have both been replaced with the `logLevel` config option.

Remove the `Config.debug()` function. It only worked with the deprecated config option, and isn't used anywhere.

Part of #738

## Remove apiKey deprecated config option

The `apiKey` was replaced with the `pushApiKey` config option some time ago. Remove the deprecated config option for the next major release.

Part of #738

## Remove workingDirPath config option

This has been replaced with `workingDirectoryPath` a long time ago.

Since `workingDirPath` was undocumented for Node.js, I did not add a changeset for it. I assume no one uses it.

Part of #738

---

Closes #738