### PR TITLE
Add root name magic attribute helper

### DIFF
--- a/src/__tests__/helpers.test.ts
+++ b/src/__tests__/helpers.test.ts
@@ -17,6 +17,7 @@ import {
   setSessionData,
   setTag,
   setNamespace,
+  setRootName,
   setError,
   sendError
 } from "../helpers"
@@ -85,6 +86,7 @@ describe("Helpers", () => {
       setHeader("content-type", "application/json")
       setTag("something", true)
       setNamespace("web")
+      setRootName("Root name")
 
       span.end()
     })
@@ -99,7 +101,8 @@ describe("Helpers", () => {
       "appsignal.request.session_data": '{"admin":true}',
       "appsignal.request.headers.content-type": "application/json",
       "appsignal.tag.something": true,
-      "appsignal.namespace": "web"
+      "appsignal.namespace": "web",
+      "appsignal.root_name": "Root name"
     })
   })
 

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -85,6 +85,10 @@ export function setNamespace(namespace: string) {
   setAttribute("appsignal.namespace", namespace)
 }
 
+export function setRootName(name: string) {
+  setAttribute("appsignal.root_name", name)
+}
+
 export function setError(error: Error) {
   if (error && error.name && error.message) {
     const activeSpan = trace.getActiveSpan()


### PR DESCRIPTION
Allow users change the incident's action name by overriding the root span name for OpenTelemetry traces. This is the counterpart to the `setName` helper that only changes the active span's name. The "name" translates to the "title" you see on the box when you hover over an event in the event timeline.

This helper does the same as `rootSpan.setName("Name")`, but not always can users access the root span of the trace. Which is where this helper comes in to make it still possible to overwrite the root span's name. If the `setRootName` function is used, it overwrites any `rootSpan.setName` value.

I'm also okay with changing this name to `setTraceName` if that would make it more clear what is the root in this context.

This also requires the processor change I submitted earlier.

[skip changeset]

Part of https://github.com/appsignal/opentelemetry/issues/46