### PR TITLE
Remove ignoreInstrumentations config option

### DIFF
--- a/src/config/options.ts
+++ b/src/config/options.ts
@@ -17,7 +17,6 @@ export type AppsignalOptions = {
   httpProxy: string
   ignoreActions: string[]
   ignoreErrors: string[]
-  ignoreInstrumentation: string[]
   ignoreNamespaces: string[]
   log: string
   logPath: string


### PR DESCRIPTION
It's unused since the OpenTelemetry related changes to the Client.

Closes #752

[skip changeset]

First approval and we're merging this tiny change.