### PR TITLE
Bump agent and extension to v-8dd80e5

### DIFF
--- a/scripts/extension/support/constants.js
+++ b/scripts/extension/support/constants.js
@@ -3,7 +3,7 @@
 // appsignal-agent repository.
 // Modifications to this file will be overwritten with the next agent release.
 
-const AGENT_VERSION = "06391fb"
+const AGENT_VERSION = "8dd80e5"
 const MIRRORS = [
   "https://appsignal-agent-releases.global.ssl.fastly.net",
   "https://d135dj0rjqvssy.cloudfront.net"
@@ -12,67 +12,67 @@ const MIRRORS = [
 const TRIPLES = {
   "x86_64-darwin": {
     checksum:
-      "9bf41c183d94c80e980f57ea2e29d08bae97e8097b5284a2b91a5484bf866f8c",
+      "97421eb7d264f0093bcc68c7bb7282070e4d683124d5eb6c9b4cc649fce885e9",
     filename: "appsignal-x86_64-darwin-all-static.tar.gz"
   },
   "universal-darwin": {
     checksum:
-      "9bf41c183d94c80e980f57ea2e29d08bae97e8097b5284a2b91a5484bf866f8c",
+      "97421eb7d264f0093bcc68c7bb7282070e4d683124d5eb6c9b4cc649fce885e9",
     filename: "appsignal-x86_64-darwin-all-static.tar.gz"
   },
   "aarch64-darwin": {
     checksum:
-      "74edd7b97995f3314c10e3d84fc832c1b842c236c331ed4f2f77146ad004d179",
+      "43c95eb9bc349511c0501ba67e5fefb76621ef0c91f3c7f2d7813e5a552fab8c",
     filename: "appsignal-aarch64-darwin-all-static.tar.gz"
   },
   "arm64-darwin": {
     checksum:
-      "74edd7b97995f3314c10e3d84fc832c1b842c236c331ed4f2f77146ad004d179",
+      "43c95eb9bc349511c0501ba67e5fefb76621ef0c91f3c7f2d7813e5a552fab8c",
     filename: "appsignal-aarch64-darwin-all-static.tar.gz"
   },
   "arm-darwin": {
     checksum:
-      "74edd7b97995f3314c10e3d84fc832c1b842c236c331ed4f2f77146ad004d179",
+      "43c95eb9bc349511c0501ba67e5fefb76621ef0c91f3c7f2d7813e5a552fab8c",
     filename: "appsignal-aarch64-darwin-all-static.tar.gz"
   },
   "aarch64-linux": {
     checksum:
-      "0f2430e637eb77ce2093f021777087e87cb1e7be7c86a53771172696791c4879",
+      "57a667fc7893b0e62bc7938265c8d85a445fc4015451e54d2601de7fca65a89c",
     filename: "appsignal-aarch64-linux-all-static.tar.gz"
   },
   "i686-linux": {
     checksum:
-      "449ba623aaa1853c2d211bf1e2d3a14e5ae09225a62457cbdbcc0983a5713a52",
+      "79adeb2c286d6584dd6c5114e34a8514db37976ecccf83eafdcd2ea9ecea0a15",
     filename: "appsignal-i686-linux-all-static.tar.gz"
   },
   "x86-linux": {
     checksum:
-      "449ba623aaa1853c2d211bf1e2d3a14e5ae09225a62457cbdbcc0983a5713a52",
+      "79adeb2c286d6584dd6c5114e34a8514db37976ecccf83eafdcd2ea9ecea0a15",
     filename: "appsignal-i686-linux-all-static.tar.gz"
   },
   "x86_64-linux": {
     checksum:
-      "394796c0ddeb4881c9f2e6ce82f840e66bcb69e027324f6c04f6671067445fbb",
+      "40b7f7650a65205c344c524de745fafb2fc798423eb6f508218318313b14f490",
     filename: "appsignal-x86_64-linux-all-static.tar.gz"
   },
   "x86_64-linux-musl": {
     checksum:
-      "673271c8c5fd55053d8a719bcd307f787db4ca4633baf8cf961c442bf1805614",
+      "eea2f571c3a6c786c84ba57995d45f90119b92d20e666249ab964d4ee0d6849f",
     filename: "appsignal-x86_64-linux-musl-all-static.tar.gz"
   },
   "aarch64-linux-musl": {
     checksum:
-      "e90ca19bf61596be022ba04897e8902b3401add58f351a40a3d3a7af241d0bbb",
+      "c6070d63a838a08760f9c87dd2e253f7f4bc8e633eb3c4ea21b87a32a44a24f9",
     filename: "appsignal-aarch64-linux-musl-all-static.tar.gz"
   },
   "x86_64-freebsd": {
     checksum:
-      "cb45da91c51123859e5ef5cea850460c28d6e77dfa08b90375178d9017162ba8",
+      "de9a33514d34e577b4ebad24f17d5eac286fb54c6a65cc9111c9d79588363fb6",
     filename: "appsignal-x86_64-freebsd-all-static.tar.gz"
   },
   "amd64-freebsd": {
     checksum:
-      "cb45da91c51123859e5ef5cea850460c28d6e77dfa08b90375178d9017162ba8",
+      "de9a33514d34e577b4ebad24f17d5eac286fb54c6a65cc9111c9d79588363fb6",
     filename: "appsignal-x86_64-freebsd-all-static.tar.gz"
   }
 }

--- a/src/__tests__/span_processor.test.ts
+++ b/src/__tests__/span_processor.test.ts
@@ -48,7 +48,7 @@ describe("Span processor", () => {
       name: "unknownSpan",
       closed: true,
       attributes: expect.objectContaining({
-        foo: "bar",
+        "appsignal:category": "unknown",
         "appsignal:body": expect.stringContaining("unknown-instrumentation")
       }),
       parent_span_id: "",


### PR DESCRIPTION
- Add more extractors for OpenTelemetry span.
- Add agent HTTP server.
- Fix the return value for appsignal_import_opentelemetry_span extension function.

[skip review]
[skip changeset]