### PR TITLE
Bump agent to v-de2dd6e

### DIFF
--- a/.changesets/bump-agent-to-v-de2dd6e.md
+++ b/.changesets/bump-agent-to-v-de2dd6e.md
@@ -1,0 +1,14 @@
+---
+bump: "patch"
+type: "change"
+---
+
+Bump agent to v-de2dd6e.
+
+- Remove fallback for unknown span body. The notice about a missing extractor
+  is now a trace level log.
+- Filter root span attributes that are set as tags, params, headers, etc.
+- Filter more root span attributes that can contain PII information.
+- Improve http extractor span name to use `http.route` attribute to always
+  build the incident action name. This should avoid new incidents with 
+  `HTTP POST`-like naming.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@appsignal/nodejs",
-  "version": "2.4.2",
+  "version": "3.0.0-beta.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@appsignal/nodejs",
-      "version": "2.4.2",
+      "version": "3.0.0-beta.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/scripts/extension/support/constants.js
+++ b/scripts/extension/support/constants.js
@@ -3,7 +3,7 @@
 // appsignal-agent repository.
 // Modifications to this file will be overwritten with the next agent release.
 
-const AGENT_VERSION = "8dd80e5"
+const AGENT_VERSION = "de2dd6e"
 const MIRRORS = [
   "https://appsignal-agent-releases.global.ssl.fastly.net",
   "https://d135dj0rjqvssy.cloudfront.net"
@@ -12,67 +12,67 @@ const MIRRORS = [
 const TRIPLES = {
   "x86_64-darwin": {
     checksum:
-      "97421eb7d264f0093bcc68c7bb7282070e4d683124d5eb6c9b4cc649fce885e9",
+      "95dcfb45b90551ffe2d2297ada64598fb117e1d76a75417940d525c853f91592",
     filename: "appsignal-x86_64-darwin-all-static.tar.gz"
   },
   "universal-darwin": {
     checksum:
-      "97421eb7d264f0093bcc68c7bb7282070e4d683124d5eb6c9b4cc649fce885e9",
+      "95dcfb45b90551ffe2d2297ada64598fb117e1d76a75417940d525c853f91592",
     filename: "appsignal-x86_64-darwin-all-static.tar.gz"
   },
   "aarch64-darwin": {
     checksum:
-      "43c95eb9bc349511c0501ba67e5fefb76621ef0c91f3c7f2d7813e5a552fab8c",
+      "16e604e0835f90a23de20497bba58e29e633cce5cff9b994b9cca219f35abd83",
     filename: "appsignal-aarch64-darwin-all-static.tar.gz"
   },
   "arm64-darwin": {
     checksum:
-      "43c95eb9bc349511c0501ba67e5fefb76621ef0c91f3c7f2d7813e5a552fab8c",
+      "16e604e0835f90a23de20497bba58e29e633cce5cff9b994b9cca219f35abd83",
     filename: "appsignal-aarch64-darwin-all-static.tar.gz"
   },
   "arm-darwin": {
     checksum:
-      "43c95eb9bc349511c0501ba67e5fefb76621ef0c91f3c7f2d7813e5a552fab8c",
+      "16e604e0835f90a23de20497bba58e29e633cce5cff9b994b9cca219f35abd83",
     filename: "appsignal-aarch64-darwin-all-static.tar.gz"
   },
   "aarch64-linux": {
     checksum:
-      "57a667fc7893b0e62bc7938265c8d85a445fc4015451e54d2601de7fca65a89c",
+      "51270f21e843b53824854c184ea52bc95be2a25c761ef2e930b0b0d02d8e07da",
     filename: "appsignal-aarch64-linux-all-static.tar.gz"
   },
   "i686-linux": {
     checksum:
-      "79adeb2c286d6584dd6c5114e34a8514db37976ecccf83eafdcd2ea9ecea0a15",
+      "8efe967ded49ba2cef2cabf67f97e4dfe242fb9fba4fd02f848a22d6e5ae7165",
     filename: "appsignal-i686-linux-all-static.tar.gz"
   },
   "x86-linux": {
     checksum:
-      "79adeb2c286d6584dd6c5114e34a8514db37976ecccf83eafdcd2ea9ecea0a15",
+      "8efe967ded49ba2cef2cabf67f97e4dfe242fb9fba4fd02f848a22d6e5ae7165",
     filename: "appsignal-i686-linux-all-static.tar.gz"
   },
   "x86_64-linux": {
     checksum:
-      "40b7f7650a65205c344c524de745fafb2fc798423eb6f508218318313b14f490",
+      "7d27b3a7f59d9a3515cd7d0403e19dd618452b15444d87d42197d43227e4a539",
     filename: "appsignal-x86_64-linux-all-static.tar.gz"
   },
   "x86_64-linux-musl": {
     checksum:
-      "eea2f571c3a6c786c84ba57995d45f90119b92d20e666249ab964d4ee0d6849f",
+      "4ee8fb0e743634a4365113114d4a077779b2773f521e5a71e917d210d9ffe07b",
     filename: "appsignal-x86_64-linux-musl-all-static.tar.gz"
   },
   "aarch64-linux-musl": {
     checksum:
-      "c6070d63a838a08760f9c87dd2e253f7f4bc8e633eb3c4ea21b87a32a44a24f9",
+      "d1a19f4ba04849ceb3ad44ff254fd15a7c12dacffc1c3d58be6705a59395cbe2",
     filename: "appsignal-aarch64-linux-musl-all-static.tar.gz"
   },
   "x86_64-freebsd": {
     checksum:
-      "de9a33514d34e577b4ebad24f17d5eac286fb54c6a65cc9111c9d79588363fb6",
+      "93a7b1235a230d09f9416b01ed04f902b775b069a292d79c659f0aefa02afe05",
     filename: "appsignal-x86_64-freebsd-all-static.tar.gz"
   },
   "amd64-freebsd": {
     checksum:
-      "de9a33514d34e577b4ebad24f17d5eac286fb54c6a65cc9111c9d79588363fb6",
+      "93a7b1235a230d09f9416b01ed04f902b775b069a292d79c659f0aefa02afe05",
     filename: "appsignal-x86_64-freebsd-all-static.tar.gz"
   }
 }

--- a/src/__tests__/span_processor.test.ts
+++ b/src/__tests__/span_processor.test.ts
@@ -48,8 +48,7 @@ describe("Span processor", () => {
       name: "unknownSpan",
       closed: true,
       attributes: expect.objectContaining({
-        "appsignal:category": "unknown",
-        "appsignal:body": expect.stringContaining("unknown-instrumentation")
+        "appsignal:category": "unknown"
       }),
       parent_span_id: "",
       error: null


### PR DESCRIPTION
- Remove fallback for unknown span body. The notice about a missing extractor is now a trace level log.
- Filter root span attributes that are set as tags, params, headers, etc.
- Filter more root span attributes that can contain PII information.
- Improve http extractor span name to use `http.route` attribute to always build the incident action name. This should avoid new incidents with `HTTP POST`-like naming.

[skip review]