### PR TITLE
Bump agent to version 9046191

### DIFF
--- a/.changesets/bump-agent-v-9046191-http-proxy.md
+++ b/.changesets/bump-agent-v-9046191-http-proxy.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Update the AppSignal agent version to fix an issue with the HTTP proxy where the proxy port would always be set to 8080.

--- a/.changesets/bump-agent-v-9046191.md
+++ b/.changesets/bump-agent-v-9046191.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "add"
+---
+
+Update the AppSignal agent version to add Nest.js support.

--- a/scripts/extension/support/constants.js
+++ b/scripts/extension/support/constants.js
@@ -3,7 +3,7 @@
 // appsignal-agent repository.
 // Modifications to this file will be overwritten with the next agent release.
 
-const AGENT_VERSION = "de2dd6e"
+const AGENT_VERSION = "9046191"
 const MIRRORS = [
   "https://appsignal-agent-releases.global.ssl.fastly.net",
   "https://d135dj0rjqvssy.cloudfront.net"
@@ -12,67 +12,67 @@ const MIRRORS = [
 const TRIPLES = {
   "x86_64-darwin": {
     checksum:
-      "95dcfb45b90551ffe2d2297ada64598fb117e1d76a75417940d525c853f91592",
+      "d4a44bb6c4caeabb874424c8daae7cdb982773afa0eafd0b37b8533cd68c5b93",
     filename: "appsignal-x86_64-darwin-all-static.tar.gz"
   },
   "universal-darwin": {
     checksum:
-      "95dcfb45b90551ffe2d2297ada64598fb117e1d76a75417940d525c853f91592",
+      "d4a44bb6c4caeabb874424c8daae7cdb982773afa0eafd0b37b8533cd68c5b93",
     filename: "appsignal-x86_64-darwin-all-static.tar.gz"
   },
   "aarch64-darwin": {
     checksum:
-      "16e604e0835f90a23de20497bba58e29e633cce5cff9b994b9cca219f35abd83",
+      "0ac14b73df8238b542f5d93622959444e4c5041aaac458cc772c6210c74bb901",
     filename: "appsignal-aarch64-darwin-all-static.tar.gz"
   },
   "arm64-darwin": {
     checksum:
-      "16e604e0835f90a23de20497bba58e29e633cce5cff9b994b9cca219f35abd83",
+      "0ac14b73df8238b542f5d93622959444e4c5041aaac458cc772c6210c74bb901",
     filename: "appsignal-aarch64-darwin-all-static.tar.gz"
   },
   "arm-darwin": {
     checksum:
-      "16e604e0835f90a23de20497bba58e29e633cce5cff9b994b9cca219f35abd83",
+      "0ac14b73df8238b542f5d93622959444e4c5041aaac458cc772c6210c74bb901",
     filename: "appsignal-aarch64-darwin-all-static.tar.gz"
   },
   "aarch64-linux": {
     checksum:
-      "51270f21e843b53824854c184ea52bc95be2a25c761ef2e930b0b0d02d8e07da",
+      "229f509e0a04b47051873e4a253dbbb6965f9cc62bd79902977cbb5257c91904",
     filename: "appsignal-aarch64-linux-all-static.tar.gz"
   },
   "i686-linux": {
     checksum:
-      "8efe967ded49ba2cef2cabf67f97e4dfe242fb9fba4fd02f848a22d6e5ae7165",
+      "089929e5ec207871e6562fe70bdf5b236ef9473e14e6797ddbffda310d95cf8c",
     filename: "appsignal-i686-linux-all-static.tar.gz"
   },
   "x86-linux": {
     checksum:
-      "8efe967ded49ba2cef2cabf67f97e4dfe242fb9fba4fd02f848a22d6e5ae7165",
+      "089929e5ec207871e6562fe70bdf5b236ef9473e14e6797ddbffda310d95cf8c",
     filename: "appsignal-i686-linux-all-static.tar.gz"
   },
   "x86_64-linux": {
     checksum:
-      "7d27b3a7f59d9a3515cd7d0403e19dd618452b15444d87d42197d43227e4a539",
+      "e93022433b6f4bc7bc882aeb49a5d43a004f017d41569a3459c7109768021cbb",
     filename: "appsignal-x86_64-linux-all-static.tar.gz"
   },
   "x86_64-linux-musl": {
     checksum:
-      "4ee8fb0e743634a4365113114d4a077779b2773f521e5a71e917d210d9ffe07b",
+      "1b66a0ce1ecc375dad8059df99b5bd0bc1e1723228b1256f09dee6124fa4576a",
     filename: "appsignal-x86_64-linux-musl-all-static.tar.gz"
   },
   "aarch64-linux-musl": {
     checksum:
-      "d1a19f4ba04849ceb3ad44ff254fd15a7c12dacffc1c3d58be6705a59395cbe2",
+      "0b6b59ce4f1e2bc8bea6f1743e9f52dde99f39aba2922aa125cde9a1d498b52d",
     filename: "appsignal-aarch64-linux-musl-all-static.tar.gz"
   },
   "x86_64-freebsd": {
     checksum:
-      "93a7b1235a230d09f9416b01ed04f902b775b069a292d79c659f0aefa02afe05",
+      "12301c2346f1654558bf6c95f605b3ca1a95433fcab3aaf303ceea59b175dcf8",
     filename: "appsignal-x86_64-freebsd-all-static.tar.gz"
   },
   "amd64-freebsd": {
     checksum:
-      "93a7b1235a230d09f9416b01ed04f902b775b069a292d79c659f0aefa02afe05",
+      "12301c2346f1654558bf6c95f605b3ca1a95433fcab3aaf303ceea59b175dcf8",
     filename: "appsignal-x86_64-freebsd-all-static.tar.gz"
   }
 }


### PR DESCRIPTION
Add support for Nest.js details extraction.