### PR TITLE
Add OpenTelemetry SpanKind as a magic attribute

### DIFF
--- a/.changesets/add-opentelemetry-spankind-as-a-magic-attribute.md
+++ b/.changesets/add-opentelemetry-spankind-as-a-magic-attribute.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "add"
+---
+
+Add OpenTelemetry SpanKind as a magic attribute

--- a/src/__tests__/span_processor.test.ts
+++ b/src/__tests__/span_processor.test.ts
@@ -122,4 +122,20 @@ describe("Span processor", () => {
       })
     )
   })
+
+  it("gets the span kind as an attribute", () => {
+    tracer.startSpan("kindSpan").end()
+
+    expect(SpanTestRegistry.count()).toEqual(1)
+    expect(SpanTestRegistry.lastSpan()?.toObject()).toMatchObject({
+      name: "kindSpan",
+      closed: true,
+      attributes: expect.objectContaining({
+        "appsignal:category": "unknown",
+        "appsignal.kind": "INTERNAL"
+      }),
+      parent_span_id: "",
+      error: null
+    })
+  })
 })

--- a/src/span_processor.ts
+++ b/src/span_processor.ts
@@ -1,5 +1,6 @@
 import * as fs from "fs"
 import type { Context } from "@opentelemetry/api"
+import { SpanKind } from "@opentelemetry/api"
 import type {
   Span,
   ReadableSpan,
@@ -22,6 +23,12 @@ export class SpanProcessor implements OpenTelemetrySpanProcessor {
   onStart(_span: Span, _parentContext: Context): void {}
 
   onEnd(span: ReadableSpan): void {
+    // Add OpenTelemetry kind enum value as a magic attribute
+    const spanAttributes = {
+      ...span.attributes,
+      "appsignal.kind": SpanKind[span.kind]
+    }
+
     const opentelemetrySpan = this.client.extension.createOpenTelemetrySpan(
       span.spanContext().spanId,
       span.parentSpanId || "",
@@ -31,7 +38,7 @@ export class SpanProcessor implements OpenTelemetrySpanProcessor {
       span.endTime[0],
       span.endTime[1],
       span.name,
-      span.attributes,
+      spanAttributes,
       span.instrumentationLibrary.name
     )
 


### PR DESCRIPTION
To identify the origin of the HTTP requests from their spans, the `SpanKind` attribute is needed. As adding a completely new attribute will add a lot of overhead requiring modifications in all steps, the attribute is now added from the SpanProcessor as a magic attribute.

More info on OpenTelemetry's SpanKind:
https://opentelemetry.io/docs/reference/specification/trace/api/#spankind

Fixes: https://github.com/appsignal/opentelemetry/issues/42