### PR TITLE
Move integration test config helpers to module

### DIFF
--- a/test/express-apollo/tests/spec/app_spec.rb
+++ b/test/express-apollo/tests/spec/app_spec.rb
@@ -4,7 +4,7 @@ require "http"
 
 RSpec.describe "Express Apollo app" do
   before(:all) do
-    @test_app_url = URI(ENV.fetch("TEST_APP_URL"))
+    @test_app_url = ConfigHelper.test_app_url
   end
 
   describe("POST /graphql querying for all books and authors") do

--- a/test/express-mongoose/tests/spec/app_spec.rb
+++ b/test/express-mongoose/tests/spec/app_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe "Prisma app" do
   before(:all) do
-    @test_app_url = ENV.fetch("TEST_APP_URL")
+    @test_app_url = ConfigHelper.test_app_url
   end
 
   describe("GET /") do

--- a/test/express-postgres/tests/spec/app_spec.rb
+++ b/test/express-postgres/tests/spec/app_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe "Postgres app" do
   before(:all) do
-    @test_app_url = ENV.fetch("TEST_APP_URL")
+    @test_app_url = ConfigHelper.test_app_url
   end
 
   describe("GET /pg-query") do

--- a/test/express-prisma-mongo/tests/spec/app_spec.rb
+++ b/test/express-prisma-mongo/tests/spec/app_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe "Prisma app" do
   before(:all) do
-    @test_app_url = ENV.fetch("TEST_APP_URL")
+    @test_app_url = ConfigHelper.test_app_url
   end
 
   describe("GET /") do

--- a/test/express-prisma-postgres/tests/spec/app_spec.rb
+++ b/test/express-prisma-postgres/tests/spec/app_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe "Prisma app" do
   before(:all) do
-    @test_app_url = ENV.fetch("TEST_APP_URL")
+    @test_app_url = ConfigHelper.test_app_url
   end
 
   describe("GET /") do

--- a/test/express-redis/tests/spec/app_spec.rb
+++ b/test/express-redis/tests/spec/app_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe "Redis app" do
   before(:all) do
-    @test_app_url = ENV.fetch("TEST_APP_URL")
+    @test_app_url = ConfigHelper.test_app_url
   end
 
   describe "GET / with params" do

--- a/test/express-yoga/tests/spec/app_spec.rb
+++ b/test/express-yoga/tests/spec/app_spec.rb
@@ -4,7 +4,7 @@ require "http"
 
 RSpec.describe "Express Yoga app" do
   before(:all) do
-    @test_app_url = URI(ENV.fetch("TEST_APP_URL"))
+    @test_app_url = ConfigHelper.test_app_url
   end
 
   describe("POST /graphql querying for all books and authors") do

--- a/test/fastify/tests/spec/app_spec.rb
+++ b/test/fastify/tests/spec/app_spec.rb
@@ -4,7 +4,7 @@ require "http"
 
 RSpec.describe "Fastify app" do
   before(:all) do
-    @test_app_url = URI(ENV.fetch("TEST_APP_URL"))
+    @test_app_url = ConfigHelper.test_app_url
   end
 
   describe("GET /") do

--- a/test/helpers/config_helper.rb
+++ b/test/helpers/config_helper.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class ConfigHelper
+  class << self
+    def test_app_url
+      ENV.fetch("TEST_APP_URL", "http://localhost:4001")
+    end
+
+    def spans_file_path
+      ENV.fetch("SPANS_FILE_PATH", "/tmp/appsignal_spans.json")
+    end
+  end
+end

--- a/test/helpers/integration_helper.rb
+++ b/test/helpers/integration_helper.rb
@@ -1,15 +1,14 @@
 # frozen_string_literal: true
 
-module IntegrationHelper
-  SPANS_FILE_PATH = ENV.fetch("SPANS_FILE_PATH")
-  TEST_APP_URL = ENV.fetch("TEST_APP_URL")
+require_relative "./config_helper"
 
+module IntegrationHelper
   def self.wait_for_start
     max_retries = 1200
     retries = 0
 
     begin
-      HTTP.timeout(1).get("#{TEST_APP_URL}/")
+      HTTP.timeout(1).get("#{ConfigHelper.test_app_url}/")
       puts "The app has started!"
     rescue HTTP::ConnectionError, HTTP::TimeoutError
       if retries >= max_retries

--- a/test/helpers/span.rb
+++ b/test/helpers/span.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
+require_relative "./config_helper"
+
 class Span
   class << self
-    SPANS_FILE_PATH = ENV.fetch("SPANS_FILE_PATH")
-
     def all
       # Wait for spans that haven't been written yet
       sleep 1
-      File.readlines(SPANS_FILE_PATH).map do |line|
+      File.readlines(ConfigHelper.spans_file_path).map do |line|
         new(JSON.parse(line))
       end
     end
@@ -34,7 +34,7 @@ class Span
     end
 
     def clear_all
-      File.open(SPANS_FILE_PATH, "w").close
+      File.open(ConfigHelper.spans_file_path, "w").close
     end
 
     def roots

--- a/test/koa-mongo/tests/spec/app_spec.rb
+++ b/test/koa-mongo/tests/spec/app_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe "Koa + Mongo app" do
   before(:all) do
-    @test_app_url = ENV.fetch("TEST_APP_URL")
+    @test_app_url = ConfigHelper.test_app_url
   end
 
   describe "GET /" do

--- a/test/koa-mysql/tests/spec/app_spec.rb
+++ b/test/koa-mysql/tests/spec/app_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe "Koa + MySQL app" do
   before(:all) do
-    @test_app_url = ENV.fetch("TEST_APP_URL")
+    @test_app_url = ConfigHelper.test_app_url
   end
 
   describe "GET /get" do

--- a/test/nestjs/tests/spec/app_spec.rb
+++ b/test/nestjs/tests/spec/app_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe "NestJS APP" do
   before(:all) do
-    @test_app_url = ENV.fetch("TEST_APP_URL")
+    @test_app_url = ConfigHelper.test_app_url
   end
 
   describe "GET /" do

--- a/test/nextjs/tests/spec/app_spec.rb
+++ b/test/nextjs/tests/spec/app_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe "NextJS app" do
   before(:all) do
-    @test_app_url = ENV.fetch("TEST_APP_URL")
+    @test_app_url = ConfigHelper.test_app_url
   end
 
   describe("GET /") do


### PR DESCRIPTION
Instead of repeating the `ENV.fetch(...)` code everywhere the environment variables are read, move this logic to a helper.

Whenever we change the ENV var name or add additional checks to this value, it will be easier to update.

I also added some defaults, so it's easier to run locally. Those defaults are for running it locally and do not match the Docker test env.

I wanted to quickly run one of the test apps to see what kind of span attributes are available for a GraphQL span.

Related to https://github.com/appsignal/appsignal-nodejs/issues/792
[skip changeset]