### PR TITLE
Add noop user and integration logger

### DIFF
--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -2,8 +2,10 @@ import { InstrumentationTestRegistry } from "../../test/instrumentation_registry
 import { Extension } from "../extension"
 import { Client } from "../client"
 import { Metrics } from "../metrics"
-import { NoopMetrics } from "../noops"
+import { NoopIntegrationLogger, NoopLogger, NoopMetrics } from "../noops"
 import { Instrumentation } from "@opentelemetry/instrumentation"
+import { BaseIntegrationLogger } from "../integration_logger"
+import { BaseLogger } from "../logger"
 
 describe("Client", () => {
   const name = "TEST APP"
@@ -58,21 +60,48 @@ describe("Client", () => {
     expect(Client.integrationLogger).toEqual(client.integrationLogger)
   })
 
+  it("returns a noop integration logger if the client has not been initialised", () => {
+    global.__APPSIGNAL__ = undefined as any
+    expect(Client.integrationLogger).toBeInstanceOf(NoopIntegrationLogger)
+  })
+
+  it("returns the user logger from global object if the client is active", () => {
+    client = new Client({ ...DEFAULT_OPTS, active: true })
+    expect(Client.logger("groupname")).toBeInstanceOf(BaseLogger)
+  })
+
+  it("returns a noop user logger if the client is not active", () => {
+    expect(Client.logger("groupname")).toBeInstanceOf(NoopLogger)
+  })
+
+  it("returns a noop user logger if the client has not been initialised", () => {
+    global.__APPSIGNAL__ = undefined as any
+    expect(Client.logger("groupname")).toBeInstanceOf(NoopLogger)
+  })
+
   it("sets the integration logger level to info by default and uses a file transport", () => {
-    expect(Client.integrationLogger.type).toEqual("file")
-    expect(Client.integrationLogger.level).toEqual("info")
+    expect((Client.integrationLogger as BaseIntegrationLogger).type).toEqual(
+      "file"
+    )
+    expect((Client.integrationLogger as BaseIntegrationLogger).level).toEqual(
+      "info"
+    )
   })
 
   it("sets the integration logger level to the translated one", () => {
     client = new Client({ ...DEFAULT_OPTS, logLevel: "trace" })
 
-    expect(Client.integrationLogger.level).toEqual("silly")
+    expect((Client.integrationLogger as BaseIntegrationLogger).level).toEqual(
+      "silly"
+    )
   })
 
   it("uses a console transport for integration logging if specified", () => {
     client = new Client({ ...DEFAULT_OPTS, log: "stdout" })
 
-    expect(Client.integrationLogger.type).toEqual("stdout")
+    expect((Client.integrationLogger as BaseIntegrationLogger).type).toEqual(
+      "stdout"
+    )
   })
 
   it("does not start the client if the config is not valid", () => {

--- a/src/__tests__/integration_logger.test.ts
+++ b/src/__tests__/integration_logger.test.ts
@@ -1,10 +1,10 @@
-import { IntegrationLogger } from "../integration_logger"
+import { BaseIntegrationLogger } from "../integration_logger"
 
-describe("IntegrationLogger", () => {
-  let logger: IntegrationLogger
+describe("BaseIntegrationLogger", () => {
+  let logger: BaseIntegrationLogger
 
   beforeEach(() => {
-    logger = new IntegrationLogger("stdout", "trace")
+    logger = new BaseIntegrationLogger("stdout", "trace")
   })
 
   it("sends errors to winston", () => {
@@ -43,22 +43,22 @@ describe("IntegrationLogger", () => {
   })
 
   it("sets the proper npm log levels from our log levels", () => {
-    logger = new IntegrationLogger("stdout", "error")
+    logger = new BaseIntegrationLogger("stdout", "error")
     expect(logger.level).toEqual("error")
 
-    logger = new IntegrationLogger("stdout", "warning")
+    logger = new BaseIntegrationLogger("stdout", "warning")
     expect(logger.level).toEqual("warn")
 
-    logger = new IntegrationLogger("stdout", "info")
+    logger = new BaseIntegrationLogger("stdout", "info")
     expect(logger.level).toEqual("info")
 
-    logger = new IntegrationLogger("stdout", "debug")
+    logger = new BaseIntegrationLogger("stdout", "debug")
     expect(logger.level).toEqual("debug")
 
-    logger = new IntegrationLogger("stdout", "trace")
+    logger = new BaseIntegrationLogger("stdout", "trace")
     expect(logger.level).toEqual("silly")
 
-    logger = new IntegrationLogger("stdout", "fooBarBaz")
+    logger = new BaseIntegrationLogger("stdout", "fooBarBaz")
     expect(logger.level).toEqual("info")
   })
 })

--- a/src/__tests__/logger.test.ts
+++ b/src/__tests__/logger.test.ts
@@ -1,8 +1,8 @@
 import { Client } from "../client"
-import { Logger, LoggerLevel } from "../logger"
+import { BaseLogger, LoggerLevel } from "../logger"
 
-describe("Logger", () => {
-  let logger: Logger
+describe("BaseLogger", () => {
+  let logger: BaseLogger
   let client: Client
 
   beforeAll(() => {
@@ -15,7 +15,7 @@ describe("Logger", () => {
   beforeEach(() => {
     client.extension.log = jest.fn()
     client.integrationLogger.warn = jest.fn()
-    logger = client.logger("groupname")
+    logger = new BaseLogger(client, "groupname")
   })
 
   it("defaults to an info logger level", () => {
@@ -24,7 +24,7 @@ describe("Logger", () => {
   })
 
   it("sets an info logger level when the severity is unknown and logs a warning", () => {
-    logger = client.logger("groupname", "bacon" as LoggerLevel)
+    logger = new BaseLogger(client, "groupname", "bacon" as LoggerLevel)
     expect(logger.severityThreshold).toEqual(3)
     expect(client.integrationLogger.warn).toHaveBeenCalledWith(
       expect.stringContaining(`"bacon"`)
@@ -32,12 +32,24 @@ describe("Logger", () => {
   })
 
   it("sets the right severity threshold for a known logger level", () => {
-    expect(client.logger("groupname", "trace").severityThreshold).toEqual(1)
-    expect(client.logger("groupname", "debug").severityThreshold).toEqual(2)
-    expect(client.logger("groupname", "info").severityThreshold).toEqual(3)
-    expect(client.logger("groupname", "log").severityThreshold).toEqual(4)
-    expect(client.logger("groupname", "warn").severityThreshold).toEqual(5)
-    expect(client.logger("groupname", "error").severityThreshold).toEqual(6)
+    expect(
+      new BaseLogger(client, "groupname", "trace").severityThreshold
+    ).toEqual(1)
+    expect(
+      new BaseLogger(client, "groupname", "debug").severityThreshold
+    ).toEqual(2)
+    expect(
+      new BaseLogger(client, "groupname", "info").severityThreshold
+    ).toEqual(3)
+    expect(
+      new BaseLogger(client, "groupname", "log").severityThreshold
+    ).toEqual(4)
+    expect(
+      new BaseLogger(client, "groupname", "warn").severityThreshold
+    ).toEqual(5)
+    expect(
+      new BaseLogger(client, "groupname", "error").severityThreshold
+    ).toEqual(6)
   })
 
   it("logs to the extension if at or above the logger level", () => {

--- a/src/integration_logger.ts
+++ b/src/integration_logger.ts
@@ -1,7 +1,15 @@
 import winston from "winston"
 const { combine, timestamp, printf } = winston.format
 
-export class IntegrationLogger {
+export interface IntegrationLogger {
+  error(message: string): void
+  warn(message: string): void
+  info(message: string): void
+  debug(message: string): void
+  trace(message: string): void
+}
+
+export class BaseIntegrationLogger {
   type: string
   level: string
   logger: winston.Logger

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -2,7 +2,7 @@ import { Client } from "./client"
 
 export type LoggerLevel = "trace" | "debug" | "info" | "log" | "warn" | "error"
 
-type LoggerAttributes = Record<string, string | number | boolean>
+export type LoggerAttributes = Record<string, string | number | boolean>
 
 const LOGGER_LEVEL_SEVERITY: Record<LoggerLevel, number> = {
   trace: 1,
@@ -19,7 +19,16 @@ function severity(level: LoggerLevel) {
   return LOGGER_LEVEL_SEVERITY[level] ?? UNKNOWN_SEVERITY
 }
 
-export class Logger {
+export interface Logger {
+  trace(message: string, attributes?: LoggerAttributes): void
+  debug(message: string, attributes?: LoggerAttributes): void
+  info(message: string, attributes?: LoggerAttributes): void
+  log(message: string, attributes?: LoggerAttributes): void
+  warn(message: string, attributes?: LoggerAttributes): void
+  error(message: string, attributes?: LoggerAttributes): void
+}
+
+export class BaseLogger implements Logger {
   #client: Client
   #group: string
   severityThreshold: number

--- a/src/noops/index.ts
+++ b/src/noops/index.ts
@@ -1,1 +1,3 @@
 export * from "./metrics"
+export * from "./integration_logger"
+export * from "./logger"

--- a/src/noops/integration_logger.ts
+++ b/src/noops/integration_logger.ts
@@ -1,0 +1,21 @@
+import { IntegrationLogger } from "../integration_logger"
+
+export class NoopIntegrationLogger implements IntegrationLogger {
+  error(_message: string) {
+    // noop
+  }
+  warn(_message: string) {
+    // noop
+  }
+  info(_message: string) {
+    // noop
+  }
+  debug(_message: string) {
+    // noop
+  }
+  trace(_message: string) {
+    // noop
+  }
+}
+
+export const noopIntegrationLogger = new NoopIntegrationLogger()

--- a/src/noops/logger.ts
+++ b/src/noops/logger.ts
@@ -1,0 +1,24 @@
+import { Logger, LoggerAttributes } from "../logger"
+
+export class NoopLogger implements Logger {
+  trace(_message: string, _attributes?: LoggerAttributes) {
+    // noop
+  }
+  debug(_message: string, _attributes?: LoggerAttributes) {
+    // noop
+  }
+  info(_message: string, _attributes?: LoggerAttributes) {
+    // noop
+  }
+  log(_message: string, _attributes?: LoggerAttributes) {
+    // noop
+  }
+  warn(_message: string, _attributes?: LoggerAttributes) {
+    // noop
+  }
+  error(_message: string, _attributes?: LoggerAttributes) {
+    // noop
+  }
+}
+
+export const noopLogger = new NoopLogger()


### PR DESCRIPTION
This makes it safe for our code to call `Client.integrationLogger` if the client is not initialised. For example, when running scripts that do not `--require './appsignal.cjs'` (such as test scripts) but that may call code that indirectly attempts to use the integration logger (such as the custom instrumentation helpers)

It also makes it safe for users to call `Client.logger("foo")` and call methods on that logger when the client is not active or is not initialized. This allows users who integrate our AppSignal logger into their code to use that same code in contexts where AppSignal is not active or initialised.