### PR TITLE
Rebuild test app if changed

### DIFF
--- a/script/integration_test_app
+++ b/script/integration_test_app
@@ -13,11 +13,11 @@ fi
 
 test_app_path="test/$app"
 
-if [ ! -d $test_app_path ]; then
+if [ ! -d "$test_app_path" ]; then
   echo "Not test directory for app $app in $test_app_path"
   echo "Please check if the directory exists in the tests/ directory"
   exit 1
 fi
 
-cd $test_app_path
+cd "$test_app_path"
 docker-compose up --abort-on-container-exit --exit-code-from tests

--- a/script/integration_test_app
+++ b/script/integration_test_app
@@ -20,4 +20,4 @@ if [ ! -d "$test_app_path" ]; then
 fi
 
 cd "$test_app_path"
-docker-compose up --abort-on-container-exit --exit-code-from tests
+docker-compose up --abort-on-container-exit --exit-code-from tests --build


### PR DESCRIPTION
## Fix Shellcheck errors in test script

Error reported:
- SC2086: Double quote to prevent globbing and word splitting.

## Rebuild test app if changed

I spent a non-trivial amount figuring out why the test apps were testing
some unrelated endpoint from a test app I copied. Turns out the Docker
image for the "tests" container wasn't rebuilt when I changed it.

Add the `--build` flag to the `docker-compose up` command to rebuild it
if something in the `tests/` directory or the Dockerfile itself has
changed.


---

[skip changeset]