### PR TITLE
Fix test suite for Node.js 19.1

### DIFF
--- a/src/__tests__/transmitter.test.ts
+++ b/src/__tests__/transmitter.test.ts
@@ -267,7 +267,8 @@ describe("Transmitter", () => {
       nock("http://example.invalid")
         .get("/301")
         .reply(301, undefined, {
-          Location: "http://example.invalid/302"
+          Location: "http://example.invalid/302",
+          FooHeader: "Location"
         })
         .get("/302")
         .reply(302, undefined, {


### PR DESCRIPTION
The header setters are now no-op functions since Node.js 19.1. Nock, the http mocking library we use for our transmitter tests uses these setters so our tests break. This commit uses the `rawHeaders` attribute instead to get green tests until the issue is fixed on either side.

More info: https://github.com/nodejs/node/issues/45510

[skip changeset]