### PR TITLE
Bump agent to version 0c870c0

### DIFF
--- a/scripts/extension/support/constants.js
+++ b/scripts/extension/support/constants.js
@@ -3,7 +3,7 @@
 // appsignal-agent repository.
 // Modifications to this file will be overwritten with the next agent release.
 
-const AGENT_VERSION = "9b62288"
+const AGENT_VERSION = "0c870c0"
 const MIRRORS = [
   "https://appsignal-agent-releases.global.ssl.fastly.net",
   "https://d135dj0rjqvssy.cloudfront.net"
@@ -12,67 +12,67 @@ const MIRRORS = [
 const TRIPLES = {
   "x86_64-darwin": {
     checksum:
-      "5ff2ec4f16f5089e15188670b2c43866c76ab5db2ac07d72878a9816e63171ca",
+      "13d2676d2c2b0d4feff4af8eeafd0f1259bffa7e2bca6843301c6b177fec89de",
     filename: "appsignal-x86_64-darwin-all-static.tar.gz"
   },
   "universal-darwin": {
     checksum:
-      "5ff2ec4f16f5089e15188670b2c43866c76ab5db2ac07d72878a9816e63171ca",
+      "13d2676d2c2b0d4feff4af8eeafd0f1259bffa7e2bca6843301c6b177fec89de",
     filename: "appsignal-x86_64-darwin-all-static.tar.gz"
   },
   "aarch64-darwin": {
     checksum:
-      "9dfdfd6697b3eeeb80a30356fdc1d03a79b8601f18cedd1b2c1442e512d2ed6a",
+      "1fe7db059d84a2aac2f7fd939b055b125355f39c10eeb975cb8725d3ece12039",
     filename: "appsignal-aarch64-darwin-all-static.tar.gz"
   },
   "arm64-darwin": {
     checksum:
-      "9dfdfd6697b3eeeb80a30356fdc1d03a79b8601f18cedd1b2c1442e512d2ed6a",
+      "1fe7db059d84a2aac2f7fd939b055b125355f39c10eeb975cb8725d3ece12039",
     filename: "appsignal-aarch64-darwin-all-static.tar.gz"
   },
   "arm-darwin": {
     checksum:
-      "9dfdfd6697b3eeeb80a30356fdc1d03a79b8601f18cedd1b2c1442e512d2ed6a",
+      "1fe7db059d84a2aac2f7fd939b055b125355f39c10eeb975cb8725d3ece12039",
     filename: "appsignal-aarch64-darwin-all-static.tar.gz"
   },
   "aarch64-linux": {
     checksum:
-      "0e5d89aeda1e883c912ff069bb76029a1e3cad69f493865d877ffaffa2b45142",
+      "61bb2c0a2314b174b85785f37aa0dcc2587bba62d9156118cd222bf3e90b12cf",
     filename: "appsignal-aarch64-linux-all-static.tar.gz"
   },
   "i686-linux": {
     checksum:
-      "ff3cffb1204afd846ba0bb33c50b03f8ada8305527a5908ccfebed6fdcce0e61",
+      "547912aacbecb396af356564971b6d2d2494320c7533362edc3818f44080feac",
     filename: "appsignal-i686-linux-all-static.tar.gz"
   },
   "x86-linux": {
     checksum:
-      "ff3cffb1204afd846ba0bb33c50b03f8ada8305527a5908ccfebed6fdcce0e61",
+      "547912aacbecb396af356564971b6d2d2494320c7533362edc3818f44080feac",
     filename: "appsignal-i686-linux-all-static.tar.gz"
   },
   "x86_64-linux": {
     checksum:
-      "0b6fe4b343461a1a906fc73edb44bc5b12c75214d21fc81ed26d3eb88588003e",
+      "39b4cd3d3e648c8d8de52720bf4794328f454ae43f130cd67dafbf88c9070b90",
     filename: "appsignal-x86_64-linux-all-static.tar.gz"
   },
   "x86_64-linux-musl": {
     checksum:
-      "b3f52d7a7a1f4ae8095dd5b1207270dc1797766820d925aca0d09133983c9163",
+      "ca14cf60bab664600d90cc9b13239e60dd68e4005f78d401e3d41442dcbc0471",
     filename: "appsignal-x86_64-linux-musl-all-static.tar.gz"
   },
   "aarch64-linux-musl": {
     checksum:
-      "d306c50cc9f1bc8ea3339b4185b2a60a1c27f17d9067a529b1889d74c6c0a8d6",
+      "016b90274bcedf02253244b44cd93b85b1baf4d5a6b2f9761f9ab15b8c895198",
     filename: "appsignal-aarch64-linux-musl-all-static.tar.gz"
   },
   "x86_64-freebsd": {
     checksum:
-      "135d2ff898f30b15721eca36569d1a0a5deaaee7b4787937d0888ed49f25019b",
+      "0dc94715af8cc8dbbc21237e4675c4bbaf5f418c0ec10e1fb1f89cf1786602fc",
     filename: "appsignal-x86_64-freebsd-all-static.tar.gz"
   },
   "amd64-freebsd": {
     checksum:
-      "135d2ff898f30b15721eca36569d1a0a5deaaee7b4787937d0888ed49f25019b",
+      "0dc94715af8cc8dbbc21237e4675c4bbaf5f418c0ec10e1fb1f89cf1786602fc",
     filename: "appsignal-x86_64-freebsd-all-static.tar.gz"
   }
 }


### PR DESCRIPTION
Update the agent version to perform hoisting on the agent instead of in the processor, and to use the merged version of the logging branch.