### PR TITLE
Track OS distro in diagnose report

### DIFF
--- a/.changesets/track-the-operating-system-release-distro-in-the-diagnose-report.md
+++ b/.changesets/track-the-operating-system-release-distro-in-the-diagnose-report.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "add"
+---
+
+Track the Operating System release/distro in the diagnose report. This helps us with debugging what exact version of Linux an app is running on, for example.

--- a/src/diagnose.ts
+++ b/src/diagnose.ts
@@ -79,10 +79,24 @@ export class DiagnoseTool {
     return {
       architecture: process.arch,
       os: process.platform,
+      os_distribution: this.getOsDistribution(),
       language_version: process.versions.node,
       heroku,
       root: processGetuid() === 0,
       running_in_container: this.#extension.runningInContainer()
+    }
+  }
+
+  private getOsDistribution() {
+    const path = "/etc/os-release"
+    if (fs.existsSync(path)) {
+      try {
+        return fs.readFileSync(path, "utf8")
+      } catch (error) {
+        return `Error reading ${path}: ${error}`
+      }
+    } else {
+      return ""
     }
   }
 


### PR DESCRIPTION
This helps us with debugging what exact version of Linux an app is running on, for example.

Part of https://github.com/appsignal/support/issues/206