### PR TITLE
Bump agent to version c0e80b9

### DIFF
--- a/.changesets/remove-client-ip-from-http-traces.md
+++ b/.changesets/remove-client-ip-from-http-traces.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Remove client IP from HTTP traces

--- a/scripts/extension/support/constants.js
+++ b/scripts/extension/support/constants.js
@@ -3,7 +3,7 @@
 // appsignal-agent repository.
 // Modifications to this file will be overwritten with the next agent release.
 
-const AGENT_VERSION = "0c870c0"
+const AGENT_VERSION = "c0e80b9"
 const MIRRORS = [
   "https://appsignal-agent-releases.global.ssl.fastly.net",
   "https://d135dj0rjqvssy.cloudfront.net"
@@ -12,67 +12,67 @@ const MIRRORS = [
 const TRIPLES = {
   "x86_64-darwin": {
     checksum:
-      "13d2676d2c2b0d4feff4af8eeafd0f1259bffa7e2bca6843301c6b177fec89de",
+      "c0e1fc966eff49dd942ed07b44f5c5db6be41676f4e35530c300bac8f99e03c4",
     filename: "appsignal-x86_64-darwin-all-static.tar.gz"
   },
   "universal-darwin": {
     checksum:
-      "13d2676d2c2b0d4feff4af8eeafd0f1259bffa7e2bca6843301c6b177fec89de",
+      "c0e1fc966eff49dd942ed07b44f5c5db6be41676f4e35530c300bac8f99e03c4",
     filename: "appsignal-x86_64-darwin-all-static.tar.gz"
   },
   "aarch64-darwin": {
     checksum:
-      "1fe7db059d84a2aac2f7fd939b055b125355f39c10eeb975cb8725d3ece12039",
+      "37fcdf17250ce9e2149f28a8492074f5957691636ab542c7073b323a1b9dbdd8",
     filename: "appsignal-aarch64-darwin-all-static.tar.gz"
   },
   "arm64-darwin": {
     checksum:
-      "1fe7db059d84a2aac2f7fd939b055b125355f39c10eeb975cb8725d3ece12039",
+      "37fcdf17250ce9e2149f28a8492074f5957691636ab542c7073b323a1b9dbdd8",
     filename: "appsignal-aarch64-darwin-all-static.tar.gz"
   },
   "arm-darwin": {
     checksum:
-      "1fe7db059d84a2aac2f7fd939b055b125355f39c10eeb975cb8725d3ece12039",
+      "37fcdf17250ce9e2149f28a8492074f5957691636ab542c7073b323a1b9dbdd8",
     filename: "appsignal-aarch64-darwin-all-static.tar.gz"
   },
   "aarch64-linux": {
     checksum:
-      "61bb2c0a2314b174b85785f37aa0dcc2587bba62d9156118cd222bf3e90b12cf",
+      "ce9075ee5bc14ea786b734793b6bb6331567398cab6a21f2ceaa9062cfbdb373",
     filename: "appsignal-aarch64-linux-all-static.tar.gz"
   },
   "i686-linux": {
     checksum:
-      "547912aacbecb396af356564971b6d2d2494320c7533362edc3818f44080feac",
+      "ea3d1a29cf1534293738f2bd27ae29b8addf8dbe34dde77dc4ae150e109e2e4f",
     filename: "appsignal-i686-linux-all-static.tar.gz"
   },
   "x86-linux": {
     checksum:
-      "547912aacbecb396af356564971b6d2d2494320c7533362edc3818f44080feac",
+      "ea3d1a29cf1534293738f2bd27ae29b8addf8dbe34dde77dc4ae150e109e2e4f",
     filename: "appsignal-i686-linux-all-static.tar.gz"
   },
   "x86_64-linux": {
     checksum:
-      "39b4cd3d3e648c8d8de52720bf4794328f454ae43f130cd67dafbf88c9070b90",
+      "adeceb091c4ed277c29eda018ffc61fd064e5c486b2b0a239b26873168a7fdb0",
     filename: "appsignal-x86_64-linux-all-static.tar.gz"
   },
   "x86_64-linux-musl": {
     checksum:
-      "ca14cf60bab664600d90cc9b13239e60dd68e4005f78d401e3d41442dcbc0471",
+      "b57aec8c334b1d3646c80d87f20372287e4e2bdbd798c195e0e36ceeb2aac68a",
     filename: "appsignal-x86_64-linux-musl-all-static.tar.gz"
   },
   "aarch64-linux-musl": {
     checksum:
-      "016b90274bcedf02253244b44cd93b85b1baf4d5a6b2f9761f9ab15b8c895198",
+      "fc780524942fc7aeaa4cabec64dfc104c82969df7e8b5cd0fa8eae24c1c9b304",
     filename: "appsignal-aarch64-linux-musl-all-static.tar.gz"
   },
   "x86_64-freebsd": {
     checksum:
-      "0dc94715af8cc8dbbc21237e4675c4bbaf5f418c0ec10e1fb1f89cf1786602fc",
+      "574137de415487afe8d2cc29eac3b1fda2c8e1001474b8f25ebee0cbb32fb1ca",
     filename: "appsignal-x86_64-freebsd-all-static.tar.gz"
   },
   "amd64-freebsd": {
     checksum:
-      "0dc94715af8cc8dbbc21237e4675c4bbaf5f418c0ec10e1fb1f89cf1786602fc",
+      "574137de415487afe8d2cc29eac3b1fda2c8e1001474b8f25ebee0cbb32fb1ca",
     filename: "appsignal-x86_64-freebsd-all-static.tar.gz"
   }
 }


### PR DESCRIPTION
Bump the agent version to include a fix for client IPs showing up in HTTP traces.