### PR TITLE
Only instrument `fs` with parent span

### DIFF
--- a/.changesets/only-instrument-fs-with-parent-span.md
+++ b/.changesets/only-instrument-fs-with-parent-span.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Prevent creating fs-only samples by only creating an fs span if there is a parent span present.

--- a/src/client.ts
+++ b/src/client.ts
@@ -11,6 +11,7 @@ import { setParams, setSessionData } from "./helpers"
 import { BaseLogger, Logger, LoggerLevel } from "./logger"
 
 import { Instrumentation } from "@opentelemetry/instrumentation"
+import { trace } from "@opentelemetry/api"
 import {
   ExpressInstrumentation,
   ExpressLayerType
@@ -299,6 +300,11 @@ export class Client {
       },
       "@prisma/instrumentation": {
         middleware: true
+      },
+      "@opentelemetry/instrumentation-fs": {
+        createHook: () => {
+          return trace.getActiveSpan() !== undefined
+        }
       }
     }
   }


### PR DESCRIPTION
Fixes #813.

After implementing the OTel PR with the `requireParentSpan` configuration option, while ungarbling the README file in order to document it, I realised that there was an easy way to do this already available within the instrumentation. 🤦

This is that easy way. It might be good to replace this with `requireParentSpan` once/if it's merged, but it's merely a nice-to-have.