### PR TITLE
Track restify request parameters

### DIFF
--- a/.changesets/report-request-parameters-for-restify.md
+++ b/.changesets/report-request-parameters-for-restify.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "add"
+---
+
+Report request parameters for restify apps. This is reported automatically. You can disable parameter reporting with the AppSignal `sendParams: false` configuration option.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@appsignal/nodejs",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@appsignal/nodejs",
-      "version": "3.0.1",
+      "version": "3.0.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -27,7 +27,7 @@
         "@opentelemetry/instrumentation-pg": "^0.33.0",
         "@opentelemetry/instrumentation-redis": "^0.34.0",
         "@opentelemetry/instrumentation-redis-4": "^0.34.0",
-        "@opentelemetry/instrumentation-restify": "^0.31.0",
+        "@opentelemetry/instrumentation-restify": "^0.32.0",
         "@opentelemetry/sdk-node": "^0.34.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@prisma/instrumentation": "^4.4.0",
@@ -1895,9 +1895,9 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-restify": {
-      "version": "0.31.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-restify/-/instrumentation-restify-0.31.0.tgz",
-      "integrity": "sha512-b0AWFZ9+tm4Iaydt1AquBpsQty+Uv1YQ3C9Jb4/JTknWDWW63tb8FoCcALMPYDulvOgH+PPDvtvZY0Q0Imbstg==",
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-restify/-/instrumentation-restify-0.32.0.tgz",
+      "integrity": "sha512-Jyt6WVr5LGfQDYoAlavgNJLLkIUABiqKi/5C0eucrbc9XGn+BeEDo0nrzo/4yaW37VAbA0rn4c271OMHp7W5iw==",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
         "@opentelemetry/instrumentation": "^0.34.0",
@@ -12680,9 +12680,9 @@
       }
     },
     "@opentelemetry/instrumentation-restify": {
-      "version": "0.31.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-restify/-/instrumentation-restify-0.31.0.tgz",
-      "integrity": "sha512-b0AWFZ9+tm4Iaydt1AquBpsQty+Uv1YQ3C9Jb4/JTknWDWW63tb8FoCcALMPYDulvOgH+PPDvtvZY0Q0Imbstg==",
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-restify/-/instrumentation-restify-0.32.0.tgz",
+      "integrity": "sha512-Jyt6WVr5LGfQDYoAlavgNJLLkIUABiqKi/5C0eucrbc9XGn+BeEDo0nrzo/4yaW37VAbA0rn4c271OMHp7W5iw==",
       "requires": {
         "@opentelemetry/core": "^1.7.0",
         "@opentelemetry/instrumentation": "^0.33.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@opentelemetry/instrumentation-pg": "^0.33.0",
     "@opentelemetry/instrumentation-redis": "^0.34.0",
     "@opentelemetry/instrumentation-redis-4": "^0.34.0",
-    "@opentelemetry/instrumentation-restify": "^0.31.0",
+    "@opentelemetry/instrumentation-restify": "^0.32.0",
     "@opentelemetry/sdk-node": "^0.34.0",
     "@opentelemetry/sdk-trace-base": "^1.8.0",
     "@prisma/instrumentation": "^4.4.0",

--- a/test/restify/app/src/app.ts
+++ b/test/restify/app/src/app.ts
@@ -6,6 +6,7 @@ function respond(req: any, res: any, next: any) {
 }
 
 const server = restify.createServer()
+server.use(restify.plugins.queryParser())
 server.get("/", function (req: any, res: any, next: any) {
   res.send("home")
   return next()

--- a/test/restify/tests/spec/app_spec.rb
+++ b/test/restify/tests/spec/app_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe "restify app" do
 
   describe "GET /hello/:name" do
     it "creates restify spans" do
-      response = HTTP.get("#{test_app_url}/hello/world")
+      response = HTTP.get("#{test_app_url}/hello/world?query=value")
 
       expect(Span.root!).to be_http_span_with_route("GET /hello/:name")
       expect(response.code.to_i).to eq(200)
@@ -32,7 +32,8 @@ RSpec.describe "restify app" do
       expect(span.attributes).to include(
         "restify.type" => "request_handler",
         "restify.method" => "get",
-        "http.route" => "/hello/:name"
+        "http.route" => "/hello/:name",
+        "appsignal.request.parameters" => JSON.dump(:name => "world", :query => "value")
       )
     end
   end
@@ -41,7 +42,7 @@ RSpec.describe "restify app" do
     it "creates restify spans" do
       response = HTTP
         .headers("accept-version" => "~2")
-        .get("#{test_app_url}/goodbye/world")
+        .get("#{test_app_url}/goodbye/world?query=value")
 
       expect(Span.root!).to be_http_span_with_route("GET /goodbye/:name")
       expect(response.code.to_i).to eq(200)
@@ -50,7 +51,8 @@ RSpec.describe "restify app" do
       expect(span.attributes).to include(
         "restify.type" => "request_handler",
         "restify.method" => "get",
-        "http.route" => "/goodbye/:name"
+        "http.route" => "/goodbye/:name",
+        "appsignal.request.parameters" => JSON.dump(:name => "world", :query => "value")
       )
     end
   end


### PR DESCRIPTION
Upgrade to the latest restify package that includes the `requestHook` config option to report the parameters.

We only track them for the request handler layer type and not all middlewares that may be present to avoid it being set multiple times and it overwriting one another.

This relies on the `params` and `query` properties on the request. These are the parsed request params and query params for the request that are only available when the restify queryParser plugin is loaded. This avoids us having to parse it separately, and I assume it will only be necessary to track parameters if the plugin is added to the app.

Closes #787 