### PR TITLE
Remove package.json overrides

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1607,6 +1607,22 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
+    "node_modules/@opentelemetry/instrumentation-knex/node_modules/@opentelemetry/instrumentation": {
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.34.0.tgz",
+      "integrity": "sha512-VET/bOh4StOQV4vf1sAvn2JD67BhW2vPZ/ynl2gHXyafme2yB8Hs9+tr1TLzFwNGo7jwMFviFQkZjCYxMuK0AA==",
+      "dependencies": {
+        "require-in-the-middle": "^5.0.3",
+        "semver": "^7.3.2",
+        "shimmer": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
     "node_modules/@opentelemetry/instrumentation-koa": {
       "version": "0.34.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-koa/-/instrumentation-koa-0.34.0.tgz",
@@ -1902,6 +1918,22 @@
         "@opentelemetry/core": "^1.8.0",
         "@opentelemetry/instrumentation": "^0.34.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-restify/node_modules/@opentelemetry/instrumentation": {
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.34.0.tgz",
+      "integrity": "sha512-VET/bOh4StOQV4vf1sAvn2JD67BhW2vPZ/ynl2gHXyafme2yB8Hs9+tr1TLzFwNGo7jwMFviFQkZjCYxMuK0AA==",
+      "dependencies": {
+        "require-in-the-middle": "^5.0.3",
+        "semver": "^7.3.2",
+        "shimmer": "^1.2.1"
       },
       "engines": {
         "node": ">=14"
@@ -12282,7 +12314,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.8.0.tgz",
       "integrity": "sha512-6SDjwBML4Am0AQmy7z1j6HGrWDgeK8awBRUvl1PGw6HayViMk4QpnUXvv4HTHisecgVBy43NE/cstWprm8tIfw==",
       "requires": {
-        "@opentelemetry/semantic-conventions": "^1.7.0"
+        "@opentelemetry/semantic-conventions": "1.8.0"
       }
     },
     "@opentelemetry/exporter-jaeger": {
@@ -12290,9 +12322,9 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-jaeger/-/exporter-jaeger-1.8.0.tgz",
       "integrity": "sha512-3h16Sb1T/G33S+RM3yjt1t2xRuu/mi9iB172faS6qFQEclTTJru1pTK4wuWG+9GyI7uyBLfbQoXVA5/BA6gvHw==",
       "requires": {
-        "@opentelemetry/core": "^1.7.0",
+        "@opentelemetry/core": "1.8.0",
         "@opentelemetry/sdk-trace-base": "1.8.0",
-        "@opentelemetry/semantic-conventions": "^1.7.0",
+        "@opentelemetry/semantic-conventions": "1.8.0",
         "jaeger-client": "^3.15.0"
       }
     },
@@ -12302,7 +12334,7 @@
       "integrity": "sha512-x1V0daRLS6k0dhBPNNLMOP+OSrh8M60Xs9/YkuZS0+/zdbcIjNvPzo/8+dK3zOJx+j1KF0oBX9zxK0SX3PSnZw==",
       "requires": {
         "@grpc/grpc-js": "^1.7.1",
-        "@opentelemetry/core": "^1.7.0",
+        "@opentelemetry/core": "1.8.0",
         "@opentelemetry/otlp-grpc-exporter-base": "0.34.0",
         "@opentelemetry/otlp-transformer": "0.34.0",
         "@opentelemetry/resources": "1.8.0",
@@ -12314,7 +12346,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.34.0.tgz",
       "integrity": "sha512-MBtUwMvgpdoRo9iqK2eDJ8SP2xKYWeBCSu99s4cc1kg4HKKOpenXLE/6daGsSZ+QTPwd8j+9xMSd+hhBg+Bvzw==",
       "requires": {
-        "@opentelemetry/core": "^1.7.0",
+        "@opentelemetry/core": "1.8.0",
         "@opentelemetry/otlp-exporter-base": "0.34.0",
         "@opentelemetry/otlp-transformer": "0.34.0",
         "@opentelemetry/resources": "1.8.0",
@@ -12326,7 +12358,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.34.0.tgz",
       "integrity": "sha512-Ump/OyKxq1b4I01aBWSHJw8PCquZAHZh6ykplcmFBs9BZ8DIM7Jl3+zqrS8Vb7YcZ7DZTYORl8Xv/JQoQ+cFlw==",
       "requires": {
-        "@opentelemetry/core": "^1.7.0",
+        "@opentelemetry/core": "1.8.0",
         "@opentelemetry/otlp-exporter-base": "0.34.0",
         "@opentelemetry/otlp-proto-exporter-base": "0.34.0",
         "@opentelemetry/otlp-transformer": "0.34.0",
@@ -12339,10 +12371,10 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-zipkin/-/exporter-zipkin-1.8.0.tgz",
       "integrity": "sha512-Y3WqNCZjfWKnHiRzb35sXpDfGL4Gx2qajFAv059s/VFayIPytLHUOrZMiQqrpfzU/TSIKPG4OHJaypFtUtNlQQ==",
       "requires": {
-        "@opentelemetry/core": "^1.7.0",
+        "@opentelemetry/core": "1.8.0",
         "@opentelemetry/resources": "1.8.0",
         "@opentelemetry/sdk-trace-base": "1.8.0",
-        "@opentelemetry/semantic-conventions": "^1.7.0"
+        "@opentelemetry/semantic-conventions": "1.8.0"
       }
     },
     "@opentelemetry/instrumentation": {
@@ -12361,14 +12393,15 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-express/-/instrumentation-express-0.32.0.tgz",
       "integrity": "sha512-t2QOKwaZXUXQSJn4G90THpOyxyNBUyK0B059PUQpOqc/uybUo0SI8edfVlYRlcfHadG+S0fnU8QvnldmZ8AJqA==",
       "requires": {
-        "@opentelemetry/core": "^1.7.0",
-        "@opentelemetry/instrumentation": "^0.33.0",
-        "@opentelemetry/semantic-conventions": "^1.7.0",
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.34.0",
+        "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/express": "4.17.13"
       },
       "dependencies": {
         "@opentelemetry/instrumentation": {
-          "version": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.34.0.tgz",
+          "version": "0.34.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.34.0.tgz",
           "integrity": "sha512-VET/bOh4StOQV4vf1sAvn2JD67BhW2vPZ/ynl2gHXyafme2yB8Hs9+tr1TLzFwNGo7jwMFviFQkZjCYxMuK0AA==",
           "requires": {
             "require-in-the-middle": "^5.0.3",
@@ -12383,13 +12416,14 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fastify/-/instrumentation-fastify-0.31.0.tgz",
       "integrity": "sha512-HLKoG3ZY8hgK/xHwTy4CD/ybAc+cRkjal4AEE978vVeV8ArUfiN7SwQu5P97kW03lIpzJ8IDtk8UewpNe8VWyA==",
       "requires": {
-        "@opentelemetry/core": "^1.7.0",
-        "@opentelemetry/instrumentation": "^0.33.0",
-        "@opentelemetry/semantic-conventions": "^1.7.0"
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.34.0",
+        "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "dependencies": {
         "@opentelemetry/instrumentation": {
-          "version": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.34.0.tgz",
+          "version": "0.34.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.34.0.tgz",
           "integrity": "sha512-VET/bOh4StOQV4vf1sAvn2JD67BhW2vPZ/ynl2gHXyafme2yB8Hs9+tr1TLzFwNGo7jwMFviFQkZjCYxMuK0AA==",
           "requires": {
             "require-in-the-middle": "^5.0.3",
@@ -12404,13 +12438,14 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fs/-/instrumentation-fs-0.6.0.tgz",
       "integrity": "sha512-TBnEW1wthnfcYA65VJqbFtDpKqDnwTqqJ9R1tQ4qU3qrxhRhN6mMOok6XaCbT+ddCerI7fvWHtm5jYBJ00XQmw==",
       "requires": {
-        "@opentelemetry/core": "^1.7.0",
-        "@opentelemetry/instrumentation": "^0.33.0",
-        "@opentelemetry/semantic-conventions": "^1.7.0"
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.34.0",
+        "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "dependencies": {
         "@opentelemetry/instrumentation": {
-          "version": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.34.0.tgz",
+          "version": "0.34.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.34.0.tgz",
           "integrity": "sha512-VET/bOh4StOQV4vf1sAvn2JD67BhW2vPZ/ynl2gHXyafme2yB8Hs9+tr1TLzFwNGo7jwMFviFQkZjCYxMuK0AA==",
           "requires": {
             "require-in-the-middle": "^5.0.3",
@@ -12425,11 +12460,12 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-graphql/-/instrumentation-graphql-0.33.0.tgz",
       "integrity": "sha512-d3Qv847LI5JLJF3iR9+86V7K/+nUqVkNu2XJ1L1/4Ze5sih1R+722tx7IrS7UEDkkoNI0E0m74Yg9pJ0kwXMTQ==",
       "requires": {
-        "@opentelemetry/instrumentation": "^0.33.0"
+        "@opentelemetry/instrumentation": "^0.34.0"
       },
       "dependencies": {
         "@opentelemetry/instrumentation": {
-          "version": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.34.0.tgz",
+          "version": "0.34.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.34.0.tgz",
           "integrity": "sha512-VET/bOh4StOQV4vf1sAvn2JD67BhW2vPZ/ynl2gHXyafme2yB8Hs9+tr1TLzFwNGo7jwMFviFQkZjCYxMuK0AA==",
           "requires": {
             "require-in-the-middle": "^5.0.3",
@@ -12444,14 +12480,15 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.34.0.tgz",
       "integrity": "sha512-sZxpYOggRIFwdcdy1wWBGG8fwiuWWK4j3qv/rdqTwcPvrVT4iSCoPNDMZYxOcxSEP1fybq28SK43e+IKwxVElQ==",
       "requires": {
-        "@opentelemetry/core": "^1.7.0",
-        "@opentelemetry/instrumentation": "^0.33.0",
-        "@opentelemetry/semantic-conventions": "^1.7.0",
+        "@opentelemetry/core": "1.8.0",
+        "@opentelemetry/instrumentation": "0.34.0",
+        "@opentelemetry/semantic-conventions": "1.8.0",
         "semver": "^7.3.5"
       },
       "dependencies": {
         "@opentelemetry/instrumentation": {
-          "version": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.34.0.tgz",
+          "version": "0.34.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.34.0.tgz",
           "integrity": "sha512-VET/bOh4StOQV4vf1sAvn2JD67BhW2vPZ/ynl2gHXyafme2yB8Hs9+tr1TLzFwNGo7jwMFviFQkZjCYxMuK0AA==",
           "requires": {
             "require-in-the-middle": "^5.0.3",
@@ -12466,13 +12503,14 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-ioredis/-/instrumentation-ioredis-0.33.0.tgz",
       "integrity": "sha512-RhsR3PFdUNiNGnGPVoNpjrsoNWxKrdyAqSOaodE1uoVsJrVBIEKNCD4P82ccTjCuQHsa8ni0/DCt4Cxq7oNG3g==",
       "requires": {
-        "@opentelemetry/instrumentation": "^0.33.0",
-        "@opentelemetry/semantic-conventions": "^1.7.0",
+        "@opentelemetry/instrumentation": "^0.34.0",
+        "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/ioredis": "4.26.6"
       },
       "dependencies": {
         "@opentelemetry/instrumentation": {
-          "version": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.34.0.tgz",
+          "version": "0.34.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.34.0.tgz",
           "integrity": "sha512-VET/bOh4StOQV4vf1sAvn2JD67BhW2vPZ/ynl2gHXyafme2yB8Hs9+tr1TLzFwNGo7jwMFviFQkZjCYxMuK0AA==",
           "requires": {
             "require-in-the-middle": "^5.0.3",
@@ -12487,8 +12525,20 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-knex/-/instrumentation-knex-0.31.0.tgz",
       "integrity": "sha512-BqEFTckHDYgD9sPNhdkoL5BHbGevFoPK2XTKBTZah2DR4rD48G8ntsE8K6kt17lA1Q1jgdqe4U690UxGC6/m3g==",
       "requires": {
-        "@opentelemetry/instrumentation": "^0.33.0",
-        "@opentelemetry/semantic-conventions": "^1.7.0"
+        "@opentelemetry/instrumentation": "^0.34.0",
+        "@opentelemetry/semantic-conventions": "^1.0.0"
+      },
+      "dependencies": {
+        "@opentelemetry/instrumentation": {
+          "version": "0.34.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.34.0.tgz",
+          "integrity": "sha512-VET/bOh4StOQV4vf1sAvn2JD67BhW2vPZ/ynl2gHXyafme2yB8Hs9+tr1TLzFwNGo7jwMFviFQkZjCYxMuK0AA==",
+          "requires": {
+            "require-in-the-middle": "^5.0.3",
+            "semver": "^7.3.2",
+            "shimmer": "^1.2.1"
+          }
+        }
       }
     },
     "@opentelemetry/instrumentation-koa": {
@@ -12496,15 +12546,16 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-koa/-/instrumentation-koa-0.34.0.tgz",
       "integrity": "sha512-+ZLABLbe08U6Xg8Eyu0AJCjchk9Kpah8lUEAUhaNdY2M5RdEqlm4LkvlCdmq425KzsrTX0AeWaCfcvGqFr4+lw==",
       "requires": {
-        "@opentelemetry/core": "^1.7.0",
-        "@opentelemetry/instrumentation": "^0.33.0",
-        "@opentelemetry/semantic-conventions": "^1.7.0",
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.34.0",
+        "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/koa": "2.13.4",
         "@types/koa__router": "8.0.7"
       },
       "dependencies": {
         "@opentelemetry/instrumentation": {
-          "version": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.34.0.tgz",
+          "version": "0.34.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.34.0.tgz",
           "integrity": "sha512-VET/bOh4StOQV4vf1sAvn2JD67BhW2vPZ/ynl2gHXyafme2yB8Hs9+tr1TLzFwNGo7jwMFviFQkZjCYxMuK0AA==",
           "requires": {
             "require-in-the-middle": "^5.0.3",
@@ -12519,12 +12570,13 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongodb/-/instrumentation-mongodb-0.33.0.tgz",
       "integrity": "sha512-bjRF55grOFRn5XQxm1yDL56FD9UVvmIcBDSsgA0dbUr3VOUu3sN7o34t2uDx7EpnfwhMeAvOBO1wbWXdHBzapg==",
       "requires": {
-        "@opentelemetry/instrumentation": "^0.33.0",
-        "@opentelemetry/semantic-conventions": "^1.7.0"
+        "@opentelemetry/instrumentation": "^0.34.0",
+        "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "dependencies": {
         "@opentelemetry/instrumentation": {
-          "version": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.34.0.tgz",
+          "version": "0.34.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.34.0.tgz",
           "integrity": "sha512-VET/bOh4StOQV4vf1sAvn2JD67BhW2vPZ/ynl2gHXyafme2yB8Hs9+tr1TLzFwNGo7jwMFviFQkZjCYxMuK0AA==",
           "requires": {
             "require-in-the-middle": "^5.0.3",
@@ -12539,13 +12591,14 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongoose/-/instrumentation-mongoose-0.32.0.tgz",
       "integrity": "sha512-Br8x76u1xsMiU4nwioYX8NwIBxl4Kt0dTDrZvqtwLkmr7gmHoxApN17QquQcEcuTfonQ4NXIB3A/k1BiPAaq/g==",
       "requires": {
-        "@opentelemetry/core": "^1.7.0",
-        "@opentelemetry/instrumentation": "^0.33.0",
-        "@opentelemetry/semantic-conventions": "^1.7.0"
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.34.0",
+        "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "dependencies": {
         "@opentelemetry/instrumentation": {
-          "version": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.34.0.tgz",
+          "version": "0.34.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.34.0.tgz",
           "integrity": "sha512-VET/bOh4StOQV4vf1sAvn2JD67BhW2vPZ/ynl2gHXyafme2yB8Hs9+tr1TLzFwNGo7jwMFviFQkZjCYxMuK0AA==",
           "requires": {
             "require-in-the-middle": "^5.0.3",
@@ -12560,13 +12613,14 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql/-/instrumentation-mysql-0.32.0.tgz",
       "integrity": "sha512-9BGbc0wiNokflUKmI3WEOnmCqp9QffcnrIoIs2cjqQekZGAzSmL7tyyL3SoW/qXWOUP8FM+OuEomklujNOZYbg==",
       "requires": {
-        "@opentelemetry/instrumentation": "^0.33.0",
-        "@opentelemetry/semantic-conventions": "^1.7.0",
+        "@opentelemetry/instrumentation": "^0.34.0",
+        "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/mysql": "2.15.19"
       },
       "dependencies": {
         "@opentelemetry/instrumentation": {
-          "version": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.34.0.tgz",
+          "version": "0.34.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.34.0.tgz",
           "integrity": "sha512-VET/bOh4StOQV4vf1sAvn2JD67BhW2vPZ/ynl2gHXyafme2yB8Hs9+tr1TLzFwNGo7jwMFviFQkZjCYxMuK0AA==",
           "requires": {
             "require-in-the-middle": "^5.0.3",
@@ -12581,12 +12635,13 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql2/-/instrumentation-mysql2-0.33.0.tgz",
       "integrity": "sha512-DVWkr/WkALmIdtLoiVp/vgZVOXUCFvnlKOEz+LOQMHOktm0FLhdHRjX7jJhtVtEO7DdZQRnfpUYv8zP37gMawQ==",
       "requires": {
-        "@opentelemetry/instrumentation": "^0.33.0",
-        "@opentelemetry/semantic-conventions": "^1.7.0"
+        "@opentelemetry/instrumentation": "^0.34.0",
+        "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "dependencies": {
         "@opentelemetry/instrumentation": {
-          "version": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.34.0.tgz",
+          "version": "0.34.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.34.0.tgz",
           "integrity": "sha512-VET/bOh4StOQV4vf1sAvn2JD67BhW2vPZ/ynl2gHXyafme2yB8Hs9+tr1TLzFwNGo7jwMFviFQkZjCYxMuK0AA==",
           "requires": {
             "require-in-the-middle": "^5.0.3",
@@ -12601,12 +12656,13 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-nestjs-core/-/instrumentation-nestjs-core-0.32.0.tgz",
       "integrity": "sha512-kpzegHf1tNqtZhC+BCM/B9n3/e+vBYYYGZK+HUgiL/lHUoUf3Lsj6869eckSgucrScLjDGNBuo5j8JAkdNJ5zw==",
       "requires": {
-        "@opentelemetry/instrumentation": "^0.33.0",
-        "@opentelemetry/semantic-conventions": "^1.7.0"
+        "@opentelemetry/instrumentation": "^0.34.0",
+        "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "dependencies": {
         "@opentelemetry/instrumentation": {
-          "version": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.34.0.tgz",
+          "version": "0.34.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.34.0.tgz",
           "integrity": "sha512-VET/bOh4StOQV4vf1sAvn2JD67BhW2vPZ/ynl2gHXyafme2yB8Hs9+tr1TLzFwNGo7jwMFviFQkZjCYxMuK0AA==",
           "requires": {
             "require-in-the-middle": "^5.0.3",
@@ -12621,14 +12677,15 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pg/-/instrumentation-pg-0.33.0.tgz",
       "integrity": "sha512-RYs4xsGkIKM5cw/3WPRKxjDyLd1DXhwYaNugJlbozDzkToZ1SRzd8I2qAJ2nTTKHtFrWYCqZILPXnRguZNHmnA==",
       "requires": {
-        "@opentelemetry/instrumentation": "^0.33.0",
-        "@opentelemetry/semantic-conventions": "^1.7.0",
+        "@opentelemetry/instrumentation": "^0.34.0",
+        "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/pg": "8.6.1",
         "@types/pg-pool": "2.0.3"
       },
       "dependencies": {
         "@opentelemetry/instrumentation": {
-          "version": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.34.0.tgz",
+          "version": "0.34.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.34.0.tgz",
           "integrity": "sha512-VET/bOh4StOQV4vf1sAvn2JD67BhW2vPZ/ynl2gHXyafme2yB8Hs9+tr1TLzFwNGo7jwMFviFQkZjCYxMuK0AA==",
           "requires": {
             "require-in-the-middle": "^5.0.3",
@@ -12643,13 +12700,14 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis/-/instrumentation-redis-0.34.0.tgz",
       "integrity": "sha512-fUrU3Ekhxu6bcnurP/rfhZJNxQV9qUP2vQSQSRwPiPZs+s3UKuY19rQEFCST10jF66rQrqB32VwnGqeQyZbHlw==",
       "requires": {
-        "@opentelemetry/instrumentation": "^0.33.0",
-        "@opentelemetry/semantic-conventions": "^1.7.0",
+        "@opentelemetry/instrumentation": "^0.34.0",
+        "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/redis": "2.8.31"
       },
       "dependencies": {
         "@opentelemetry/instrumentation": {
-          "version": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.34.0.tgz",
+          "version": "0.34.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.34.0.tgz",
           "integrity": "sha512-VET/bOh4StOQV4vf1sAvn2JD67BhW2vPZ/ynl2gHXyafme2yB8Hs9+tr1TLzFwNGo7jwMFviFQkZjCYxMuK0AA==",
           "requires": {
             "require-in-the-middle": "^5.0.3",
@@ -12664,12 +12722,13 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis-4/-/instrumentation-redis-4-0.34.0.tgz",
       "integrity": "sha512-b3joRK8+aSszaznUoL8vtZrwreN/CJY0VZbmE3HE8IUvOc6W0QRvOl7fDAJ2z56lDT0f7cZSV05gpvslXgZeWg==",
       "requires": {
-        "@opentelemetry/instrumentation": "^0.33.0",
-        "@opentelemetry/semantic-conventions": "^1.7.0"
+        "@opentelemetry/instrumentation": "^0.34.0",
+        "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "dependencies": {
         "@opentelemetry/instrumentation": {
-          "version": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.34.0.tgz",
+          "version": "0.34.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.34.0.tgz",
           "integrity": "sha512-VET/bOh4StOQV4vf1sAvn2JD67BhW2vPZ/ynl2gHXyafme2yB8Hs9+tr1TLzFwNGo7jwMFviFQkZjCYxMuK0AA==",
           "requires": {
             "require-in-the-middle": "^5.0.3",
@@ -12684,9 +12743,21 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-restify/-/instrumentation-restify-0.31.0.tgz",
       "integrity": "sha512-b0AWFZ9+tm4Iaydt1AquBpsQty+Uv1YQ3C9Jb4/JTknWDWW63tb8FoCcALMPYDulvOgH+PPDvtvZY0Q0Imbstg==",
       "requires": {
-        "@opentelemetry/core": "^1.7.0",
-        "@opentelemetry/instrumentation": "^0.33.0",
-        "@opentelemetry/semantic-conventions": "^1.7.0"
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.34.0",
+        "@opentelemetry/semantic-conventions": "^1.0.0"
+      },
+      "dependencies": {
+        "@opentelemetry/instrumentation": {
+          "version": "0.34.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.34.0.tgz",
+          "integrity": "sha512-VET/bOh4StOQV4vf1sAvn2JD67BhW2vPZ/ynl2gHXyafme2yB8Hs9+tr1TLzFwNGo7jwMFviFQkZjCYxMuK0AA==",
+          "requires": {
+            "require-in-the-middle": "^5.0.3",
+            "semver": "^7.3.2",
+            "shimmer": "^1.2.1"
+          }
+        }
       }
     },
     "@opentelemetry/otlp-exporter-base": {
@@ -12694,7 +12765,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.34.0.tgz",
       "integrity": "sha512-xVNvQm7oXeQogeI21iTZRnBrBYS0OVekPutEJgb7jQtHg7x2GWuCBQK9sDo84FRWNXBpNOgSYqsf8/+PxIJ2vA==",
       "requires": {
-        "@opentelemetry/core": "^1.7.0"
+        "@opentelemetry/core": "1.8.0"
       }
     },
     "@opentelemetry/otlp-grpc-exporter-base": {
@@ -12704,7 +12775,7 @@
       "requires": {
         "@grpc/grpc-js": "^1.7.1",
         "@grpc/proto-loader": "^0.7.3",
-        "@opentelemetry/core": "^1.7.0",
+        "@opentelemetry/core": "1.8.0",
         "@opentelemetry/otlp-exporter-base": "0.34.0"
       }
     },
@@ -12713,7 +12784,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-proto-exporter-base/-/otlp-proto-exporter-base-0.34.0.tgz",
       "integrity": "sha512-qHnwcAafW8OKeM2a1YQNoL9/sgWVE+JxvMgxf2CtYBqsccIakGPoQ43hLCFLAL3I2Af4BNb5t4KnW8lrtnyUjg==",
       "requires": {
-        "@opentelemetry/core": "^1.7.0",
+        "@opentelemetry/core": "1.8.0",
         "@opentelemetry/otlp-exporter-base": "0.34.0",
         "protobufjs": "7.1.1"
       },
@@ -12749,7 +12820,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.34.0.tgz",
       "integrity": "sha512-NghPJvn3pVoWBuhWyBe1n/nWIrj1D1EFUH/bIkWEp0CMVWFLux6R+BkRPZQo5klTcj8xFhCZZIZsL/ubkYPryg==",
       "requires": {
-        "@opentelemetry/core": "^1.7.0",
+        "@opentelemetry/core": "1.8.0",
         "@opentelemetry/resources": "1.8.0",
         "@opentelemetry/sdk-metrics": "1.8.0",
         "@opentelemetry/sdk-trace-base": "1.8.0"
@@ -12760,7 +12831,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.8.0.tgz",
       "integrity": "sha512-ffP6AVHyISqK1kiUY1MoVKt43Wp3FJXI8NOePqxBrAU7bRDJ13276VbSl4ugCZbZLTPrPhhSmvQh1WqlfUgcAg==",
       "requires": {
-        "@opentelemetry/core": "^1.7.0"
+        "@opentelemetry/core": "1.8.0"
       }
     },
     "@opentelemetry/propagator-jaeger": {
@@ -12768,7 +12839,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.8.0.tgz",
       "integrity": "sha512-v6GA38k2cqeGAh3368prLW5MsuG2/KxpfWI/PxTPjCa9tThDPq0cvhKpk7cEma3y+F6rieMhwmzZhKQL5QVBzQ==",
       "requires": {
-        "@opentelemetry/core": "^1.7.0"
+        "@opentelemetry/core": "1.8.0"
       }
     },
     "@opentelemetry/resources": {
@@ -12776,8 +12847,8 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.8.0.tgz",
       "integrity": "sha512-KSyMH6Jvss/PFDy16z5qkCK0ERlpyqixb1xwb73wLMvVq+j7i89lobDjw3JkpCcd1Ws0J6jAI4fw28Zufj2ssg==",
       "requires": {
-        "@opentelemetry/core": "^1.7.0",
-        "@opentelemetry/semantic-conventions": "^1.7.0"
+        "@opentelemetry/core": "1.8.0",
+        "@opentelemetry/semantic-conventions": "1.8.0"
       }
     },
     "@opentelemetry/sdk-metrics": {
@@ -12785,7 +12856,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.8.0.tgz",
       "integrity": "sha512-+KYb+uj0vHhl8xzJO+oChS4oP1e+/2Wl3SXoHoIdcEjd1TQfDV+lxOm4oqxWq6wykXvI35/JHyejxSoT+qxGmg==",
       "requires": {
-        "@opentelemetry/core": "^1.7.0",
+        "@opentelemetry/core": "1.8.0",
         "@opentelemetry/resources": "1.8.0",
         "lodash.merge": "4.6.2"
       }
@@ -12795,22 +12866,23 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-node/-/sdk-node-0.34.0.tgz",
       "integrity": "sha512-4OX2qvOPoK3De2e600Gim46I3PahI6UkD8uZ9hEgSg40egHXKw3keIaFnz1CWkYwa5hhVVIBsoobI41cHfulHA==",
       "requires": {
-        "@opentelemetry/core": "^1.7.0",
+        "@opentelemetry/core": "1.8.0",
         "@opentelemetry/exporter-jaeger": "1.8.0",
         "@opentelemetry/exporter-trace-otlp-grpc": "0.34.0",
         "@opentelemetry/exporter-trace-otlp-http": "0.34.0",
         "@opentelemetry/exporter-trace-otlp-proto": "0.34.0",
         "@opentelemetry/exporter-zipkin": "1.8.0",
-        "@opentelemetry/instrumentation": "^0.33.0",
+        "@opentelemetry/instrumentation": "0.34.0",
         "@opentelemetry/resources": "1.8.0",
         "@opentelemetry/sdk-metrics": "1.8.0",
         "@opentelemetry/sdk-trace-base": "1.8.0",
         "@opentelemetry/sdk-trace-node": "1.8.0",
-        "@opentelemetry/semantic-conventions": "^1.7.0"
+        "@opentelemetry/semantic-conventions": "1.8.0"
       },
       "dependencies": {
         "@opentelemetry/instrumentation": {
-          "version": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.34.0.tgz",
+          "version": "0.34.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.34.0.tgz",
           "integrity": "sha512-VET/bOh4StOQV4vf1sAvn2JD67BhW2vPZ/ynl2gHXyafme2yB8Hs9+tr1TLzFwNGo7jwMFviFQkZjCYxMuK0AA==",
           "requires": {
             "require-in-the-middle": "^5.0.3",
@@ -12825,9 +12897,9 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.8.0.tgz",
       "integrity": "sha512-iH41m0UTddnCKJzZx3M85vlhKzRcmT48pUeBbnzsGrq4nIay1oWVHKM5nhB5r8qRDGvd/n7f/YLCXClxwM0tvA==",
       "requires": {
-        "@opentelemetry/core": "^1.7.0",
+        "@opentelemetry/core": "1.8.0",
         "@opentelemetry/resources": "1.8.0",
-        "@opentelemetry/semantic-conventions": "^1.7.0"
+        "@opentelemetry/semantic-conventions": "1.8.0"
       }
     },
     "@opentelemetry/sdk-trace-node": {
@@ -12836,7 +12908,7 @@
       "integrity": "sha512-6FqhJEgW9Nke5SO4Ul9+5EWOfms/JeLg5LRqILMPMK4UMBWcOtk7jldvGGyfVpraJ16/WPo/R5NSnMwlupN5zQ==",
       "requires": {
         "@opentelemetry/context-async-hooks": "1.8.0",
-        "@opentelemetry/core": "^1.7.0",
+        "@opentelemetry/core": "1.8.0",
         "@opentelemetry/propagator-b3": "1.8.0",
         "@opentelemetry/propagator-jaeger": "1.8.0",
         "@opentelemetry/sdk-trace-base": "1.8.0",

--- a/package.json
+++ b/package.json
@@ -38,11 +38,6 @@
     "tslib": "^2.0.3",
     "winston": "^3.6.0"
   },
-  "overrides": {
-    "@opentelemetry/core": "^1.7.0",
-    "@opentelemetry/instrumentation": "^0.33.0",
-    "@opentelemetry/semantic-conventions": "^1.7.0"
-  },
   "devDependencies": {
     "@types/jest": "^26.0.19",
     "@typescript-eslint/eslint-plugin": "^5.13.0",


### PR DESCRIPTION
We added these to ensure our tests passed, back when OpenTelemetry instrumentations wildly diverged on their dependencies. This should not be necessary anymore, as they are now fairly unified in that regard.

Part of #822, though not really directly related.

[skip changeset]