### PR TITLE
Add OpenTelemetry SDK start promise as a property

### DIFF
--- a/.changesets/add-opentelemetry-sdk-initialization-to-client.md
+++ b/.changesets/add-opentelemetry-sdk-initialization-to-client.md
@@ -1,0 +1,9 @@
+---
+bump: "patch"
+type: "add"
+---
+
+Add OpenTelemetry SDK initialization to client
+
+The OpenTelemetry instrumentations are loaded async, this is OK when users rely on automatic instrumentations, but for custom instrumentations
+it might cause spans not to be reported. There's a new property in the client that contains the instrumentations registration that can be awaited for resolution before running any custom instrumentations.

--- a/src/client.ts
+++ b/src/client.ts
@@ -93,6 +93,7 @@ export class Client {
   config: Configuration
   readonly integrationLogger: IntegrationLogger
   extension: Extension
+  instrumentationsLoaded?: Promise<void>
 
   #metrics: Metrics
   #sdk?: NodeSDK
@@ -374,7 +375,7 @@ export class Client {
       spanProcessor
     })
 
-    sdk.start()
+    this.instrumentationsLoaded = sdk.start()
 
     return sdk
   }


### PR DESCRIPTION
There's a new property in the client called `instrumentationsLoaded`. It contains a promise that registers the instrumentations and the tracer provider. This fixes custom instrumentation in one-off scripts and in app top levels not being reported due to unregistered instrumentations.

## Usage instructions

If you're using `import` syntax

```js
import { Appsignal, sendError } from "@appsignal/nodejs"

await Appsignal.client.instrumentationsLoaded

sendError(new Error("Test error"))
```

If you're not using `import` syntax

```js
import { Appsignal, sendError } from "@appsignal/nodejs"

Appsignal.client.instrumentationsLoaded.then(() => {
  sendError(new Error("Test error"))
})
```

Fixes #837 