### PR TITLE
Add instrumentationsLoaded as a helper

### DIFF
--- a/.changesets/add-opentelemetry-sdk-initialization-to-client.md
+++ b/.changesets/add-opentelemetry-sdk-initialization-to-client.md
@@ -3,7 +3,7 @@ bump: "patch"
 type: "add"
 ---
 
-Add OpenTelemetry SDK initialization to client
+Add OpenTelemetry SDK initialization helper function
 
 The OpenTelemetry instrumentations are loaded async, this is OK when users rely on automatic instrumentations, but for custom instrumentations
-it might cause spans not to be reported. There's a new property in the client that contains the instrumentations registration that can be awaited for resolution before running any custom instrumentations.
+it might cause spans not to be reported. There's a new helper function that contains the instrumentations registration that can be awaited for resolution before running any custom instrumentations.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@appsignal/nodejs",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@appsignal/nodejs",
-      "version": "3.0.2",
+      "version": "3.0.3",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/src/__tests__/helpers.test.ts
+++ b/src/__tests__/helpers.test.ts
@@ -19,7 +19,8 @@ import {
   setNamespace,
   setRootName,
   setError,
-  sendError
+  sendError,
+  instrumentationsLoaded
 } from "../helpers"
 
 function throwError() {
@@ -284,6 +285,27 @@ describe("Helpers", () => {
       expectErrorEvent(childSpan.events[0])
 
       expect(debugMock).not.toHaveBeenCalled()
+    })
+  })
+
+  describe("instrumentationsLoaded", () => {
+    it("returns a promise from the globally stored client if found", () => {
+      const debugMock = jest.spyOn(Client.integrationLogger, "debug")
+
+      expect(instrumentationsLoaded()).toBeInstanceOf(Promise)
+      expect(debugMock).toHaveBeenCalledTimes(0)
+    })
+
+    it("returns an empty promise and logs if the globally stored client is not found", () => {
+      // Remove the stored client
+      global.__APPSIGNAL__ = null as any
+
+      const debugMock = jest.spyOn(Client.integrationLogger, "debug")
+
+      expect(instrumentationsLoaded()).toBeInstanceOf(Promise)
+      expect(debugMock).toHaveBeenCalledWith(
+        "Client is not initialized, cannot get OpenTelemetry instrumentations loaded"
+      )
     })
   })
 })

--- a/src/client.ts
+++ b/src/client.ts
@@ -93,7 +93,7 @@ export class Client {
   config: Configuration
   readonly integrationLogger: IntegrationLogger
   extension: Extension
-  instrumentationsLoaded?: Promise<void>
+  instrumentationsLoaded: Promise<void>
 
   #metrics: Metrics
   #sdk?: NodeSDK
@@ -141,6 +141,7 @@ export class Client {
     this.config = new Configuration(options)
     this.extension = new Extension()
     this.integrationLogger = this.setUpIntegrationLogger()
+    this.instrumentationsLoaded = Promise.resolve()
     this.storeInGlobal()
 
     if (this.isActive) {

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -128,3 +128,16 @@ export function sendError(error: Error, fn: () => void = () => {}) {
     )
   }
 }
+
+export function instrumentationsLoaded(): Promise<void> {
+  const globallyStoredClient = Client.client
+
+  if (globallyStoredClient) {
+    return globallyStoredClient.instrumentationsLoaded
+  } else {
+    Client.integrationLogger.debug(
+      "Client is not initialized, cannot get OpenTelemetry instrumentations loaded"
+    )
+    return Promise.resolve()
+  }
+}


### PR DESCRIPTION
Instead of calling `instrumentationsLoaded()` from a client property, add it as an isolated helper function so users' apps keep working if they haven't initialized the AppSignal client.

## Usage instructions

If you're using `import` syntax

```js
import { instrumentationsLoaded } from "@appsignal/nodejs"

await instrumentationsLoaded()

sendError(new Error("Test error"))
```

If you're not using `import` syntax

```js
import { instrumentationsLoaded } from "@appsignal/nodejs"

instrumentationsLoaded().then(() => {
  sendError(new Error("Test error"))
})
```