### PR TITLE
Update prisma instrumentation package

### DIFF
--- a/.changesets/update-prisma-instrumentation-package.md
+++ b/.changesets/update-prisma-instrumentation-package.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "change"
+---
+
+Update prisma instrumentation package. Fixes installation deprecation warning.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@appsignal/nodejs",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@appsignal/nodejs",
-      "version": "3.0.3",
+      "version": "3.0.4",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -30,7 +30,7 @@
         "@opentelemetry/instrumentation-restify": "^0.32.0",
         "@opentelemetry/sdk-node": "^0.34.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
-        "@prisma/instrumentation": "^4.4.0",
+        "@prisma/instrumentation": "^4.9.0",
         "node-addon-api": "^3.1.0",
         "node-gyp": "^9.0.0",
         "tslib": "^2.0.3",
@@ -1257,17 +1257,6 @@
         "node": ">=8.0.0"
       }
     },
-    "node_modules/@opentelemetry/api-metrics": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-metrics/-/api-metrics-0.33.0.tgz",
-      "integrity": "sha512-78evfPRRRnJA6uZ3xuBuS3VZlXTO/LRs+Ff1iv3O/7DgibCtq9k27T6Zlj8yRdJDFmcjcbQrvC0/CpDpWHaZYA==",
-      "dependencies": {
-        "@opentelemetry/api": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/@opentelemetry/context-async-hooks": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.8.0.tgz",
@@ -1384,11 +1373,10 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.33.0.tgz",
-      "integrity": "sha512-8joPjKJ6TznNt04JbnzZG+m1j/4wm1OIrX7DEw/V5lyZ9/2fahIqG72jeZ26VKOZnLOpVzUUnU/dweURqBzT3Q==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.34.0.tgz",
+      "integrity": "sha512-VET/bOh4StOQV4vf1sAvn2JD67BhW2vPZ/ynl2gHXyafme2yB8Hs9+tr1TLzFwNGo7jwMFviFQkZjCYxMuK0AA==",
       "dependencies": {
-        "@opentelemetry/api-metrics": "0.33.0",
         "require-in-the-middle": "^5.0.3",
         "semver": "^7.3.2",
         "shimmer": "^1.2.1"
@@ -1397,7 +1385,7 @@
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": "^1.0.0"
+        "@opentelemetry/api": "^1.3.0"
       }
     },
     "node_modules/@opentelemetry/instrumentation-express": {
@@ -1409,22 +1397,6 @@
         "@opentelemetry/instrumentation": "^0.34.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/express": "4.17.13"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/instrumentation-express/node_modules/@opentelemetry/instrumentation": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.34.0.tgz",
-      "integrity": "sha512-VET/bOh4StOQV4vf1sAvn2JD67BhW2vPZ/ynl2gHXyafme2yB8Hs9+tr1TLzFwNGo7jwMFviFQkZjCYxMuK0AA==",
-      "dependencies": {
-        "require-in-the-middle": "^5.0.3",
-        "semver": "^7.3.2",
-        "shimmer": "^1.2.1"
       },
       "engines": {
         "node": ">=14"
@@ -1449,22 +1421,6 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
-    "node_modules/@opentelemetry/instrumentation-fastify/node_modules/@opentelemetry/instrumentation": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.34.0.tgz",
-      "integrity": "sha512-VET/bOh4StOQV4vf1sAvn2JD67BhW2vPZ/ynl2gHXyafme2yB8Hs9+tr1TLzFwNGo7jwMFviFQkZjCYxMuK0AA==",
-      "dependencies": {
-        "require-in-the-middle": "^5.0.3",
-        "semver": "^7.3.2",
-        "shimmer": "^1.2.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
     "node_modules/@opentelemetry/instrumentation-fs": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fs/-/instrumentation-fs-0.6.0.tgz",
@@ -1481,44 +1437,12 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
-    "node_modules/@opentelemetry/instrumentation-fs/node_modules/@opentelemetry/instrumentation": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.34.0.tgz",
-      "integrity": "sha512-VET/bOh4StOQV4vf1sAvn2JD67BhW2vPZ/ynl2gHXyafme2yB8Hs9+tr1TLzFwNGo7jwMFviFQkZjCYxMuK0AA==",
-      "dependencies": {
-        "require-in-the-middle": "^5.0.3",
-        "semver": "^7.3.2",
-        "shimmer": "^1.2.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
     "node_modules/@opentelemetry/instrumentation-graphql": {
       "version": "0.33.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-graphql/-/instrumentation-graphql-0.33.0.tgz",
       "integrity": "sha512-d3Qv847LI5JLJF3iR9+86V7K/+nUqVkNu2XJ1L1/4Ze5sih1R+722tx7IrS7UEDkkoNI0E0m74Yg9pJ0kwXMTQ==",
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.34.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/instrumentation-graphql/node_modules/@opentelemetry/instrumentation": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.34.0.tgz",
-      "integrity": "sha512-VET/bOh4StOQV4vf1sAvn2JD67BhW2vPZ/ynl2gHXyafme2yB8Hs9+tr1TLzFwNGo7jwMFviFQkZjCYxMuK0AA==",
-      "dependencies": {
-        "require-in-the-middle": "^5.0.3",
-        "semver": "^7.3.2",
-        "shimmer": "^1.2.1"
       },
       "engines": {
         "node": ">=14"
@@ -1544,22 +1468,6 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
-    "node_modules/@opentelemetry/instrumentation-http/node_modules/@opentelemetry/instrumentation": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.34.0.tgz",
-      "integrity": "sha512-VET/bOh4StOQV4vf1sAvn2JD67BhW2vPZ/ynl2gHXyafme2yB8Hs9+tr1TLzFwNGo7jwMFviFQkZjCYxMuK0AA==",
-      "dependencies": {
-        "require-in-the-middle": "^5.0.3",
-        "semver": "^7.3.2",
-        "shimmer": "^1.2.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
     "node_modules/@opentelemetry/instrumentation-ioredis": {
       "version": "0.33.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-ioredis/-/instrumentation-ioredis-0.33.0.tgz",
@@ -1576,22 +1484,6 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
-    "node_modules/@opentelemetry/instrumentation-ioredis/node_modules/@opentelemetry/instrumentation": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.34.0.tgz",
-      "integrity": "sha512-VET/bOh4StOQV4vf1sAvn2JD67BhW2vPZ/ynl2gHXyafme2yB8Hs9+tr1TLzFwNGo7jwMFviFQkZjCYxMuK0AA==",
-      "dependencies": {
-        "require-in-the-middle": "^5.0.3",
-        "semver": "^7.3.2",
-        "shimmer": "^1.2.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
     "node_modules/@opentelemetry/instrumentation-knex": {
       "version": "0.31.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-knex/-/instrumentation-knex-0.31.0.tgz",
@@ -1599,22 +1491,6 @@
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.34.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/instrumentation-knex/node_modules/@opentelemetry/instrumentation": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.34.0.tgz",
-      "integrity": "sha512-VET/bOh4StOQV4vf1sAvn2JD67BhW2vPZ/ynl2gHXyafme2yB8Hs9+tr1TLzFwNGo7jwMFviFQkZjCYxMuK0AA==",
-      "dependencies": {
-        "require-in-the-middle": "^5.0.3",
-        "semver": "^7.3.2",
-        "shimmer": "^1.2.1"
       },
       "engines": {
         "node": ">=14"
@@ -1641,22 +1517,6 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
-    "node_modules/@opentelemetry/instrumentation-koa/node_modules/@opentelemetry/instrumentation": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.34.0.tgz",
-      "integrity": "sha512-VET/bOh4StOQV4vf1sAvn2JD67BhW2vPZ/ynl2gHXyafme2yB8Hs9+tr1TLzFwNGo7jwMFviFQkZjCYxMuK0AA==",
-      "dependencies": {
-        "require-in-the-middle": "^5.0.3",
-        "semver": "^7.3.2",
-        "shimmer": "^1.2.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
     "node_modules/@opentelemetry/instrumentation-mongodb": {
       "version": "0.33.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongodb/-/instrumentation-mongodb-0.33.0.tgz",
@@ -1664,22 +1524,6 @@
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.34.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/instrumentation-mongodb/node_modules/@opentelemetry/instrumentation": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.34.0.tgz",
-      "integrity": "sha512-VET/bOh4StOQV4vf1sAvn2JD67BhW2vPZ/ynl2gHXyafme2yB8Hs9+tr1TLzFwNGo7jwMFviFQkZjCYxMuK0AA==",
-      "dependencies": {
-        "require-in-the-middle": "^5.0.3",
-        "semver": "^7.3.2",
-        "shimmer": "^1.2.1"
       },
       "engines": {
         "node": ">=14"
@@ -1704,22 +1548,6 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
-    "node_modules/@opentelemetry/instrumentation-mongoose/node_modules/@opentelemetry/instrumentation": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.34.0.tgz",
-      "integrity": "sha512-VET/bOh4StOQV4vf1sAvn2JD67BhW2vPZ/ynl2gHXyafme2yB8Hs9+tr1TLzFwNGo7jwMFviFQkZjCYxMuK0AA==",
-      "dependencies": {
-        "require-in-the-middle": "^5.0.3",
-        "semver": "^7.3.2",
-        "shimmer": "^1.2.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
     "node_modules/@opentelemetry/instrumentation-mysql": {
       "version": "0.32.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql/-/instrumentation-mysql-0.32.0.tgz",
@@ -1728,22 +1556,6 @@
         "@opentelemetry/instrumentation": "^0.34.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/mysql": "2.15.19"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/instrumentation-mysql/node_modules/@opentelemetry/instrumentation": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.34.0.tgz",
-      "integrity": "sha512-VET/bOh4StOQV4vf1sAvn2JD67BhW2vPZ/ynl2gHXyafme2yB8Hs9+tr1TLzFwNGo7jwMFviFQkZjCYxMuK0AA==",
-      "dependencies": {
-        "require-in-the-middle": "^5.0.3",
-        "semver": "^7.3.2",
-        "shimmer": "^1.2.1"
       },
       "engines": {
         "node": ">=14"
@@ -1767,22 +1579,6 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
-    "node_modules/@opentelemetry/instrumentation-mysql2/node_modules/@opentelemetry/instrumentation": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.34.0.tgz",
-      "integrity": "sha512-VET/bOh4StOQV4vf1sAvn2JD67BhW2vPZ/ynl2gHXyafme2yB8Hs9+tr1TLzFwNGo7jwMFviFQkZjCYxMuK0AA==",
-      "dependencies": {
-        "require-in-the-middle": "^5.0.3",
-        "semver": "^7.3.2",
-        "shimmer": "^1.2.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
     "node_modules/@opentelemetry/instrumentation-nestjs-core": {
       "version": "0.32.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-nestjs-core/-/instrumentation-nestjs-core-0.32.0.tgz",
@@ -1790,22 +1586,6 @@
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.34.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/instrumentation-nestjs-core/node_modules/@opentelemetry/instrumentation": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.34.0.tgz",
-      "integrity": "sha512-VET/bOh4StOQV4vf1sAvn2JD67BhW2vPZ/ynl2gHXyafme2yB8Hs9+tr1TLzFwNGo7jwMFviFQkZjCYxMuK0AA==",
-      "dependencies": {
-        "require-in-the-middle": "^5.0.3",
-        "semver": "^7.3.2",
-        "shimmer": "^1.2.1"
       },
       "engines": {
         "node": ">=14"
@@ -1823,22 +1603,6 @@
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/pg": "8.6.1",
         "@types/pg-pool": "2.0.3"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/instrumentation-pg/node_modules/@opentelemetry/instrumentation": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.34.0.tgz",
-      "integrity": "sha512-VET/bOh4StOQV4vf1sAvn2JD67BhW2vPZ/ynl2gHXyafme2yB8Hs9+tr1TLzFwNGo7jwMFviFQkZjCYxMuK0AA==",
-      "dependencies": {
-        "require-in-the-middle": "^5.0.3",
-        "semver": "^7.3.2",
-        "shimmer": "^1.2.1"
       },
       "engines": {
         "node": ">=14"
@@ -1878,38 +1642,6 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
-    "node_modules/@opentelemetry/instrumentation-redis-4/node_modules/@opentelemetry/instrumentation": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.34.0.tgz",
-      "integrity": "sha512-VET/bOh4StOQV4vf1sAvn2JD67BhW2vPZ/ynl2gHXyafme2yB8Hs9+tr1TLzFwNGo7jwMFviFQkZjCYxMuK0AA==",
-      "dependencies": {
-        "require-in-the-middle": "^5.0.3",
-        "semver": "^7.3.2",
-        "shimmer": "^1.2.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/instrumentation-redis/node_modules/@opentelemetry/instrumentation": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.34.0.tgz",
-      "integrity": "sha512-VET/bOh4StOQV4vf1sAvn2JD67BhW2vPZ/ynl2gHXyafme2yB8Hs9+tr1TLzFwNGo7jwMFviFQkZjCYxMuK0AA==",
-      "dependencies": {
-        "require-in-the-middle": "^5.0.3",
-        "semver": "^7.3.2",
-        "shimmer": "^1.2.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
     "node_modules/@opentelemetry/instrumentation-restify": {
       "version": "0.32.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-restify/-/instrumentation-restify-0.32.0.tgz",
@@ -1918,22 +1650,6 @@
         "@opentelemetry/core": "^1.8.0",
         "@opentelemetry/instrumentation": "^0.34.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/instrumentation-restify/node_modules/@opentelemetry/instrumentation": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.34.0.tgz",
-      "integrity": "sha512-VET/bOh4StOQV4vf1sAvn2JD67BhW2vPZ/ynl2gHXyafme2yB8Hs9+tr1TLzFwNGo7jwMFviFQkZjCYxMuK0AA==",
-      "dependencies": {
-        "require-in-the-middle": "^5.0.3",
-        "semver": "^7.3.2",
-        "shimmer": "^1.2.1"
       },
       "engines": {
         "node": ">=14"
@@ -2118,22 +1834,6 @@
         "@opentelemetry/api": ">=1.3.0 <1.4.0"
       }
     },
-    "node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/instrumentation": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.34.0.tgz",
-      "integrity": "sha512-VET/bOh4StOQV4vf1sAvn2JD67BhW2vPZ/ynl2gHXyafme2yB8Hs9+tr1TLzFwNGo7jwMFviFQkZjCYxMuK0AA==",
-      "dependencies": {
-        "require-in-the-middle": "^5.0.3",
-        "semver": "^7.3.2",
-        "shimmer": "^1.2.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
     "node_modules/@opentelemetry/sdk-trace-base": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.8.0.tgz",
@@ -2178,12 +1878,12 @@
       }
     },
     "node_modules/@prisma/instrumentation": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@prisma/instrumentation/-/instrumentation-4.4.0.tgz",
-      "integrity": "sha512-bSJfnH8aW3VXRuQ/pvi4uilnoJvuiXTT+YfXj+N4wURn+o1OGHIJsQZw14DrVPtMNjtZPFtmcUMPhPMc25QB8Q==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@prisma/instrumentation/-/instrumentation-4.9.0.tgz",
+      "integrity": "sha512-VUXZIshCZCrCTHKiH++u7bWlWlpwwK9sHhO/5c+U1wc1GFEOO61ReW8Vy8CMxVUiCxs0zB1bgXQ2UG0JdXug9Q==",
       "dependencies": {
-        "@opentelemetry/api": "^1.1.0",
-        "@opentelemetry/instrumentation": "^0.33.0"
+        "@opentelemetry/api": "^1.3.0",
+        "@opentelemetry/instrumentation": "^0.34.0"
       }
     },
     "node_modules/@protobufjs/aspromise": {
@@ -12295,14 +11995,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.3.0.tgz",
       "integrity": "sha512-YveTnGNsFFixTKJz09Oi4zYkiLT5af3WpZDu4aIUM7xX+2bHAkOJayFTVQd6zB8kkWPpbua4Ha6Ql00grdLlJQ=="
     },
-    "@opentelemetry/api-metrics": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-metrics/-/api-metrics-0.33.0.tgz",
-      "integrity": "sha512-78evfPRRRnJA6uZ3xuBuS3VZlXTO/LRs+Ff1iv3O/7DgibCtq9k27T6Zlj8yRdJDFmcjcbQrvC0/CpDpWHaZYA==",
-      "requires": {
-        "@opentelemetry/api": "^1.0.0"
-      }
-    },
     "@opentelemetry/context-async-hooks": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.8.0.tgz",
@@ -12378,11 +12070,10 @@
       }
     },
     "@opentelemetry/instrumentation": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.33.0.tgz",
-      "integrity": "sha512-8joPjKJ6TznNt04JbnzZG+m1j/4wm1OIrX7DEw/V5lyZ9/2fahIqG72jeZ26VKOZnLOpVzUUnU/dweURqBzT3Q==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.34.0.tgz",
+      "integrity": "sha512-VET/bOh4StOQV4vf1sAvn2JD67BhW2vPZ/ynl2gHXyafme2yB8Hs9+tr1TLzFwNGo7jwMFviFQkZjCYxMuK0AA==",
       "requires": {
-        "@opentelemetry/api-metrics": "0.33.0",
         "require-in-the-middle": "^5.0.3",
         "semver": "^7.3.2",
         "shimmer": "^1.2.1"
@@ -12397,18 +12088,6 @@
         "@opentelemetry/instrumentation": "^0.34.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/express": "4.17.13"
-      },
-      "dependencies": {
-        "@opentelemetry/instrumentation": {
-          "version": "0.34.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.34.0.tgz",
-          "integrity": "sha512-VET/bOh4StOQV4vf1sAvn2JD67BhW2vPZ/ynl2gHXyafme2yB8Hs9+tr1TLzFwNGo7jwMFviFQkZjCYxMuK0AA==",
-          "requires": {
-            "require-in-the-middle": "^5.0.3",
-            "semver": "^7.3.2",
-            "shimmer": "^1.2.1"
-          }
-        }
       }
     },
     "@opentelemetry/instrumentation-fastify": {
@@ -12419,18 +12098,6 @@
         "@opentelemetry/core": "^1.8.0",
         "@opentelemetry/instrumentation": "^0.34.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
-      },
-      "dependencies": {
-        "@opentelemetry/instrumentation": {
-          "version": "0.34.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.34.0.tgz",
-          "integrity": "sha512-VET/bOh4StOQV4vf1sAvn2JD67BhW2vPZ/ynl2gHXyafme2yB8Hs9+tr1TLzFwNGo7jwMFviFQkZjCYxMuK0AA==",
-          "requires": {
-            "require-in-the-middle": "^5.0.3",
-            "semver": "^7.3.2",
-            "shimmer": "^1.2.1"
-          }
-        }
       }
     },
     "@opentelemetry/instrumentation-fs": {
@@ -12441,18 +12108,6 @@
         "@opentelemetry/core": "^1.8.0",
         "@opentelemetry/instrumentation": "^0.34.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
-      },
-      "dependencies": {
-        "@opentelemetry/instrumentation": {
-          "version": "0.34.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.34.0.tgz",
-          "integrity": "sha512-VET/bOh4StOQV4vf1sAvn2JD67BhW2vPZ/ynl2gHXyafme2yB8Hs9+tr1TLzFwNGo7jwMFviFQkZjCYxMuK0AA==",
-          "requires": {
-            "require-in-the-middle": "^5.0.3",
-            "semver": "^7.3.2",
-            "shimmer": "^1.2.1"
-          }
-        }
       }
     },
     "@opentelemetry/instrumentation-graphql": {
@@ -12461,18 +12116,6 @@
       "integrity": "sha512-d3Qv847LI5JLJF3iR9+86V7K/+nUqVkNu2XJ1L1/4Ze5sih1R+722tx7IrS7UEDkkoNI0E0m74Yg9pJ0kwXMTQ==",
       "requires": {
         "@opentelemetry/instrumentation": "^0.34.0"
-      },
-      "dependencies": {
-        "@opentelemetry/instrumentation": {
-          "version": "0.34.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.34.0.tgz",
-          "integrity": "sha512-VET/bOh4StOQV4vf1sAvn2JD67BhW2vPZ/ynl2gHXyafme2yB8Hs9+tr1TLzFwNGo7jwMFviFQkZjCYxMuK0AA==",
-          "requires": {
-            "require-in-the-middle": "^5.0.3",
-            "semver": "^7.3.2",
-            "shimmer": "^1.2.1"
-          }
-        }
       }
     },
     "@opentelemetry/instrumentation-http": {
@@ -12484,18 +12127,6 @@
         "@opentelemetry/instrumentation": "0.34.0",
         "@opentelemetry/semantic-conventions": "1.8.0",
         "semver": "^7.3.5"
-      },
-      "dependencies": {
-        "@opentelemetry/instrumentation": {
-          "version": "0.34.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.34.0.tgz",
-          "integrity": "sha512-VET/bOh4StOQV4vf1sAvn2JD67BhW2vPZ/ynl2gHXyafme2yB8Hs9+tr1TLzFwNGo7jwMFviFQkZjCYxMuK0AA==",
-          "requires": {
-            "require-in-the-middle": "^5.0.3",
-            "semver": "^7.3.2",
-            "shimmer": "^1.2.1"
-          }
-        }
       }
     },
     "@opentelemetry/instrumentation-ioredis": {
@@ -12506,18 +12137,6 @@
         "@opentelemetry/instrumentation": "^0.34.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/ioredis": "4.26.6"
-      },
-      "dependencies": {
-        "@opentelemetry/instrumentation": {
-          "version": "0.34.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.34.0.tgz",
-          "integrity": "sha512-VET/bOh4StOQV4vf1sAvn2JD67BhW2vPZ/ynl2gHXyafme2yB8Hs9+tr1TLzFwNGo7jwMFviFQkZjCYxMuK0AA==",
-          "requires": {
-            "require-in-the-middle": "^5.0.3",
-            "semver": "^7.3.2",
-            "shimmer": "^1.2.1"
-          }
-        }
       }
     },
     "@opentelemetry/instrumentation-knex": {
@@ -12527,18 +12146,6 @@
       "requires": {
         "@opentelemetry/instrumentation": "^0.34.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
-      },
-      "dependencies": {
-        "@opentelemetry/instrumentation": {
-          "version": "0.34.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.34.0.tgz",
-          "integrity": "sha512-VET/bOh4StOQV4vf1sAvn2JD67BhW2vPZ/ynl2gHXyafme2yB8Hs9+tr1TLzFwNGo7jwMFviFQkZjCYxMuK0AA==",
-          "requires": {
-            "require-in-the-middle": "^5.0.3",
-            "semver": "^7.3.2",
-            "shimmer": "^1.2.1"
-          }
-        }
       }
     },
     "@opentelemetry/instrumentation-koa": {
@@ -12551,18 +12158,6 @@
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/koa": "2.13.4",
         "@types/koa__router": "8.0.7"
-      },
-      "dependencies": {
-        "@opentelemetry/instrumentation": {
-          "version": "0.34.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.34.0.tgz",
-          "integrity": "sha512-VET/bOh4StOQV4vf1sAvn2JD67BhW2vPZ/ynl2gHXyafme2yB8Hs9+tr1TLzFwNGo7jwMFviFQkZjCYxMuK0AA==",
-          "requires": {
-            "require-in-the-middle": "^5.0.3",
-            "semver": "^7.3.2",
-            "shimmer": "^1.2.1"
-          }
-        }
       }
     },
     "@opentelemetry/instrumentation-mongodb": {
@@ -12572,18 +12167,6 @@
       "requires": {
         "@opentelemetry/instrumentation": "^0.34.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
-      },
-      "dependencies": {
-        "@opentelemetry/instrumentation": {
-          "version": "0.34.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.34.0.tgz",
-          "integrity": "sha512-VET/bOh4StOQV4vf1sAvn2JD67BhW2vPZ/ynl2gHXyafme2yB8Hs9+tr1TLzFwNGo7jwMFviFQkZjCYxMuK0AA==",
-          "requires": {
-            "require-in-the-middle": "^5.0.3",
-            "semver": "^7.3.2",
-            "shimmer": "^1.2.1"
-          }
-        }
       }
     },
     "@opentelemetry/instrumentation-mongoose": {
@@ -12594,18 +12177,6 @@
         "@opentelemetry/core": "^1.8.0",
         "@opentelemetry/instrumentation": "^0.34.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
-      },
-      "dependencies": {
-        "@opentelemetry/instrumentation": {
-          "version": "0.34.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.34.0.tgz",
-          "integrity": "sha512-VET/bOh4StOQV4vf1sAvn2JD67BhW2vPZ/ynl2gHXyafme2yB8Hs9+tr1TLzFwNGo7jwMFviFQkZjCYxMuK0AA==",
-          "requires": {
-            "require-in-the-middle": "^5.0.3",
-            "semver": "^7.3.2",
-            "shimmer": "^1.2.1"
-          }
-        }
       }
     },
     "@opentelemetry/instrumentation-mysql": {
@@ -12616,18 +12187,6 @@
         "@opentelemetry/instrumentation": "^0.34.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/mysql": "2.15.19"
-      },
-      "dependencies": {
-        "@opentelemetry/instrumentation": {
-          "version": "0.34.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.34.0.tgz",
-          "integrity": "sha512-VET/bOh4StOQV4vf1sAvn2JD67BhW2vPZ/ynl2gHXyafme2yB8Hs9+tr1TLzFwNGo7jwMFviFQkZjCYxMuK0AA==",
-          "requires": {
-            "require-in-the-middle": "^5.0.3",
-            "semver": "^7.3.2",
-            "shimmer": "^1.2.1"
-          }
-        }
       }
     },
     "@opentelemetry/instrumentation-mysql2": {
@@ -12637,18 +12196,6 @@
       "requires": {
         "@opentelemetry/instrumentation": "^0.34.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
-      },
-      "dependencies": {
-        "@opentelemetry/instrumentation": {
-          "version": "0.34.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.34.0.tgz",
-          "integrity": "sha512-VET/bOh4StOQV4vf1sAvn2JD67BhW2vPZ/ynl2gHXyafme2yB8Hs9+tr1TLzFwNGo7jwMFviFQkZjCYxMuK0AA==",
-          "requires": {
-            "require-in-the-middle": "^5.0.3",
-            "semver": "^7.3.2",
-            "shimmer": "^1.2.1"
-          }
-        }
       }
     },
     "@opentelemetry/instrumentation-nestjs-core": {
@@ -12658,18 +12205,6 @@
       "requires": {
         "@opentelemetry/instrumentation": "^0.34.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
-      },
-      "dependencies": {
-        "@opentelemetry/instrumentation": {
-          "version": "0.34.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.34.0.tgz",
-          "integrity": "sha512-VET/bOh4StOQV4vf1sAvn2JD67BhW2vPZ/ynl2gHXyafme2yB8Hs9+tr1TLzFwNGo7jwMFviFQkZjCYxMuK0AA==",
-          "requires": {
-            "require-in-the-middle": "^5.0.3",
-            "semver": "^7.3.2",
-            "shimmer": "^1.2.1"
-          }
-        }
       }
     },
     "@opentelemetry/instrumentation-pg": {
@@ -12681,18 +12216,6 @@
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/pg": "8.6.1",
         "@types/pg-pool": "2.0.3"
-      },
-      "dependencies": {
-        "@opentelemetry/instrumentation": {
-          "version": "0.34.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.34.0.tgz",
-          "integrity": "sha512-VET/bOh4StOQV4vf1sAvn2JD67BhW2vPZ/ynl2gHXyafme2yB8Hs9+tr1TLzFwNGo7jwMFviFQkZjCYxMuK0AA==",
-          "requires": {
-            "require-in-the-middle": "^5.0.3",
-            "semver": "^7.3.2",
-            "shimmer": "^1.2.1"
-          }
-        }
       }
     },
     "@opentelemetry/instrumentation-redis": {
@@ -12703,18 +12226,6 @@
         "@opentelemetry/instrumentation": "^0.34.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/redis": "2.8.31"
-      },
-      "dependencies": {
-        "@opentelemetry/instrumentation": {
-          "version": "0.34.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.34.0.tgz",
-          "integrity": "sha512-VET/bOh4StOQV4vf1sAvn2JD67BhW2vPZ/ynl2gHXyafme2yB8Hs9+tr1TLzFwNGo7jwMFviFQkZjCYxMuK0AA==",
-          "requires": {
-            "require-in-the-middle": "^5.0.3",
-            "semver": "^7.3.2",
-            "shimmer": "^1.2.1"
-          }
-        }
       }
     },
     "@opentelemetry/instrumentation-redis-4": {
@@ -12724,18 +12235,6 @@
       "requires": {
         "@opentelemetry/instrumentation": "^0.34.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
-      },
-      "dependencies": {
-        "@opentelemetry/instrumentation": {
-          "version": "0.34.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.34.0.tgz",
-          "integrity": "sha512-VET/bOh4StOQV4vf1sAvn2JD67BhW2vPZ/ynl2gHXyafme2yB8Hs9+tr1TLzFwNGo7jwMFviFQkZjCYxMuK0AA==",
-          "requires": {
-            "require-in-the-middle": "^5.0.3",
-            "semver": "^7.3.2",
-            "shimmer": "^1.2.1"
-          }
-        }
       }
     },
     "@opentelemetry/instrumentation-restify": {
@@ -12746,18 +12245,6 @@
         "@opentelemetry/core": "^1.8.0",
         "@opentelemetry/instrumentation": "^0.34.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
-      },
-      "dependencies": {
-        "@opentelemetry/instrumentation": {
-          "version": "0.34.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.34.0.tgz",
-          "integrity": "sha512-VET/bOh4StOQV4vf1sAvn2JD67BhW2vPZ/ynl2gHXyafme2yB8Hs9+tr1TLzFwNGo7jwMFviFQkZjCYxMuK0AA==",
-          "requires": {
-            "require-in-the-middle": "^5.0.3",
-            "semver": "^7.3.2",
-            "shimmer": "^1.2.1"
-          }
-        }
       }
     },
     "@opentelemetry/otlp-exporter-base": {
@@ -12878,18 +12365,6 @@
         "@opentelemetry/sdk-trace-base": "1.8.0",
         "@opentelemetry/sdk-trace-node": "1.8.0",
         "@opentelemetry/semantic-conventions": "1.8.0"
-      },
-      "dependencies": {
-        "@opentelemetry/instrumentation": {
-          "version": "0.34.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.34.0.tgz",
-          "integrity": "sha512-VET/bOh4StOQV4vf1sAvn2JD67BhW2vPZ/ynl2gHXyafme2yB8Hs9+tr1TLzFwNGo7jwMFviFQkZjCYxMuK0AA==",
-          "requires": {
-            "require-in-the-middle": "^5.0.3",
-            "semver": "^7.3.2",
-            "shimmer": "^1.2.1"
-          }
-        }
       }
     },
     "@opentelemetry/sdk-trace-base": {
@@ -12921,12 +12396,12 @@
       "integrity": "sha512-TYh1MRcm4JnvpqtqOwT9WYaBYY4KERHdToxs/suDTLviGRsQkIjS5yYROTYTSJQUnYLOn/TuOh5GoMwfLSU+Ew=="
     },
     "@prisma/instrumentation": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@prisma/instrumentation/-/instrumentation-4.4.0.tgz",
-      "integrity": "sha512-bSJfnH8aW3VXRuQ/pvi4uilnoJvuiXTT+YfXj+N4wURn+o1OGHIJsQZw14DrVPtMNjtZPFtmcUMPhPMc25QB8Q==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@prisma/instrumentation/-/instrumentation-4.9.0.tgz",
+      "integrity": "sha512-VUXZIshCZCrCTHKiH++u7bWlWlpwwK9sHhO/5c+U1wc1GFEOO61ReW8Vy8CMxVUiCxs0zB1bgXQ2UG0JdXug9Q==",
       "requires": {
-        "@opentelemetry/api": "^1.1.0",
-        "@opentelemetry/instrumentation": "^0.33.0"
+        "@opentelemetry/api": "^1.3.0",
+        "@opentelemetry/instrumentation": "^0.34.0"
       }
     },
     "@protobufjs/aspromise": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@opentelemetry/instrumentation-restify": "^0.32.0",
     "@opentelemetry/sdk-node": "^0.34.0",
     "@opentelemetry/sdk-trace-base": "^1.8.0",
-    "@prisma/instrumentation": "^4.4.0",
+    "@prisma/instrumentation": "^4.9.0",
     "node-addon-api": "^3.1.0",
     "node-gyp": "^9.0.0",
     "tslib": "^2.0.3",


### PR DESCRIPTION
Resolves issue #822 about it printing a deprecation warning about the `@opentelemetry/api-metrics` package upon install.