### PR TITLE
Bump agent to 050d7a5

### DIFF
--- a/.changesets/bump-agent-to-050d7a5.md
+++ b/.changesets/bump-agent-to-050d7a5.md
@@ -1,0 +1,9 @@
+---
+bump: "patch"
+type: "change"
+---
+
+Bump agent to 050d7a5.
+
+- Fix distributed tracing for Node.js HTTP requests.
+- Create tags for specific HTTP attributes for all spans.

--- a/scripts/extension/support/constants.js
+++ b/scripts/extension/support/constants.js
@@ -3,7 +3,7 @@
 // appsignal-agent repository.
 // Modifications to this file will be overwritten with the next agent release.
 
-const AGENT_VERSION = "041b9c4"
+const AGENT_VERSION = "050d7a5"
 const MIRRORS = [
   "https://appsignal-agent-releases.global.ssl.fastly.net",
   "https://d135dj0rjqvssy.cloudfront.net"
@@ -12,67 +12,67 @@ const MIRRORS = [
 const TRIPLES = {
   "x86_64-darwin": {
     checksum:
-      "1516895bcf7295b182ae816535ae21992cf7ab56686b3084787bed1d72007c52",
+      "ee62934bada7c56fdcd24db84acd42f2cca5d1451f8d0dc7da300c39cc3d6775",
     filename: "appsignal-x86_64-darwin-all-static.tar.gz"
   },
   "universal-darwin": {
     checksum:
-      "1516895bcf7295b182ae816535ae21992cf7ab56686b3084787bed1d72007c52",
+      "ee62934bada7c56fdcd24db84acd42f2cca5d1451f8d0dc7da300c39cc3d6775",
     filename: "appsignal-x86_64-darwin-all-static.tar.gz"
   },
   "aarch64-darwin": {
     checksum:
-      "1131e69c561a8b8df162f6d7d18b8e7a13a6ae3df095eccad5fe47ad3ebdf4db",
+      "d13c776f6de7a2a727cb6483a30c46e322f8e1190bea403e30b10095633422f8",
     filename: "appsignal-aarch64-darwin-all-static.tar.gz"
   },
   "arm64-darwin": {
     checksum:
-      "1131e69c561a8b8df162f6d7d18b8e7a13a6ae3df095eccad5fe47ad3ebdf4db",
+      "d13c776f6de7a2a727cb6483a30c46e322f8e1190bea403e30b10095633422f8",
     filename: "appsignal-aarch64-darwin-all-static.tar.gz"
   },
   "arm-darwin": {
     checksum:
-      "1131e69c561a8b8df162f6d7d18b8e7a13a6ae3df095eccad5fe47ad3ebdf4db",
+      "d13c776f6de7a2a727cb6483a30c46e322f8e1190bea403e30b10095633422f8",
     filename: "appsignal-aarch64-darwin-all-static.tar.gz"
   },
   "aarch64-linux": {
     checksum:
-      "bb7d6cdf86882e144840f8c15d832beaf2eca0696aad9c99ad14883738c6f358",
+      "1f605cc4a9d12a4a8a3700354e93b0989e7cfbf643d5233de961d6ac9428479b",
     filename: "appsignal-aarch64-linux-all-static.tar.gz"
   },
   "i686-linux": {
     checksum:
-      "68eed9076c4a859d3415127fc0b0ad9d6a059df936af3fe619df5efca5162915",
+      "a2e18e3468b9b10a7f51f292343f00715a1c3bfa8784b5646ef8fbd8939a29a8",
     filename: "appsignal-i686-linux-all-static.tar.gz"
   },
   "x86-linux": {
     checksum:
-      "68eed9076c4a859d3415127fc0b0ad9d6a059df936af3fe619df5efca5162915",
+      "a2e18e3468b9b10a7f51f292343f00715a1c3bfa8784b5646ef8fbd8939a29a8",
     filename: "appsignal-i686-linux-all-static.tar.gz"
   },
   "x86_64-linux": {
     checksum:
-      "13e9bd42518adac8838b938d197e1c211ed41611906f6b4b19962c95ba2ec352",
+      "799666e1f87c9a72f8020ea68db1a59fe97bf0ee8a963a9d2fe2e4b83a6033f2",
     filename: "appsignal-x86_64-linux-all-static.tar.gz"
   },
   "x86_64-linux-musl": {
     checksum:
-      "89b517bf79514e534d2e9df39c2b5e7aa857e831c961034586334f1d622ca633",
+      "dbcf231cbddf730c80a2e34c0c615df4f36dbd98618eeb51da4d752c757f5a43",
     filename: "appsignal-x86_64-linux-musl-all-static.tar.gz"
   },
   "aarch64-linux-musl": {
     checksum:
-      "64034582e6caed028c102a7f24c0a0dec0f8447eeadaf86a156db8527f936815",
+      "517a37943737449fea6c9bdc7bda3c4e9ce7f4f934548124228e2d70f3868e38",
     filename: "appsignal-aarch64-linux-musl-all-static.tar.gz"
   },
   "x86_64-freebsd": {
     checksum:
-      "c37a5e48eebc91ed750c1e51b8a0d569b5913f183405f62b4c3c15f9a17f1980",
+      "7276a11b75d2e9c00dfe16f5f5e59ee2e39984188104ec8bf6d8ec74290a0847",
     filename: "appsignal-x86_64-freebsd-all-static.tar.gz"
   },
   "amd64-freebsd": {
     checksum:
-      "c37a5e48eebc91ed750c1e51b8a0d569b5913f183405f62b4c3c15f9a17f1980",
+      "7276a11b75d2e9c00dfe16f5f5e59ee2e39984188104ec8bf6d8ec74290a0847",
     filename: "appsignal-x86_64-freebsd-all-static.tar.gz"
   }
 }


### PR DESCRIPTION
- Fix distributed tracing for Node.js HTTP requests.
- Create tags for specific HTTP attributes for all spans.

[skip review]