### PR TITLE
Support formats in logger

### DIFF
--- a/.changesets/bump-agent-to-8d042e2.md
+++ b/.changesets/bump-agent-to-8d042e2.md
@@ -1,0 +1,8 @@
+---
+bump: "patch"
+type: "change"
+---
+
+Bump agent to 8d042e2.
+
+- Support multiple log formats.

--- a/ext/appsignal_extension.cpp
+++ b/ext/appsignal_extension.cpp
@@ -257,13 +257,15 @@ Napi::Value Log(const Napi::CallbackInfo &info) {
 
   Napi::String group = info[0].As<Napi::String>();
   Napi::Number severity = info[1].As<Napi::Number>();
-  Napi::String message = info[2].As<Napi::String>();
+  Napi::Number format = info[2].As<Napi::Number>();
+  Napi::String message = info[3].As<Napi::String>();
   Napi::External<appsignal_data_t> attributes =
-    info[3].As<Napi::External<appsignal_data_t>>();
+    info[4].As<Napi::External<appsignal_data_t>>();
 
   appsignal_log(
     MakeAppsignalString(group),
     severity.Int32Value(),
+    format.Int32Value(),
     MakeAppsignalString(message),
     attributes.Data()
   );

--- a/scripts/extension/support/constants.js
+++ b/scripts/extension/support/constants.js
@@ -3,7 +3,7 @@
 // appsignal-agent repository.
 // Modifications to this file will be overwritten with the next agent release.
 
-const AGENT_VERSION = "0d593d5"
+const AGENT_VERSION = "8d042e2"
 const MIRRORS = [
   "https://appsignal-agent-releases.global.ssl.fastly.net",
   "https://d135dj0rjqvssy.cloudfront.net"
@@ -12,67 +12,67 @@ const MIRRORS = [
 const TRIPLES = {
   "x86_64-darwin": {
     checksum:
-      "8e63a3b1ee61165914e6dbb8654c1ad7f096079c77d0559c1733dff15103f4ab",
+      "e0142859f35e31b52dcc57418636c05bcb21940ad499bbe255f90a1cf7359bf7",
     filename: "appsignal-x86_64-darwin-all-static.tar.gz"
   },
   "universal-darwin": {
     checksum:
-      "8e63a3b1ee61165914e6dbb8654c1ad7f096079c77d0559c1733dff15103f4ab",
+      "e0142859f35e31b52dcc57418636c05bcb21940ad499bbe255f90a1cf7359bf7",
     filename: "appsignal-x86_64-darwin-all-static.tar.gz"
   },
   "aarch64-darwin": {
     checksum:
-      "cdf323d1b411f45084c13dc4a2c0f980599273d64ab91a28cd07bbc48b3293f6",
+      "5a1ab02452497b29222d580f3e9d3649eb547b8c90338858462d4f221dd18ff9",
     filename: "appsignal-aarch64-darwin-all-static.tar.gz"
   },
   "arm64-darwin": {
     checksum:
-      "cdf323d1b411f45084c13dc4a2c0f980599273d64ab91a28cd07bbc48b3293f6",
+      "5a1ab02452497b29222d580f3e9d3649eb547b8c90338858462d4f221dd18ff9",
     filename: "appsignal-aarch64-darwin-all-static.tar.gz"
   },
   "arm-darwin": {
     checksum:
-      "cdf323d1b411f45084c13dc4a2c0f980599273d64ab91a28cd07bbc48b3293f6",
+      "5a1ab02452497b29222d580f3e9d3649eb547b8c90338858462d4f221dd18ff9",
     filename: "appsignal-aarch64-darwin-all-static.tar.gz"
   },
   "aarch64-linux": {
     checksum:
-      "a6baf7c586722c71c9d5ec885c8ca17da6b9fc9c5d7ab154a7b667f28d082a0f",
+      "0e85a0a13b9457c4ee1f316e92e8d95de9125bbaff90ceb826bcefaaffa413d9",
     filename: "appsignal-aarch64-linux-all-static.tar.gz"
   },
   "i686-linux": {
     checksum:
-      "c102053fe1f68af84d0b362bd892256981bc4a2dec7e12fec27ea57ba0efbda2",
+      "0e8a0490ca960bb8e57183156ed4999afbd70cf13c640fe96f9b0e25556075f1",
     filename: "appsignal-i686-linux-all-static.tar.gz"
   },
   "x86-linux": {
     checksum:
-      "c102053fe1f68af84d0b362bd892256981bc4a2dec7e12fec27ea57ba0efbda2",
+      "0e8a0490ca960bb8e57183156ed4999afbd70cf13c640fe96f9b0e25556075f1",
     filename: "appsignal-i686-linux-all-static.tar.gz"
   },
   "x86_64-linux": {
     checksum:
-      "8f3987d22f0fcbd466377e624aa645c5b9b0f4bbc88855ddb7076b09b9a8d42a",
+      "4eec193edeae76e0793789846112ac9127870c90a8ae6e47aa2a8490163733aa",
     filename: "appsignal-x86_64-linux-all-static.tar.gz"
   },
   "x86_64-linux-musl": {
     checksum:
-      "e353e165f828cb788c85199adb1b39f15c26406da948117a34b4944f6eabfabc",
+      "d91d1ed6e775cc00319fca0a4144dff064d31fb6a8a28dbb5027add44e4dab02",
     filename: "appsignal-x86_64-linux-musl-all-static.tar.gz"
   },
   "aarch64-linux-musl": {
     checksum:
-      "b08c5d65fbff05ac6838aa0ed4614b669701f009826652f7d67ab423fede0e44",
+      "0ff6702bd976871f610f39ff6c2dd73c4535b12c15c81c0d0afab7650e75922d",
     filename: "appsignal-aarch64-linux-musl-all-static.tar.gz"
   },
   "x86_64-freebsd": {
     checksum:
-      "f516b4c84274b9c56cbcb11c252685a4ef97b68b9fec6c189dde96fd37bbf515",
+      "d973edc7f13cdad2993c415f17a680a4de3288ce57fc5ae0c69ef3a1ccbb2856",
     filename: "appsignal-x86_64-freebsd-all-static.tar.gz"
   },
   "amd64-freebsd": {
     checksum:
-      "f516b4c84274b9c56cbcb11c252685a4ef97b68b9fec6c189dde96fd37bbf515",
+      "d973edc7f13cdad2993c415f17a680a4de3288ce57fc5ae0c69ef3a1ccbb2856",
     filename: "appsignal-x86_64-freebsd-all-static.tar.gz"
   }
 }

--- a/src/__tests__/winston_transport.test.ts
+++ b/src/__tests__/winston_transport.test.ts
@@ -35,6 +35,7 @@ describe("BaseLogger", () => {
     expect(client.extension.log).toHaveBeenCalledWith(
       "groupname",
       3,
+      0,
       "some data and some more data",
       { foo: 123, bar: 456 }
     )
@@ -46,6 +47,7 @@ describe("BaseLogger", () => {
     expect(client.extension.log).toHaveBeenCalledWith(
       "childgroup",
       3,
+      0,
       "child logger message",
       { child: "foo", argument: 123 }
     )
@@ -60,6 +62,7 @@ describe("BaseLogger", () => {
     expect(client.extension.log).toHaveBeenCalledWith(
       "groupname",
       3,
+      0,
       "no nested keys",
       { argument: 123 }
     )
@@ -70,6 +73,7 @@ describe("BaseLogger", () => {
     expect(client.extension.log).toHaveBeenCalledWith(
       "groupname",
       3,
+      0,
       "no arrays",
       { argument: 123 }
     )
@@ -85,6 +89,7 @@ describe("BaseLogger", () => {
     expect(client.extension.log).toHaveBeenCalledWith(
       "groupname",
       3,
+      0,
       "no color for me",
       { argument: 123 }
     )
@@ -99,6 +104,7 @@ describe("BaseLogger", () => {
     expect(client.extension.log).toHaveBeenCalledWith(
       "groupname",
       3,
+      0,
       "no timestamp for me",
       { argument: 123 }
     )
@@ -112,6 +118,7 @@ describe("BaseLogger", () => {
     expect(client.extension.log).toHaveBeenCalledWith(
       "groupname",
       3,
+      0,
       "info message",
       {}
     )
@@ -133,6 +140,7 @@ describe("BaseLogger", () => {
     expect(client.extension.log).toHaveBeenCalledWith(
       "groupname",
       1,
+      0,
       "silly message",
       {}
     )
@@ -151,6 +159,7 @@ describe("BaseLogger", () => {
     expect(client.extension.log).toHaveBeenCalledWith(
       "groupname",
       3,
+      0,
       "foobar message",
       {}
     )
@@ -179,30 +188,35 @@ describe("BaseLogger", () => {
     expect(client.extension.log).toHaveBeenCalledWith(
       "groupname",
       1,
+      0,
       "trace message",
       {}
     )
     expect(client.extension.log).toHaveBeenCalledWith(
       "groupname",
       2,
+      0,
       "debug message",
       {}
     )
     expect(client.extension.log).toHaveBeenCalledWith(
       "groupname",
       3,
+      0,
       "info message",
       {}
     )
     expect(client.extension.log).toHaveBeenCalledWith(
       "groupname",
       5,
+      0,
       "warn message",
       {}
     )
     expect(client.extension.log).toHaveBeenCalledWith(
       "groupname",
       6,
+      0,
       "error message",
       {}
     )
@@ -226,42 +240,49 @@ describe("BaseLogger", () => {
     expect(client.extension.log).toHaveBeenCalledWith(
       "groupname",
       1,
+      0,
       "silly message",
       {}
     )
     expect(client.extension.log).toHaveBeenCalledWith(
       "groupname",
       2,
+      0,
       "debug message",
       {}
     )
     expect(client.extension.log).toHaveBeenCalledWith(
       "groupname",
       2,
+      0,
       "verbose message",
       {}
     )
     expect(client.extension.log).toHaveBeenCalledWith(
       "groupname",
       3,
+      0,
       "http message",
       {}
     )
     expect(client.extension.log).toHaveBeenCalledWith(
       "groupname",
       3,
+      0,
       "http message",
       {}
     )
     expect(client.extension.log).toHaveBeenCalledWith(
       "groupname",
       5,
+      0,
       "warn message",
       {}
     )
     expect(client.extension.log).toHaveBeenCalledWith(
       "groupname",
       6,
+      0,
       "error message",
       {}
     )
@@ -287,48 +308,56 @@ describe("BaseLogger", () => {
     expect(client.extension.log).toHaveBeenCalledWith(
       "groupname",
       9,
+      0,
       "emerg message",
       {}
     )
     expect(client.extension.log).toHaveBeenCalledWith(
       "groupname",
       8,
+      0,
       "alert message",
       {}
     )
     expect(client.extension.log).toHaveBeenCalledWith(
       "groupname",
       7,
+      0,
       "crit message",
       {}
     )
     expect(client.extension.log).toHaveBeenCalledWith(
       "groupname",
       6,
+      0,
       "error message",
       {}
     )
     expect(client.extension.log).toHaveBeenCalledWith(
       "groupname",
       5,
+      0,
       "warning message",
       {}
     )
     expect(client.extension.log).toHaveBeenCalledWith(
       "groupname",
       4,
+      0,
       "notice message",
       {}
     )
     expect(client.extension.log).toHaveBeenCalledWith(
       "groupname",
       3,
+      0,
       "info message",
       {}
     )
     expect(client.extension.log).toHaveBeenCalledWith(
       "groupname",
       2,
+      0,
       "debug message",
       {}
     )

--- a/src/client.ts
+++ b/src/client.ts
@@ -8,7 +8,7 @@ import { NoopMetrics, noopIntegrationLogger, noopLogger } from "./noops"
 import { demo } from "./demo"
 import { VERSION } from "./version"
 import { setParams, setSessionData } from "./helpers"
-import { BaseLogger, Logger, LoggerLevel } from "./logger"
+import { BaseLogger, Logger, LoggerFormat, LoggerLevel } from "./logger"
 
 import { Instrumentation } from "@opentelemetry/instrumentation"
 import {
@@ -123,9 +123,13 @@ export class Client {
   /**
    * Global accessors for the AppSignal Logger API
    */
-  static logger(group: string, level?: LoggerLevel): Logger {
+  static logger(
+    group: string,
+    level: LoggerLevel = "info",
+    format: LoggerFormat = "plaintext"
+  ): Logger {
     if (this.client) {
-      return this.client.logger(group, level)
+      return this.client.logger(group, level, format)
     } else {
       return noopLogger
     }
@@ -230,9 +234,13 @@ export class Client {
     return this.#metrics
   }
 
-  public logger(group: string, level?: LoggerLevel): Logger {
+  public logger(
+    group: string,
+    level: LoggerLevel = "info",
+    format: LoggerFormat = "plaintext"
+  ): Logger {
     if (this.isActive) {
-      return new BaseLogger(this, group, level)
+      return new BaseLogger(this, group, level, format)
     } else {
       return noopLogger
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -73,10 +73,11 @@ export class Extension {
   public log(
     group: string,
     severity: number,
+    format: number,
     message: string,
     attributes: any
   ) {
-    extension.log(group, severity, message, Data.generate(attributes))
+    extension.log(group, severity, format, message, Data.generate(attributes))
   }
 
   /**

--- a/src/winston_transport.ts
+++ b/src/winston_transport.ts
@@ -76,6 +76,7 @@ export class WinstonTransport extends Transport {
     client.extension.log(
       group || this.#group,
       levelSeverity,
+      0,
       message,
       attributes
     )


### PR DESCRIPTION
Accept a third argument when creating a logger that sets the format that messages in logs will be parsed as. Bumps agent to 8d042e2