### PR TITLE
Add warnings to 2.x old packages

### DIFF
--- a/packages/apollo-server/.changesets/add-warning-to-readme.md
+++ b/packages/apollo-server/.changesets/add-warning-to-readme.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "change"
+---
+
+Add warning to README about v2 and v3 compatibility.

--- a/packages/apollo-server/README.md
+++ b/packages/apollo-server/README.md
@@ -4,6 +4,8 @@
 
 The AppSignal for Node.js integration for Apollo GraphQL (`apollo-server`) v2.0.0+.
 
+⚠️  This package is no longer required for AppSignal for Node.js [version 3.0](https://docs.appsignal.com/nodejs/3.x.html). If you use version 3.0 or newer in your app, please remove this package from your `package.json` file.
+
 ## Installation
 
 First, [sign up for an AppSignal account][appsignal-sign-up] and add both the `@appsignal/nodejs` and `@appsignal/apollo-server` packages to your `package.json`. Then, run `yarn install`/`npm install`.

--- a/packages/express/.changesets/add-warning-to-readme.md
+++ b/packages/express/.changesets/add-warning-to-readme.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "change"
+---
+
+Add warning to README about v2 and v3 compatibility.

--- a/packages/express/README.md
+++ b/packages/express/README.md
@@ -4,6 +4,8 @@
 
 The AppSignal for Node.js integration for Express.js (`express`) v4.0.0+.
 
+⚠️  This package is no longer required for AppSignal for Node.js [version 3.0](https://docs.appsignal.com/nodejs/3.x.html). If you use version 3.0 or newer in your app, please remove this package from your `package.json` file.
+
 ## Installation
 
 First, [sign up for an AppSignal account][appsignal-sign-up] and add both the `@appsignal/nodejs` and `@appsignal/express` packages to your `package.json`. Then, run `yarn install`/`npm install`.

--- a/packages/koa/.changesets/add-warning-to-readme.md
+++ b/packages/koa/.changesets/add-warning-to-readme.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "change"
+---
+
+Add warning to README about v2 and v3 compatibility.

--- a/packages/koa/README.md
+++ b/packages/koa/README.md
@@ -4,6 +4,8 @@
 
 The AppSignal for Node.js integration for Koa (`koa`) v2.0.0+.
 
+⚠️  This package is no longer required for AppSignal for Node.js [version 3.0](https://docs.appsignal.com/nodejs/3.x.html). If you use version 3.0 or newer in your app, please remove this package from your `package.json` file.
+
 ## Installation
 
 First, [sign up for an AppSignal account][appsignal-sign-up] and add both the `@appsignal/nodejs` and `@appsignal/koa` packages to your `package.json`. Then, run `yarn install`/`npm install`.

--- a/packages/nextjs/.changesets/add-warning-to-readme.md
+++ b/packages/nextjs/.changesets/add-warning-to-readme.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "change"
+---
+
+Add warning to README about v2 and v3 compatibility.

--- a/packages/nextjs/README.md
+++ b/packages/nextjs/README.md
@@ -4,6 +4,8 @@
 
 The AppSignal integration for [Next.js](https://nextjs.org/) 9.3.0+, designed to be used in conjunction with `@appsignal/nodejs`. 
 
+⚠️  This package is no longer required for AppSignal for Node.js [version 3.0](https://docs.appsignal.com/nodejs/3.x.html). If you use version 3.0 or newer in your app, please remove this package from your `package.json` file.
+
 It is recommended to be used with [`@appsignal/javascript`](https://github.com/appsignal/appsignal-javascript/tree/develop/packages/javascript) and [`@appsignal/react`](https://github.com/appsignal/appsignal-javascript/tree/develop/packages/react) on the client side for full-stack performance monitoring and error tracking.
 
 At this time, it's only possible to use this integration with a [custom server script](https://nextjs.org/docs/advanced-features/custom-server). The integration **does not** work when using the Next CLI (e.g. `next start`). 


### PR DESCRIPTION
Avoid confusion when people view our 2.x packages on npm when they're using 3.x or newer. Add a small warning to the top of the README to link people to the v3 docs.

This will require a patch release for all packages to have this update show up on npmjs.org.

Closes #869

The test suite fails for the latest Next.js, but that's irrelevant for this change.