### PR TITLE
Do not crash on malformed error events

### DIFF
--- a/src/span_processor.ts
+++ b/src/span_processor.ts
@@ -47,11 +47,17 @@ export class SpanProcessor implements OpenTelemetrySpanProcessor {
     errors.forEach(e => {
       const eventAttributes = e["attributes"] as any
 
-      opentelemetrySpan.setError(
-        eventAttributes["exception.type"],
-        eventAttributes["exception.message"],
-        eventAttributes["exception.stacktrace"]
-      )
+      if (
+        typeof eventAttributes["exception.type"] === "string" &&
+        typeof eventAttributes["exception.message"] === "string" &&
+        typeof eventAttributes["exception.stacktrace"] === "string"
+      ) {
+        opentelemetrySpan.setError(
+          eventAttributes["exception.type"],
+          eventAttributes["exception.message"],
+          eventAttributes["exception.stacktrace"]
+        )
+      }
     })
 
     opentelemetrySpan.close()


### PR DESCRIPTION
For some reason, if an error is thrown when rendering a Next.js template, the error will be forwarded to the back-end and reported to OpenTelemetry, but it will not have a type or a stacktrace. The extension, in turn, finds an `undefined` where a `string` should be, and throws an error accordingly.

I don't think we'd be able to do much with such an error further down the pipeline anyway, so if an exception event like that is encountered, consider it malformed and ignore it, not sending it to the extension.