### PR TITLE
Add the presence of the client file to diagnose

### DIFF
--- a/.changesets/report-client-file-presence-in-diagnose-result.md
+++ b/.changesets/report-client-file-presence-in-diagnose-result.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "add"
+---
+
+The diagnose CLI command now reports on the presence of the `appsignal.cjs` file.

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -216,6 +216,42 @@ describe("Configuration", () => {
     })
   })
 
+  describe("clientFilePath", () => {
+    describe("when the client file exists in the root path", () => {
+      it("returns the path to the client file", () => {
+        jest.spyOn(fs, "existsSync").mockImplementation(givenPath => {
+          return givenPath === path.join(process.cwd(), "appsignal.cjs")
+        })
+        config = new Configuration({ name, pushApiKey })
+
+        expect(config.clientFilePath).toEqual(
+          path.join(process.cwd(), "appsignal.cjs")
+        )
+      })
+    })
+
+    describe("when the client file exists in the src path", () => {
+      it("returns the path to the client file", () => {
+        jest.spyOn(fs, "existsSync").mockImplementation(givenPath => {
+          return givenPath === path.join(process.cwd(), "src", "appsignal.cjs")
+        })
+        config = new Configuration({ name, pushApiKey })
+
+        expect(config.clientFilePath).toEqual(
+          path.join(process.cwd(), "src", "appsignal.cjs")
+        )
+      })
+    })
+
+    describe("when the client file does not exist", () => {
+      it("returns undefined", () => {
+        config = new Configuration({ name, pushApiKey })
+
+        expect(config.clientFilePath).toBeUndefined()
+      })
+    })
+  })
+
   describe("private environment variables", () => {
     beforeEach(() => {
       new Configuration({})

--- a/src/cli/diagnose.ts
+++ b/src/cli/diagnose.ts
@@ -181,6 +181,13 @@ export class Diagnose {
 
     this.print_newline()
 
+    console.log(`  AppSignal client file`)
+    console.log(
+      `    Path: ${format_value(data["paths"]["appsignal.cjs"]["path"])}`
+    )
+
+    this.print_newline()
+
     console.log(`  AppSignal log`)
     console.log(
       `    Path: ${format_value(data["paths"]["appsignal.log"]["path"])}`

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,6 @@
 import path from "path"
 import os from "os"
+import fs from "fs"
 
 import { VERSION } from "./version"
 import { isWritable } from "./utils"
@@ -71,6 +72,18 @@ export class Configuration {
           `Unable to log to ${configuredPath}'${tmpDir}' fallback. Please check the permissions of these directories.`
         )
       }
+    }
+  }
+
+  public get clientFilePath(): string | undefined {
+    const filename = "appsignal.cjs"
+
+    if (fs.existsSync(path.join(process.cwd(), filename))) {
+      return path.join(process.cwd(), filename)
+    } else if (fs.existsSync(path.join(process.cwd(), "src", filename))) {
+      return path.join(process.cwd(), "src", filename)
+    } else {
+      return undefined
     }
   }
 

--- a/src/diagnose.ts
+++ b/src/diagnose.ts
@@ -147,7 +147,6 @@ export class DiagnoseTool {
 
   private getPathsData() {
     const paths: { [key: string]: FileMetadata } = {}
-
     const logFilePath = this.#config.logFilePath
 
     const pathsToCheck = {
@@ -156,6 +155,9 @@ export class DiagnoseTool {
       },
       log_dir_path: {
         path: logFilePath ? path.dirname(logFilePath) : ""
+      },
+      "appsignal.cjs": {
+        path: this.#config.clientFilePath || ""
       },
       "appsignal.log": {
         path: logFilePath || "",


### PR DESCRIPTION
The diagnose report now checks on the presence of the `appsignal.cjs` file we require customers to initialize the AppSignal client when starting their apps.

Part of: https://github.com/appsignal/appsignal-nodejs/issues/882