### PR TITLE
Config client diagnose

### DIFF
--- a/.changesets/load-the-client-file-when-running-the-diagnose.md
+++ b/.changesets/load-the-client-file-when-running-the-diagnose.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "add"
+---
+
+Load the AppSignal app configuration file when running the diagnose to include the configuration in the diagnose report.

--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -118,11 +118,11 @@ describe("Client", () => {
   })
 
   it("does not start the client if diagnose mode is enabled", () => {
-    process.env["APPSIGNAL_DIAGNOSE"] = "true"
+    process.env._APPSIGNAL_DIAGNOSE = "true"
     const startSpy = jest.spyOn(Extension.prototype, "start")
     client = new Client({ ...DEFAULT_OPTS, active: true })
-    expect(startSpy).toHaveBeenCalled()
-    delete process.env["APPSIGNAL_DIAGNOSE"]
+    expect(startSpy).not.toHaveBeenCalled()
+    delete process.env._APPSIGNAL_DIAGNOSE
   })
 
   it("starts the client when the active option is true", () => {

--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -117,6 +117,14 @@ describe("Client", () => {
     expect(startSpy).not.toHaveBeenCalled()
   })
 
+  it("does not start the client if diagnose mode is enabled", () => {
+    process.env["APPSIGNAL_DIAGNOSE"] = "true"
+    const startSpy = jest.spyOn(Extension.prototype, "start")
+    client = new Client({ ...DEFAULT_OPTS, active: true })
+    expect(startSpy).toHaveBeenCalled()
+    delete process.env["APPSIGNAL_DIAGNOSE"]
+  })
+
   it("starts the client when the active option is true", () => {
     const startSpy = jest.spyOn(Extension.prototype, "start")
     client = new Client({ ...DEFAULT_OPTS, active: true })

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -222,9 +222,8 @@ describe("Configuration", () => {
         jest.spyOn(fs, "existsSync").mockImplementation(givenPath => {
           return givenPath === path.join(process.cwd(), "appsignal.cjs")
         })
-        config = new Configuration({ name, pushApiKey })
 
-        expect(config.clientFilePath).toEqual(
+        expect(Configuration.clientFilePath).toEqual(
           path.join(process.cwd(), "appsignal.cjs")
         )
       })
@@ -235,9 +234,8 @@ describe("Configuration", () => {
         jest.spyOn(fs, "existsSync").mockImplementation(givenPath => {
           return givenPath === path.join(process.cwd(), "src", "appsignal.cjs")
         })
-        config = new Configuration({ name, pushApiKey })
 
-        expect(config.clientFilePath).toEqual(
+        expect(Configuration.clientFilePath).toEqual(
           path.join(process.cwd(), "src", "appsignal.cjs")
         )
       })
@@ -245,9 +243,7 @@ describe("Configuration", () => {
 
     describe("when the client file does not exist", () => {
       it("returns undefined", () => {
-        config = new Configuration({ name, pushApiKey })
-
-        expect(config.clientFilePath).toBeUndefined()
+        expect(Configuration.clientFilePath).toBeUndefined()
       })
     })
   })

--- a/src/client.ts
+++ b/src/client.ts
@@ -181,7 +181,11 @@ export class Client {
    * directory.
    */
   public start(): void {
-    if (this.config.isValid) {
+    if (process.env["APPSIGNAL_DIAGNOSE"]) {
+      Client.integrationLogger.info(
+        "Diagnose mode is enabled, not starting extension"
+      )
+    } else if (this.config.isValid) {
       this.extension.start()
     } else {
       console.error("Not starting, no valid AppSignal configuration found")

--- a/src/config.ts
+++ b/src/config.ts
@@ -75,7 +75,7 @@ export class Configuration {
     }
   }
 
-  public get clientFilePath(): string | undefined {
+  static get clientFilePath(): string | undefined {
     const filename = "appsignal.cjs"
 
     if (fs.existsSync(path.join(process.cwd(), filename))) {

--- a/src/diagnose.ts
+++ b/src/diagnose.ts
@@ -5,6 +5,7 @@ import { URL } from "url"
 import { isWritable, installReportPath, processGetuid } from "./utils"
 import { Extension } from "./extension"
 import { Configuration } from "./config"
+import { Client } from "./client"
 import { AGENT_VERSION, VERSION } from "./version"
 import { JS_TO_RUBY_MAPPING } from "./config/configmap"
 import { AppsignalOptions } from "./config/options"
@@ -34,7 +35,7 @@ export class DiagnoseTool {
   #extension: Extension
 
   constructor() {
-    this.#config = new Configuration({})
+    this.#config = this.getConfigObject()
     this.#extension = new Extension()
   }
 
@@ -209,6 +210,23 @@ export class DiagnoseTool {
    */
   private getConfigData() {
     return this.optionsObject(this.#config.data)
+  }
+
+  /**
+   * If it can load the client from the `appsignal.cjs` file, get the config
+   * object from the initialized client. Otherwise, return a default config object.
+   */
+  private getConfigObject(): Configuration {
+    const temporaryConfig = new Configuration({})
+
+    // The file is required to execute the client initialization
+    // that stores the config object on the global object, making
+    // it available calling `Client.config` later.
+    if (temporaryConfig.clientFilePath) {
+      require(temporaryConfig.clientFilePath)
+    }
+
+    return Client.config ?? temporaryConfig
   }
 
   /**

--- a/src/diagnose.ts
+++ b/src/diagnose.ts
@@ -158,7 +158,7 @@ export class DiagnoseTool {
         path: logFilePath ? path.dirname(logFilePath) : ""
       },
       "appsignal.cjs": {
-        path: this.#config.clientFilePath || ""
+        path: Configuration.clientFilePath || ""
       },
       "appsignal.log": {
         path: logFilePath || "",
@@ -217,16 +217,23 @@ export class DiagnoseTool {
    * object from the initialized client. Otherwise, return a default config object.
    */
   private getConfigObject(): Configuration {
-    const temporaryConfig = new Configuration({})
-
     // The file is required to execute the client initialization
     // that stores the config object on the global object, making
     // it available calling `Client.config` later.
-    if (temporaryConfig.clientFilePath) {
-      require(temporaryConfig.clientFilePath)
+    if (Configuration.clientFilePath) {
+      process.env._APPSIGNAL_DIAGNOSE = "true"
+      try {
+        require(Configuration.clientFilePath)
+      } catch (e: any) {
+        Client.integrationLogger.error(
+          `Error loading AppSignal client file ${e.message}`
+        )
+      }
+
+      delete process.env._APPSIGNAL_DIAGNOSE
     }
 
-    return Client.config ?? temporaryConfig
+    return Client.config ?? new Configuration({})
   }
 
   /**


### PR DESCRIPTION
### [Do not start extension if diagnose mode is enabled](https://github.com/appsignal/appsignal-nodejs/commit/b9fe462a2e8704c975a46b528123372ac5461dac)

When the `APPSIGNAL_DIAGNOSE` env var is present, don't start the extension from the client object. This will allow us to initialize the client during diagnose to check its configuration.

### [Load client file if present when running diagnose](https://github.com/appsignal/appsignal-nodejs/commit/90ea21a6402652cd552abbb48123cdc7a9422711)

The client file is loaded to take its values into account when running the diagnose script.

### [Make clientFilePath a static function](https://github.com/appsignal/appsignal-nodejs/pull/885/commits/26ee78f43e197297525e8161a5b9a154cd535dff) 

To know where the client file is stored, there's no need of
instantiating a Configuration object. This commit transforms the
`clientFilePath()` instance function into a static one.

Part of: https://github.com/appsignal/appsignal-nodejs/issues/882