### PR TITLE
Add deprecation warning to instrumentationsLoaded

### DIFF
--- a/.changesets/add-deprecation-warning-to-instrumentationsloaded-helper.md
+++ b/.changesets/add-deprecation-warning-to-instrumentationsloaded-helper.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "deprecate"
+---
+
+Add deprecation warning to instrumentationsLoaded helper

--- a/src/__tests__/helpers.test.ts
+++ b/src/__tests__/helpers.test.ts
@@ -288,23 +288,13 @@ describe("Helpers", () => {
     })
   })
 
-  describe("instrumentationsLoaded", () => {
-    it("returns a promise from the globally stored client if found", () => {
-      const debugMock = jest.spyOn(Client.integrationLogger, "debug")
-
-      expect(instrumentationsLoaded()).toBeInstanceOf(Promise)
-      expect(debugMock).toHaveBeenCalledTimes(0)
-    })
-
-    it("returns an empty promise and logs if the globally stored client is not found", () => {
-      // Remove the stored client
-      global.__APPSIGNAL__ = null as any
-
-      const debugMock = jest.spyOn(Client.integrationLogger, "debug")
+  describe("instrumentationsLoaded (deprecated)", () => {
+    it("returns a promise and a deprecation warning", () => {
+      const debugMock = jest.spyOn(Client.integrationLogger, "warn")
 
       expect(instrumentationsLoaded()).toBeInstanceOf(Promise)
       expect(debugMock).toHaveBeenCalledWith(
-        "Client is not initialized, cannot get OpenTelemetry instrumentations loaded"
+        "instrumentationsLoaded() is deprecated, please remove it from your code as it'll be deleted in the next major release."
       )
     })
   })

--- a/src/client.ts
+++ b/src/client.ts
@@ -90,7 +90,6 @@ export class Client {
   config: Configuration
   readonly integrationLogger: IntegrationLogger
   extension: Extension
-  instrumentationsLoaded: Promise<void>
 
   #metrics: Metrics
   #sdk?: NodeSDK
@@ -142,7 +141,6 @@ export class Client {
     this.config = new Configuration(options)
     this.extension = new Extension()
     this.integrationLogger = this.setUpIntegrationLogger()
-    this.instrumentationsLoaded = Promise.resolve()
     this.storeInGlobal()
 
     if (this.isActive) {

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -129,15 +129,13 @@ export function sendError(error: Error, fn: () => void = () => {}) {
   }
 }
 
+/**
+ * @deprecated This function is no longer required for manual instrumentation.
+ */
 export function instrumentationsLoaded(): Promise<void> {
-  const globallyStoredClient = Client.client
+  Client.integrationLogger.warn(
+    "instrumentationsLoaded() is deprecated, please remove it from your code as it'll be deleted in the next major release."
+  )
 
-  if (globallyStoredClient) {
-    return globallyStoredClient.instrumentationsLoaded
-  } else {
-    Client.integrationLogger.debug(
-      "Client is not initialized, cannot get OpenTelemetry instrumentations loaded"
-    )
-    return Promise.resolve()
-  }
+  return Promise.resolve()
 }


### PR DESCRIPTION
The `instrumentationsLoaded()` helper is not required anymore since the introduction of `sdk.start()` asynchronous OpenTelemetry load. This commits removes any logic related to the helper and a deprecation warning.

The client attribute is also removed as it was only used by the helper.

Part of: #877 