### PR TITLE
Warn if `appsignal.cjs` is missing

### DIFF
--- a/src/cli/diagnose.ts
+++ b/src/cli/diagnose.ts
@@ -356,6 +356,14 @@ export class Diagnose {
     sources: { [source: string]: { [key: string]: any } }
   }) {
     console.log(`Configuration`)
+
+    if (Object.keys(sources.initial).length === 0) {
+      console.log(
+        "\x1b[31mWarning\x1b[0m: The initialiser file (appsignal.cjs) could" +
+          " not be found. The configuration shown here may be incomplete."
+      )
+    }
+
     Object.keys(options)
       .sort()
       .forEach(key => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -76,15 +76,16 @@ export class Configuration {
   }
 
   static get clientFilePath(): string | undefined {
+    return this.clientFilePaths().find(fs.existsSync)
+  }
+
+  static clientFilePaths(): string[] {
     const filename = "appsignal.cjs"
 
-    if (fs.existsSync(path.join(process.cwd(), filename))) {
-      return path.join(process.cwd(), filename)
-    } else if (fs.existsSync(path.join(process.cwd(), "src", filename))) {
-      return path.join(process.cwd(), "src", filename)
-    } else {
-      return undefined
-    }
+    return [
+      path.join(process.cwd(), filename),
+      path.join(process.cwd(), "src", filename)
+    ]
   }
 
   /**

--- a/src/diagnose.ts
+++ b/src/diagnose.ts
@@ -231,6 +231,12 @@ export class DiagnoseTool {
       }
 
       delete process.env._APPSIGNAL_DIAGNOSE
+    } else {
+      Client.integrationLogger.warn(
+        "Could not find AppSignal client file at " +
+          `[${Configuration.clientFilePaths().join(",")}]. ` +
+          "Configuration in report may be incomplete."
+      )
     }
 
     return Client.config ?? new Configuration({})


### PR DESCRIPTION
Add a warning at the top of the configuration section when displaying the report. Also add a warning when generating the report, listing the paths at which the file was looked for.

Part of #910. [skip changeset]