### PR TITLE
Update version range to allow Prisma 5

### DIFF
--- a/.changesets/support-prisma-5.md
+++ b/.changesets/support-prisma-5.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "add"
+---
+
+Support Prisma 5

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@opentelemetry/instrumentation-restify": "^0.32.1",
         "@opentelemetry/sdk-node": "^0.37.0",
         "@opentelemetry/sdk-trace-base": "^1.11.0",
-        "@prisma/instrumentation": "^4.12.0",
+        "@prisma/instrumentation": "^4.12.0 || ^5",
         "node-addon-api": "^3.1.0",
         "node-gyp": "^9.0.0",
         "tslib": "^2.0.3",
@@ -2023,12 +2023,97 @@
       }
     },
     "node_modules/@prisma/instrumentation": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@prisma/instrumentation/-/instrumentation-4.12.0.tgz",
-      "integrity": "sha512-mSGO0EFWS1nZWBlvHpiV6IodPfbiAXgRw0PmtWJHUDCX+lPgvzSUYkfgeIKfYY/3VvECqAXyzbABDrnwaQgY2A==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@prisma/instrumentation/-/instrumentation-5.0.0.tgz",
+      "integrity": "sha512-GUt9ztQXriBmxPIDBd20eBHOX+LaF3zj4ot6mpMB/2YkceU4MvicdEoaX2VkF3r/xM7TatCF9IR2d35wOIv2GA==",
       "dependencies": {
-        "@opentelemetry/api": "^1.3.0",
-        "@opentelemetry/instrumentation": "^0.35.0"
+        "@opentelemetry/api": "1.4.1",
+        "@opentelemetry/instrumentation": "0.40.0",
+        "@opentelemetry/sdk-trace-base": "1.14.0"
+      }
+    },
+    "node_modules/@prisma/instrumentation/node_modules/@opentelemetry/core": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.14.0.tgz",
+      "integrity": "sha512-MnMZ+sxsnlzloeuXL2nm5QcNczt/iO82UOeQQDHhV83F2fP3sgntW2evvtoxJki0MBLxEsh5ADD7PR/Hn5uzjw==",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.14.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.5.0"
+      }
+    },
+    "node_modules/@prisma/instrumentation/node_modules/@opentelemetry/instrumentation": {
+      "version": "0.40.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.40.0.tgz",
+      "integrity": "sha512-23TzBKPflUS1uEq5SXymnQKQDSda35KvHjnvxdcDQGE+wg6hwDHgScUCWiBmZW4sxAaPcANfs+Wc9B7yDuyT6Q==",
+      "dependencies": {
+        "@types/shimmer": "^1.0.2",
+        "import-in-the-middle": "1.3.5",
+        "require-in-the-middle": "^7.1.0",
+        "semver": "^7.3.2",
+        "shimmer": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@prisma/instrumentation/node_modules/@opentelemetry/resources": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.14.0.tgz",
+      "integrity": "sha512-qRfWIgBxxl3z47E036Aey0Lj2ZjlFb27Q7Xnj1y1z/P293RXJZGLtcfn/w8JF7v1Q2hs3SDGxz7Wb9Dko1YUQA==",
+      "dependencies": {
+        "@opentelemetry/core": "1.14.0",
+        "@opentelemetry/semantic-conventions": "1.14.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.5.0"
+      }
+    },
+    "node_modules/@prisma/instrumentation/node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.14.0.tgz",
+      "integrity": "sha512-NzRGt3PS+HPKfQYMb6Iy8YYc5OKA73qDwci/6ujOIvyW9vcqBJSWbjZ8FeLEAmuatUB5WrRhEKu9b0sIiIYTrQ==",
+      "dependencies": {
+        "@opentelemetry/core": "1.14.0",
+        "@opentelemetry/resources": "1.14.0",
+        "@opentelemetry/semantic-conventions": "1.14.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.5.0"
+      }
+    },
+    "node_modules/@prisma/instrumentation/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.14.0.tgz",
+      "integrity": "sha512-rJfCY8rCWz3cb4KI6pEofnytvMPuj3YLQwoscCCYZ5DkdiPjo15IQ0US7+mjcWy9H3fcZIzf2pbJZ7ck/h4tug==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@prisma/instrumentation/node_modules/require-in-the-middle": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-7.2.0.tgz",
+      "integrity": "sha512-3TLx5TGyAY6AOqLBoXmHkNql0HIf2RGbuMgCDT2WO/uGVAPJs6h7Kl+bN6TIZGd9bWhWPwnDnTHGtW8Iu77sdw==",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "module-details-from-path": "^1.0.3",
+        "resolve": "^1.22.1"
+      },
+      "engines": {
+        "node": ">=8.6.0"
       }
     },
     "node_modules/@protobufjs/aspromise": {
@@ -2395,6 +2480,11 @@
         "@types/mime": "*",
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/shimmer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@types/shimmer/-/shimmer-1.0.2.tgz",
+      "integrity": "sha512-dKkr1bTxbEsFlh2ARpKzcaAmsYixqt9UyCdoEZk8rHyE4iQYcDCyvSjDSf7JUWJHlJiTtbIoQjxKh6ViywqDAg=="
     },
     "node_modules/@types/stack-utils": {
       "version": "2.0.1",
@@ -4703,6 +4793,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/import-in-the-middle": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.3.5.tgz",
+      "integrity": "sha512-yzHlBqi1EBFrkieAnSt8eTgO5oLSl+YJ7qaOpUH/PMqQOMZoQ/RmDlwnTLQrwYto+gHYjRG+i/IbsB1eDx32NQ==",
+      "dependencies": {
+        "module-details-from-path": "^1.0.3"
       }
     },
     "node_modules/import-local": {
@@ -10239,12 +10337,69 @@
       "integrity": "sha512-fG4D0AktoHyHwGhFGv+PzKrZjxbKJfckJauTJdq2A+ej5cTazmNYjJVAODXXkYyrsI10muMl+B1iO2q1R6Lp+w=="
     },
     "@prisma/instrumentation": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@prisma/instrumentation/-/instrumentation-4.12.0.tgz",
-      "integrity": "sha512-mSGO0EFWS1nZWBlvHpiV6IodPfbiAXgRw0PmtWJHUDCX+lPgvzSUYkfgeIKfYY/3VvECqAXyzbABDrnwaQgY2A==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@prisma/instrumentation/-/instrumentation-5.0.0.tgz",
+      "integrity": "sha512-GUt9ztQXriBmxPIDBd20eBHOX+LaF3zj4ot6mpMB/2YkceU4MvicdEoaX2VkF3r/xM7TatCF9IR2d35wOIv2GA==",
       "requires": {
-        "@opentelemetry/api": "^1.3.0",
-        "@opentelemetry/instrumentation": "^0.35.0"
+        "@opentelemetry/api": "1.4.1",
+        "@opentelemetry/instrumentation": "0.40.0",
+        "@opentelemetry/sdk-trace-base": "1.14.0"
+      },
+      "dependencies": {
+        "@opentelemetry/core": {
+          "version": "1.14.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.14.0.tgz",
+          "integrity": "sha512-MnMZ+sxsnlzloeuXL2nm5QcNczt/iO82UOeQQDHhV83F2fP3sgntW2evvtoxJki0MBLxEsh5ADD7PR/Hn5uzjw==",
+          "requires": {
+            "@opentelemetry/semantic-conventions": "1.14.0"
+          }
+        },
+        "@opentelemetry/instrumentation": {
+          "version": "0.40.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.40.0.tgz",
+          "integrity": "sha512-23TzBKPflUS1uEq5SXymnQKQDSda35KvHjnvxdcDQGE+wg6hwDHgScUCWiBmZW4sxAaPcANfs+Wc9B7yDuyT6Q==",
+          "requires": {
+            "@types/shimmer": "^1.0.2",
+            "import-in-the-middle": "1.3.5",
+            "require-in-the-middle": "^7.1.0",
+            "semver": "^7.3.2",
+            "shimmer": "^1.2.1"
+          }
+        },
+        "@opentelemetry/resources": {
+          "version": "1.14.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.14.0.tgz",
+          "integrity": "sha512-qRfWIgBxxl3z47E036Aey0Lj2ZjlFb27Q7Xnj1y1z/P293RXJZGLtcfn/w8JF7v1Q2hs3SDGxz7Wb9Dko1YUQA==",
+          "requires": {
+            "@opentelemetry/core": "1.14.0",
+            "@opentelemetry/semantic-conventions": "1.14.0"
+          }
+        },
+        "@opentelemetry/sdk-trace-base": {
+          "version": "1.14.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.14.0.tgz",
+          "integrity": "sha512-NzRGt3PS+HPKfQYMb6Iy8YYc5OKA73qDwci/6ujOIvyW9vcqBJSWbjZ8FeLEAmuatUB5WrRhEKu9b0sIiIYTrQ==",
+          "requires": {
+            "@opentelemetry/core": "1.14.0",
+            "@opentelemetry/resources": "1.14.0",
+            "@opentelemetry/semantic-conventions": "1.14.0"
+          }
+        },
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.14.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.14.0.tgz",
+          "integrity": "sha512-rJfCY8rCWz3cb4KI6pEofnytvMPuj3YLQwoscCCYZ5DkdiPjo15IQ0US7+mjcWy9H3fcZIzf2pbJZ7ck/h4tug=="
+        },
+        "require-in-the-middle": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-7.2.0.tgz",
+          "integrity": "sha512-3TLx5TGyAY6AOqLBoXmHkNql0HIf2RGbuMgCDT2WO/uGVAPJs6h7Kl+bN6TIZGd9bWhWPwnDnTHGtW8Iu77sdw==",
+          "requires": {
+            "debug": "^4.1.1",
+            "module-details-from-path": "^1.0.3",
+            "resolve": "^1.22.1"
+          }
+        }
       }
     },
     "@protobufjs/aspromise": {
@@ -10610,6 +10765,11 @@
         "@types/mime": "*",
         "@types/node": "*"
       }
+    },
+    "@types/shimmer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@types/shimmer/-/shimmer-1.0.2.tgz",
+      "integrity": "sha512-dKkr1bTxbEsFlh2ARpKzcaAmsYixqt9UyCdoEZk8rHyE4iQYcDCyvSjDSf7JUWJHlJiTtbIoQjxKh6ViywqDAg=="
     },
     "@types/stack-utils": {
       "version": "2.0.1",
@@ -12247,6 +12407,14 @@
       "requires": {
         "parent-module": "^1.0.0",
         "resolve-from": "^4.0.0"
+      }
+    },
+    "import-in-the-middle": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.3.5.tgz",
+      "integrity": "sha512-yzHlBqi1EBFrkieAnSt8eTgO5oLSl+YJ7qaOpUH/PMqQOMZoQ/RmDlwnTLQrwYto+gHYjRG+i/IbsB1eDx32NQ==",
+      "requires": {
+        "module-details-from-path": "^1.0.3"
       }
     },
     "import-local": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@opentelemetry/instrumentation-restify": "^0.32.1",
     "@opentelemetry/sdk-node": "^0.37.0",
     "@opentelemetry/sdk-trace-base": "^1.11.0",
-    "@prisma/instrumentation": "^4.12.0",
+    "@prisma/instrumentation": "^4.12.0 || ^5",
     "node-addon-api": "^3.1.0",
     "node-gyp": "^9.0.0",
     "tslib": "^2.0.3",


### PR DESCRIPTION
Fixes #913.

---

Change the version range to allow version 5 or greater of the
`@prisma/instrumentation` library, and update `package-lock.json` to
prefer that version whenever possible.

