### PR TITLE
Remove agent download file after extraction

### DIFF
--- a/.changesets/remove-agent-download-file-after-extraction.md
+++ b/.changesets/remove-agent-download-file-after-extraction.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Remove agent download file after extraction. This save a couple megabytes of space that are no longer needed when the agent and extension have been extracted from the downloaded `.tar.gz` file, reducing the overall app size.

--- a/scripts/extension/extension.js
+++ b/scripts/extension/extension.js
@@ -114,6 +114,14 @@ function extract(filepath) {
   })
 }
 
+function removeFile(filepath) {
+  return new Promise((resolve, reject) => {
+    return fs.rm(filepath, err => {
+      return !err ? resolve() : reject(err)
+    })
+  })
+}
+
 function verify(filepath, checksum) {
   return new Promise((resolve, reject) => {
     fs.createReadStream(filepath)
@@ -227,7 +235,9 @@ function run() {
       return verify(outputPath, metadata.checksum).then(() => {
         report.download.checksum = "verified"
 
-        return extract(outputPath)
+        return extract(outputPath).then(() => {
+          return removeFile(outputPath)
+        })
       })
     })
   }


### PR DESCRIPTION
During installation we download a `.tar.gz` file that contains the agent and extension. We didn't clean up this file after download, so it was included in production environments, leading to even larger `node_modules` directories.

Removing the file save a 4-5 megabytes of space.