### PR TITLE
Add bindAddress config option for the agent

### DIFF
--- a/.changesets/allow-bind_address-configuration.md
+++ b/.changesets/allow-bind_address-configuration.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "add"
+---
+
+Allow configuration of the agent's TCP and UDP servers using the `bindAddress` config option. This is by default set to `127.0.0.1`, which only makes it accessible from the same host. If you want it to be accessible from other machines, use `0.0.0.0` or a specific IP address.

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -257,6 +257,7 @@ describe("Configuration", () => {
       expect(env("_APPSIGNAL_ACTIVE")).toBeUndefined()
       expect(env("_APPSIGNAL_APP_ENV")).toBeDefined()
       expect(env("_APPSIGNAL_APP_NAME")).toBeUndefined()
+      expect(env("_APPSIGNAL_BIND_ADDRESS")).toBeUndefined()
       expect(env("_APPSIGNAL_CA_FILE_PATH")).toMatch(/cert\/cacert\.pem$/)
       expect(env("_APPSIGNAL_DNS_SERVERS")).toBeUndefined()
       expect(env("_APPSIGNAL_ENABLE_HOST_METRICS")).toEqual("true")
@@ -302,6 +303,7 @@ describe("Configuration", () => {
         new Configuration({
           name,
           active: true,
+          bindAddress: "0.0.0.0",
           pushApiKey,
           dnsServers: ["8.8.8.8", "8.8.4.4"],
           enableHostMetrics: false,
@@ -328,6 +330,7 @@ describe("Configuration", () => {
       it("writes configuration values to the environment", () => {
         expect(env("_APPSIGNAL_ACTIVE")).toEqual("true")
         expect(env("_APPSIGNAL_APP_NAME")).toEqual(name)
+        expect(env("_APPSIGNAL_BIND_ADDRESS")).toEqual("0.0.0.0")
         expect(env("_APPSIGNAL_DNS_SERVERS")).toEqual("8.8.8.8,8.8.4.4")
         expect(env("_APPSIGNAL_ENABLE_HOST_METRICS")).toEqual("true")
         expect(env("_APPSIGNAL_ENABLE_STATSD")).toEqual("true")

--- a/src/config/configmap.ts
+++ b/src/config/configmap.ts
@@ -4,6 +4,7 @@ export const ENV_TO_KEY_MAPPING: Record<string, keyof AppsignalOptions> = {
   APPSIGNAL_ACTIVE: "active",
   APPSIGNAL_APP_ENV: "environment",
   APPSIGNAL_APP_NAME: "name",
+  APPSIGNAL_BIND_ADDRESS: "bindAddress",
   APPSIGNAL_CA_FILE_PATH: "caFilePath",
   APPSIGNAL_DISABLE_DEFAULT_INSTRUMENTATIONS: "disableDefaultInstrumentations",
   APPSIGNAL_DNS_SERVERS: "dnsServers",
@@ -39,6 +40,7 @@ export const PRIVATE_ENV_MAPPING: Record<string, keyof AppsignalOptions> = {
   _APPSIGNAL_ACTIVE: "active",
   _APPSIGNAL_APP_ENV: "environment",
   _APPSIGNAL_APP_NAME: "name",
+  _APPSIGNAL_BIND_ADDRESS: "bindAddress",
   _APPSIGNAL_CA_FILE_PATH: "caFilePath",
   _APPSIGNAL_DNS_SERVERS: "dnsServers",
   _APPSIGNAL_ENABLE_HOST_METRICS: "enableHostMetrics",
@@ -68,6 +70,7 @@ export const PRIVATE_ENV_MAPPING: Record<string, keyof AppsignalOptions> = {
 
 export const JS_TO_RUBY_MAPPING: Record<keyof AppsignalOptions, string> = {
   active: "active",
+  bindAddress: "bind_address",
   pushApiKey: "push_api_key",
   caFilePath: "ca_file_path",
   disableDefaultInstrumentations: "disable_default_instrumentations",

--- a/src/config/options.ts
+++ b/src/config/options.ts
@@ -2,6 +2,7 @@ import type { DefaultInstrumentationName } from "../client"
 
 export type AppsignalOptions = {
   active: boolean
+  bindAddress: string
   caFilePath: string
   disableDefaultInstrumentations: DefaultInstrumentationName[] | boolean
   dnsServers: string[]


### PR DESCRIPTION
This feature has been available in the agent's standalone mode for a while now.

I'm cleaning up old issues and picking up this small one.

Part of https://github.com/appsignal/appsignal-agent/issues/915