### PR TITLE
Report total CPU usage host metric for VMs

### DIFF
--- a/.changesets/report-total-cpu-usage-metric-for-vms.md
+++ b/.changesets/report-total-cpu-usage-metric-for-vms.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "add"
+---
+
+Report total CPU usage host metric for VMs. This change adds another `state` tag value on the `cpu` metric called `total_usage`, which reports the VM's total CPU usage in percentages.

--- a/scripts/extension/support/constants.js
+++ b/scripts/extension/support/constants.js
@@ -3,7 +3,7 @@
 // appsignal-agent repository.
 // Modifications to this file will be overwritten with the next agent release.
 
-const AGENT_VERSION = "32590eb"
+const AGENT_VERSION = "ceaca3b"
 const MIRRORS = [
   "https://appsignal-agent-releases.global.ssl.fastly.net",
   "https://d135dj0rjqvssy.cloudfront.net"
@@ -12,67 +12,67 @@ const MIRRORS = [
 const TRIPLES = {
   "x86_64-darwin": {
     checksum:
-      "d19ddec878fd1c608bfc44219eee3059676e329575af0a0f9077a6ebd13ab759",
+      "00f1b2c0b79827ce1abb751005221c4852787ca1804ebcd7e2634714d146ffe0",
     filename: "appsignal-x86_64-darwin-all-static.tar.gz"
   },
   "universal-darwin": {
     checksum:
-      "d19ddec878fd1c608bfc44219eee3059676e329575af0a0f9077a6ebd13ab759",
+      "00f1b2c0b79827ce1abb751005221c4852787ca1804ebcd7e2634714d146ffe0",
     filename: "appsignal-x86_64-darwin-all-static.tar.gz"
   },
   "aarch64-darwin": {
     checksum:
-      "ee637a448d7f063a603b34bff2a0387842fd9b7efe477f43c69850d1bde649d8",
+      "e9195d0aa4e22214eeb2dcb54651014db09f2b84f5f5ef41f6c7fcddb9b58384",
     filename: "appsignal-aarch64-darwin-all-static.tar.gz"
   },
   "arm64-darwin": {
     checksum:
-      "ee637a448d7f063a603b34bff2a0387842fd9b7efe477f43c69850d1bde649d8",
+      "e9195d0aa4e22214eeb2dcb54651014db09f2b84f5f5ef41f6c7fcddb9b58384",
     filename: "appsignal-aarch64-darwin-all-static.tar.gz"
   },
   "arm-darwin": {
     checksum:
-      "ee637a448d7f063a603b34bff2a0387842fd9b7efe477f43c69850d1bde649d8",
+      "e9195d0aa4e22214eeb2dcb54651014db09f2b84f5f5ef41f6c7fcddb9b58384",
     filename: "appsignal-aarch64-darwin-all-static.tar.gz"
   },
   "aarch64-linux": {
     checksum:
-      "c723895a2b627dc9bd6f756468206bb8b946e1ddaeab13f2562d47765bcbdc92",
+      "d568c447595d5a46b726c09c44c66a28153bb85b843d9f915e755de60d2cc797",
     filename: "appsignal-aarch64-linux-all-static.tar.gz"
   },
   "i686-linux": {
     checksum:
-      "7e8e9b0ba5bde6ed3b3c697eb5c92c1840e0ab1a0ecad1e588d684c04f5aad2b",
+      "4a8135e861ef8dd347ada22fa1fc993d1c5ba5db7f9f043a38fb9891c57368a5",
     filename: "appsignal-i686-linux-all-static.tar.gz"
   },
   "x86-linux": {
     checksum:
-      "7e8e9b0ba5bde6ed3b3c697eb5c92c1840e0ab1a0ecad1e588d684c04f5aad2b",
+      "4a8135e861ef8dd347ada22fa1fc993d1c5ba5db7f9f043a38fb9891c57368a5",
     filename: "appsignal-i686-linux-all-static.tar.gz"
   },
   "x86_64-linux": {
     checksum:
-      "b34f064d17a7ab047ebb0eac512452ed4ea91eb7035cd3caa5c06ec8c425ef8e",
+      "4a22f454e5c125cd24436ad331d53df965394be81272c8ab366a2e6ea5f02625",
     filename: "appsignal-x86_64-linux-all-static.tar.gz"
   },
   "x86_64-linux-musl": {
     checksum:
-      "543e47617392cfc243aa053280cd98804ce71728ddd3e38c9b5c6f62a6006b97",
+      "d770f78f9f87d3b5b01a93f0e3f0dffc36a4f8bd664ce37574fd0671276d4d8b",
     filename: "appsignal-x86_64-linux-musl-all-static.tar.gz"
   },
   "aarch64-linux-musl": {
     checksum:
-      "7e44a1e739f1d4e01fec73cdb4878c0b0b6af5b0f5b433f30807d768fd0cf2f0",
+      "ef4838e0cd3e43d0cc138e0eb6b78b7cf1f29244daa8379bb30c47b1497f5570",
     filename: "appsignal-aarch64-linux-musl-all-static.tar.gz"
   },
   "x86_64-freebsd": {
     checksum:
-      "5ddb4d0d357fbb4677156f538f325924fa53f7fbba5885761b58596fc2ded8ad",
+      "f1730afd98b48f3fa938fd07b27dc470e7dcd3f8d2e72a7a0fc2a4b080461f5b",
     filename: "appsignal-x86_64-freebsd-all-static.tar.gz"
   },
   "amd64-freebsd": {
     checksum:
-      "5ddb4d0d357fbb4677156f538f325924fa53f7fbba5885761b58596fc2ded8ad",
+      "f1730afd98b48f3fa938fd07b27dc470e7dcd3f8d2e72a7a0fc2a4b080461f5b",
     filename: "appsignal-x86_64-freebsd-all-static.tar.gz"
   }
 }


### PR DESCRIPTION
This change adds another `state` tag value on the `cpu` metric called `total_usage`, which reports the VM's total CPU usage in percentages.

Part of https://github.com/appsignal/probes-rs/issues/64

[skip review]