### PR TITLE
Diagnose client file errors

### DIFF
--- a/src/cli/diagnose.ts
+++ b/src/cli/diagnose.ts
@@ -145,7 +145,7 @@ export class Diagnose {
 
     this.print_newline()
 
-    this.printConfiguration(data["config"])
+    this.printConfiguration(data["config"], this.#diagnose.clientFilePath())
 
     this.print_newline()
 
@@ -348,18 +348,21 @@ export class Diagnose {
     }
   }
 
-  printConfiguration({
-    options,
-    sources
-  }: {
-    options: { [key: string]: any }
-    sources: { [source: string]: { [key: string]: any } }
-  }) {
+  printConfiguration(
+    {
+      options,
+      sources
+    }: {
+      options: { [key: string]: any }
+      sources: { [source: string]: { [key: string]: any } }
+    },
+    clientFilePath: string
+  ) {
     console.log(`Configuration`)
 
     if (Object.keys(sources.initial).length === 0) {
       console.log(
-        "\x1b[31mWarning\x1b[0m: The initialiser file (appsignal.cjs) could" +
+        `\x1b[31mWarning\x1b[0m: The initialiser file ('${clientFilePath}') could` +
           " not be found. The configuration shown here may be incomplete."
       )
     }

--- a/src/diagnose.ts
+++ b/src/diagnose.ts
@@ -228,14 +228,12 @@ export class DiagnoseTool {
       try {
         require(clientFilePath)
       } catch (e: any) {
-        Client.integrationLogger.error(
-          `Error loading AppSignal client file ${e.message}`
-        )
+        console.error(`Error loading AppSignal client file ${e.message}`)
       }
 
       delete process.env._APPSIGNAL_DIAGNOSE
     } else {
-      Client.integrationLogger.warn(
+      console.warn(
         "Could not find AppSignal client file at " +
           `[${Configuration.clientFilePaths().join(",")}]. ` +
           "Configuration in report may be incomplete."

--- a/src/diagnose.ts
+++ b/src/diagnose.ts
@@ -158,8 +158,7 @@ export class DiagnoseTool {
         path: logFilePath ? path.dirname(logFilePath) : ""
       },
       "appsignal.cjs": {
-        path:
-          this.getCustomClientFilePath() || Configuration.clientFilePath || ""
+        path: this.clientFilePath() || ""
       },
       "appsignal.log": {
         path: logFilePath || "",

--- a/src/diagnose.ts
+++ b/src/diagnose.ts
@@ -218,8 +218,7 @@ export class DiagnoseTool {
    * object from the initialized client. Otherwise, return a default config object.
    */
   private getConfigObject(): Configuration {
-    const clientFilePath =
-      this.getCustomClientFilePath() || Configuration.clientFilePath
+    const clientFilePath = this.clientFilePath()
     // The file is required to execute the client initialization
     // that stores the config object on the global object, making
     // it available calling `Client.config` later.
@@ -241,6 +240,10 @@ export class DiagnoseTool {
     }
 
     return Client.config ?? new Configuration({})
+  }
+
+  private clientFilePath() {
+    return this.getCustomClientFilePath() || Configuration.clientFilePath
   }
 
   /**


### PR DESCRIPTION
## Print client file errors directly to terminal

It was using the integrationLogger, which writes it to the `/tmp/appsignal.log` file, but because the config is invalid the logger won't write anything so the whole error is missing.

This change logs it to the terminal so the user can see the error.

## Update error with user specified client file

When the client file can't be found or loaded, print the specified client file in the error message.

[skip changeset]
