### PR TITLE
Bump agent to version d789895

### DIFF
--- a/.changesets/bump-agent-d789895.md
+++ b/.changesets/bump-agent-d789895.md
@@ -1,0 +1,10 @@
+---
+bump: "patch"
+type: "change"
+---
+
+Bump agent to version d789895.
+
+- Increase short data truncation from 2000 to 10000 characters.
+- Include HTTP request method on Next.js samples as incident action name. Instead of `/path` it will now report `GET /path`.
+- Add a extractor for Remix js spans.

--- a/scripts/extension/support/constants.js
+++ b/scripts/extension/support/constants.js
@@ -3,7 +3,7 @@
 // appsignal-agent repository.
 // Modifications to this file will be overwritten with the next agent release.
 
-const AGENT_VERSION = "6bec691"
+const AGENT_VERSION = "d789895"
 const MIRRORS = [
   "https://appsignal-agent-releases.global.ssl.fastly.net",
   "https://d135dj0rjqvssy.cloudfront.net"
@@ -12,67 +12,67 @@ const MIRRORS = [
 const TRIPLES = {
   "x86_64-darwin": {
     checksum:
-      "bef6b987040f2d5feb8d4e2d9483bfa89c75b709a1b9a297b4b736643b488c6a",
+      "8ea76b7d011c728b7988d017a39fc3a432d9c86392e6e46767ecc931e583777a",
     filename: "appsignal-x86_64-darwin-all-static.tar.gz"
   },
   "universal-darwin": {
     checksum:
-      "bef6b987040f2d5feb8d4e2d9483bfa89c75b709a1b9a297b4b736643b488c6a",
+      "8ea76b7d011c728b7988d017a39fc3a432d9c86392e6e46767ecc931e583777a",
     filename: "appsignal-x86_64-darwin-all-static.tar.gz"
   },
   "aarch64-darwin": {
     checksum:
-      "ff083420f6ac000d2791800ba641ee331ac8757e298939879ea6f35d35eea80b",
+      "535fed60ac1484e40bbfe77cd4fe9131c67f25e6362a2fe31d987c36ec82ba08",
     filename: "appsignal-aarch64-darwin-all-static.tar.gz"
   },
   "arm64-darwin": {
     checksum:
-      "ff083420f6ac000d2791800ba641ee331ac8757e298939879ea6f35d35eea80b",
+      "535fed60ac1484e40bbfe77cd4fe9131c67f25e6362a2fe31d987c36ec82ba08",
     filename: "appsignal-aarch64-darwin-all-static.tar.gz"
   },
   "arm-darwin": {
     checksum:
-      "ff083420f6ac000d2791800ba641ee331ac8757e298939879ea6f35d35eea80b",
+      "535fed60ac1484e40bbfe77cd4fe9131c67f25e6362a2fe31d987c36ec82ba08",
     filename: "appsignal-aarch64-darwin-all-static.tar.gz"
   },
   "aarch64-linux": {
     checksum:
-      "755e1721befe259d4b13d914020ea7793399c1dc7abdce1e6695128f30e8670d",
+      "35f96e0adf408fd8ac3e89c6cb3c5506eb4250643199aad3ba298ab131d773c8",
     filename: "appsignal-aarch64-linux-all-static.tar.gz"
   },
   "i686-linux": {
     checksum:
-      "2590d6ecb89242849ea7bd0923b074520fcf370c360095d2b25f2ea7a8f8e310",
+      "f4a1c9a67a0a4cde7e13ef555a6782e5d4f15bfbce9277c2aaf8e248a0fb858e",
     filename: "appsignal-i686-linux-all-static.tar.gz"
   },
   "x86-linux": {
     checksum:
-      "2590d6ecb89242849ea7bd0923b074520fcf370c360095d2b25f2ea7a8f8e310",
+      "f4a1c9a67a0a4cde7e13ef555a6782e5d4f15bfbce9277c2aaf8e248a0fb858e",
     filename: "appsignal-i686-linux-all-static.tar.gz"
   },
   "x86_64-linux": {
     checksum:
-      "54b033f215d84fbe819092a553e4921c77a2f686f9924f336c8312cb9efd1d57",
+      "016c962727e31a07eee7a221944ff9c4bbb054eada7e87bbe4602233364f380c",
     filename: "appsignal-x86_64-linux-all-static.tar.gz"
   },
   "x86_64-linux-musl": {
     checksum:
-      "3c161e852b44e2f0ad1ccd849150255fc0ce39c3b0895fb003c403de12ced331",
+      "2ce9e34b283c76c6b25028d3a770a942f4975cd071c586438a8765948237ca42",
     filename: "appsignal-x86_64-linux-musl-all-static.tar.gz"
   },
   "aarch64-linux-musl": {
     checksum:
-      "bed2cb1dc599528ac4bc1939da41900f4651013bc97433f2d1c2e6864acb6b7e",
+      "017da79e62a2875c0384898c9160cd83acd712faba05154fd8a0627fec1b5ba4",
     filename: "appsignal-aarch64-linux-musl-all-static.tar.gz"
   },
   "x86_64-freebsd": {
     checksum:
-      "19b885bccb30a4209608ac1ac3ecaf07f1cd8e78c95dbdb94df51f73360c01bb",
+      "13d27afcb68aff5e164e05fc4fd8874e73f14c0154301f2e6e6e75f67fa9182c",
     filename: "appsignal-x86_64-freebsd-all-static.tar.gz"
   },
   "amd64-freebsd": {
     checksum:
-      "19b885bccb30a4209608ac1ac3ecaf07f1cd8e78c95dbdb94df51f73360c01bb",
+      "13d27afcb68aff5e164e05fc4fd8874e73f14c0154301f2e6e6e75f67fa9182c",
     filename: "appsignal-x86_64-freebsd-all-static.tar.gz"
   }
 }


### PR DESCRIPTION
- Increase short data truncation from 2000 to 10000 characters.
- Include HTTP request method on Next.js samples as incident action name. Instead of `/path` it will now report `GET /path`.
- Add a extractor for Remix js spans.

[skip review]