### PR TITLE
Bump agent to 6133900

### DIFF
--- a/.changesets/bump-agent-to-6133900.md
+++ b/.changesets/bump-agent-to-6133900.md
@@ -1,0 +1,8 @@
+---
+bump: "patch"
+type: "change"
+---
+
+Bump agent to 6133900.
+
+- Fix `disk_inodes_usage` metric name format to not be interpreted as a JSON object.

--- a/scripts/extension/support/constants.js
+++ b/scripts/extension/support/constants.js
@@ -3,7 +3,7 @@
 // appsignal-agent repository.
 // Modifications to this file will be overwritten with the next agent release.
 
-const AGENT_VERSION = "d789895"
+const AGENT_VERSION = "6133900"
 const MIRRORS = [
   "https://appsignal-agent-releases.global.ssl.fastly.net",
   "https://d135dj0rjqvssy.cloudfront.net"
@@ -12,67 +12,67 @@ const MIRRORS = [
 const TRIPLES = {
   "x86_64-darwin": {
     checksum:
-      "8ea76b7d011c728b7988d017a39fc3a432d9c86392e6e46767ecc931e583777a",
+      "19cfea536fc6c4a8fe335a26d14ce955b422c23217902642f95d7df670152238",
     filename: "appsignal-x86_64-darwin-all-static.tar.gz"
   },
   "universal-darwin": {
     checksum:
-      "8ea76b7d011c728b7988d017a39fc3a432d9c86392e6e46767ecc931e583777a",
+      "19cfea536fc6c4a8fe335a26d14ce955b422c23217902642f95d7df670152238",
     filename: "appsignal-x86_64-darwin-all-static.tar.gz"
   },
   "aarch64-darwin": {
     checksum:
-      "535fed60ac1484e40bbfe77cd4fe9131c67f25e6362a2fe31d987c36ec82ba08",
+      "4fa0dbccba79f70edc6844a86bfd047ccdd612d752b65aff46fe0e21d8a610ea",
     filename: "appsignal-aarch64-darwin-all-static.tar.gz"
   },
   "arm64-darwin": {
     checksum:
-      "535fed60ac1484e40bbfe77cd4fe9131c67f25e6362a2fe31d987c36ec82ba08",
+      "4fa0dbccba79f70edc6844a86bfd047ccdd612d752b65aff46fe0e21d8a610ea",
     filename: "appsignal-aarch64-darwin-all-static.tar.gz"
   },
   "arm-darwin": {
     checksum:
-      "535fed60ac1484e40bbfe77cd4fe9131c67f25e6362a2fe31d987c36ec82ba08",
+      "4fa0dbccba79f70edc6844a86bfd047ccdd612d752b65aff46fe0e21d8a610ea",
     filename: "appsignal-aarch64-darwin-all-static.tar.gz"
   },
   "aarch64-linux": {
     checksum:
-      "35f96e0adf408fd8ac3e89c6cb3c5506eb4250643199aad3ba298ab131d773c8",
+      "cdd75637940fcfd369b569e873048c7d37a3844d9d31d783e4459b375b78ee0e",
     filename: "appsignal-aarch64-linux-all-static.tar.gz"
   },
   "i686-linux": {
     checksum:
-      "f4a1c9a67a0a4cde7e13ef555a6782e5d4f15bfbce9277c2aaf8e248a0fb858e",
+      "a9374d1fd4baae84f1c4a74957cbb8c919b29ae2ab05a571ff75b9ca483717ab",
     filename: "appsignal-i686-linux-all-static.tar.gz"
   },
   "x86-linux": {
     checksum:
-      "f4a1c9a67a0a4cde7e13ef555a6782e5d4f15bfbce9277c2aaf8e248a0fb858e",
+      "a9374d1fd4baae84f1c4a74957cbb8c919b29ae2ab05a571ff75b9ca483717ab",
     filename: "appsignal-i686-linux-all-static.tar.gz"
   },
   "x86_64-linux": {
     checksum:
-      "016c962727e31a07eee7a221944ff9c4bbb054eada7e87bbe4602233364f380c",
+      "bd625ed84100d0632b298ac602b152463628c41afe56a8621745cdae626f8413",
     filename: "appsignal-x86_64-linux-all-static.tar.gz"
   },
   "x86_64-linux-musl": {
     checksum:
-      "2ce9e34b283c76c6b25028d3a770a942f4975cd071c586438a8765948237ca42",
+      "7988c4a2a6ba5d59be2186ce9bf51ab50b6537a60888b08c8e9066172516e59d",
     filename: "appsignal-x86_64-linux-musl-all-static.tar.gz"
   },
   "aarch64-linux-musl": {
     checksum:
-      "017da79e62a2875c0384898c9160cd83acd712faba05154fd8a0627fec1b5ba4",
+      "8e5fe2a8bc4cb7de4ba7d61fec48f15aa0cd580050f67752f07625853636eb16",
     filename: "appsignal-aarch64-linux-musl-all-static.tar.gz"
   },
   "x86_64-freebsd": {
     checksum:
-      "13d27afcb68aff5e164e05fc4fd8874e73f14c0154301f2e6e6e75f67fa9182c",
+      "09e21821eb98ad6afdb5d3708b67ea25799aedbee2ccb0d566b99d9c5703cb1e",
     filename: "appsignal-x86_64-freebsd-all-static.tar.gz"
   },
   "amd64-freebsd": {
     checksum:
-      "13d27afcb68aff5e164e05fc4fd8874e73f14c0154301f2e6e6e75f67fa9182c",
+      "09e21821eb98ad6afdb5d3708b67ea25799aedbee2ccb0d566b99d9c5703cb1e",
     filename: "appsignal-x86_64-freebsd-all-static.tar.gz"
   }
 }


### PR DESCRIPTION
- Fix `disk_inodes_usage` metric name format to not be interpreted as a JSON object.

[skip review]