### PR TITLE
Report Node.js route parameters for routes

### DIFF
--- a/.changesets/report-express-route-parameters.md
+++ b/.changesets/report-express-route-parameters.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "change"
+---
+
+Report express route parameters. If a route is defined like `/user/:id`, the `id` parameter will be reported from now on in the "Parameters" box on AppSignal.com.

--- a/src/client.ts
+++ b/src/client.ts
@@ -273,9 +273,10 @@ export class Client {
         requestHook: function (_span, info) {
           if (info.layerType === ExpressLayerType.REQUEST_HANDLER) {
             if (sendParams) {
+              const routeParams = info.request.params
               const queryParams = info.request.query
               const requestBody = info.request.body
-              const params = { ...queryParams, ...requestBody }
+              const params = { ...routeParams, ...queryParams, ...requestBody }
               setParams(params)
             }
 

--- a/test/express-redis/app/src/app.ts
+++ b/test/express-redis/app/src/app.ts
@@ -16,6 +16,10 @@ app.get("/", (_req: any, res: any) => {
   res.send("200 OK")
 })
 
+app.get("/route-param/:id", (_req: any, res: any) => {
+  res.send("200 OK")
+})
+
 app.get("/error", (_req: any, _res: any) => {
   throw new Error("Expected test error!")
 })

--- a/test/express-redis/tests/spec/app_spec.rb
+++ b/test/express-redis/tests/spec/app_spec.rb
@@ -20,6 +20,18 @@ RSpec.describe "Redis app" do
     end
   end
 
+  describe "GET route with route params" do
+    it "adds params to the HTTP root span" do
+      response = HTTP.get("#{@test_app_url}/route-param/123456")
+      expect(response.status).to eq(200)
+      expect(Span.root!).to be_http_span_with_route("GET /route-param/:id")
+
+      expected_request_parameters = { "id" => "123456" }
+
+      expect(Span.root!).to match_request_parameters(expected_request_parameters)
+    end
+  end
+
   describe "GET / with session data" do
     it "adds session data to the HTTP root span" do
       response = HTTP.cookies(:cookie => "chocolate").get(@test_app_url)


### PR DESCRIPTION
When a route like `/users/:id` is defined, report the `id` route as a parameters on the AppSignal sample data so it's shown in the "Parameters" box for a sample.

Related support issue: https://app.intercom.com/a/inbox/yzor8gyw/inbox/shared/unassigned/conversation/16410700255722?view=List
Related Slack discussion: https://appsignal.slack.com/archives/C7XHXQ7N0/p1696511750992899