### PR TITLE
Fix Express error handler signature error

### DIFF
--- a/.changesets/fix-types-compatibility-for-the-express-error-handler.md
+++ b/.changesets/fix-types-compatibility-for-the-express-error-handler.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Fix a TypeScript types compatibility error upon app compilation when using the AppSignal Express error handler.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@appsignal/nodejs",
-  "version": "3.0.23",
+  "version": "3.0.24",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@appsignal/nodejs",
-      "version": "3.0.23",
+      "version": "3.0.24",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/src/instrumentation/express/error_handler.ts
+++ b/src/instrumentation/express/error_handler.ts
@@ -1,11 +1,11 @@
-import { Request, Response, NextFunction, ErrorRequestHandler } from "express"
+import { NextFunction } from "express"
 import { setError } from "../../helpers"
 
-export function expressErrorHandler(): ErrorRequestHandler {
+export function expressErrorHandler() {
   return function (
     err: Error & { status?: number },
-    req: Request,
-    res: Response,
+    req: any,
+    res: any,
     next: NextFunction
   ) {
     if (!err.status || err.status >= 500) {

--- a/test/express-redis/app/package-lock.json
+++ b/test/express-redis/app/package-lock.json
@@ -19,7 +19,7 @@
       },
       "devDependencies": {
         "@types/cookie-parser": "^1.4.3",
-        "@types/express": "4.17.13",
+        "@types/express": "4.17.18",
         "@types/ioredis": "4.28.10",
         "@types/node": "18.6.3",
         "typescript": "4.7.4"
@@ -317,24 +317,27 @@
       }
     },
     "node_modules/@types/express": {
-      "version": "4.17.13",
+      "version": "4.17.18",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.18.tgz",
+      "integrity": "sha512-Sxv8BSLLgsBYmcnGdGjjEjqET2U+AKAdCRODmMiq02FgjwuV75Ut85DRpvFjyw/Mk0vgUOliGRU0UUmuuZHByQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/body-parser": "*",
-        "@types/express-serve-static-core": "^4.17.18",
+        "@types/express-serve-static-core": "^4.17.33",
         "@types/qs": "*",
         "@types/serve-static": "*"
       }
     },
     "node_modules/@types/express-serve-static-core": {
-      "version": "4.17.30",
+      "version": "4.17.39",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.39.tgz",
+      "integrity": "sha512-BiEUfAiGCOllomsRAZOiMFP7LAnrifHpt56pc4Z7l9K6ACyN06Ns1JLMBxwkfLOjJRlSf06NwWsT7yzfpaVpyQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/node": "*",
         "@types/qs": "*",
-        "@types/range-parser": "*"
+        "@types/range-parser": "*",
+        "@types/send": "*"
       }
     },
     "node_modules/@types/ioredis": {
@@ -356,14 +359,32 @@
       "license": "MIT"
     },
     "node_modules/@types/qs": {
-      "version": "6.9.7",
-      "dev": true,
-      "license": "MIT"
+      "version": "6.9.9",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.9.tgz",
+      "integrity": "sha512-wYLxw35euwqGvTDx6zfY1vokBFnsK0HNrzc6xNHchxfO2hpuRg74GbkEW7e3sSmPvj0TjCDT1VCa6OtHXnubsg==",
+      "dev": true
     },
     "node_modules/@types/range-parser": {
-      "version": "1.2.4",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.6.tgz",
+      "integrity": "sha512-+0autS93xyXizIYiyL02FCY8N+KkKPhILhcUSA276HxzreZ16kl+cmwvV2qAM/PuCCwPXzOXOWhiPcw20uSFcA==",
+      "dev": true
+    },
+    "node_modules/@types/send": {
+      "version": "0.17.3",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.3.tgz",
+      "integrity": "sha512-/7fKxvKUoETxjFUsuFlPB9YndePpxxRAOfGC/yJdc9kTjTeP5kRCTzfnE8kPUKCeyiyIZu0YQ76s50hCedI1ug==",
       "dev": true,
-      "license": "MIT"
+      "dependencies": {
+        "@types/mime": "^1",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/send/node_modules/@types/mime": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.4.tgz",
+      "integrity": "sha512-1Gjee59G25MrQGk8bsNvC6fxNiRgUlGn2wlhGf95a59DrprnnHk80FIMMFG9XHMdrfsuA119ht06QPDXA1Z7tw==",
+      "dev": true
     },
     "node_modules/@types/serve-static": {
       "version": "1.15.0",
@@ -2499,22 +2520,27 @@
       }
     },
     "@types/express": {
-      "version": "4.17.13",
+      "version": "4.17.18",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.18.tgz",
+      "integrity": "sha512-Sxv8BSLLgsBYmcnGdGjjEjqET2U+AKAdCRODmMiq02FgjwuV75Ut85DRpvFjyw/Mk0vgUOliGRU0UUmuuZHByQ==",
       "dev": true,
       "requires": {
         "@types/body-parser": "*",
-        "@types/express-serve-static-core": "^4.17.18",
+        "@types/express-serve-static-core": "^4.17.33",
         "@types/qs": "*",
         "@types/serve-static": "*"
       }
     },
     "@types/express-serve-static-core": {
-      "version": "4.17.30",
+      "version": "4.17.39",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.39.tgz",
+      "integrity": "sha512-BiEUfAiGCOllomsRAZOiMFP7LAnrifHpt56pc4Z7l9K6ACyN06Ns1JLMBxwkfLOjJRlSf06NwWsT7yzfpaVpyQ==",
       "dev": true,
       "requires": {
         "@types/node": "*",
         "@types/qs": "*",
-        "@types/range-parser": "*"
+        "@types/range-parser": "*",
+        "@types/send": "*"
       }
     },
     "@types/ioredis": {
@@ -2533,12 +2559,34 @@
       "dev": true
     },
     "@types/qs": {
-      "version": "6.9.7",
+      "version": "6.9.9",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.9.tgz",
+      "integrity": "sha512-wYLxw35euwqGvTDx6zfY1vokBFnsK0HNrzc6xNHchxfO2hpuRg74GbkEW7e3sSmPvj0TjCDT1VCa6OtHXnubsg==",
       "dev": true
     },
     "@types/range-parser": {
-      "version": "1.2.4",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.6.tgz",
+      "integrity": "sha512-+0autS93xyXizIYiyL02FCY8N+KkKPhILhcUSA276HxzreZ16kl+cmwvV2qAM/PuCCwPXzOXOWhiPcw20uSFcA==",
       "dev": true
+    },
+    "@types/send": {
+      "version": "0.17.3",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.3.tgz",
+      "integrity": "sha512-/7fKxvKUoETxjFUsuFlPB9YndePpxxRAOfGC/yJdc9kTjTeP5kRCTzfnE8kPUKCeyiyIZu0YQ76s50hCedI1ug==",
+      "dev": true,
+      "requires": {
+        "@types/mime": "^1",
+        "@types/node": "*"
+      },
+      "dependencies": {
+        "@types/mime": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.4.tgz",
+          "integrity": "sha512-1Gjee59G25MrQGk8bsNvC6fxNiRgUlGn2wlhGf95a59DrprnnHk80FIMMFG9XHMdrfsuA119ht06QPDXA1Z7tw==",
+          "dev": true
+        }
+      }
     },
     "@types/serve-static": {
       "version": "1.15.0",


### PR DESCRIPTION
Fixed an error thrown when using the Express error handler that depended on which types package version for Express is used.

We've tried to fix the types but couldn't get to make it work due to how the interfaces in `@types/express-serve-static-core` are. We tried to replicate the exact same types allowed in the `IRouterHandler` interface without any success.

The return type of the error handler cannot be an `ExpressErrorHandler` anymore as it doesn't comply with the latest types defined by the packages.

This commit removes the return type of the error handler and makes the `req` and `res` argument to be of `any` type to stop the error from happening and to hopefully keep the handler compatible in future possible patches of the types packages.

Closes #953 