### PR TITLE
Clean up more extension files for macOS

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "build:watch": "tsc -p tsconfig.json -w --preserveWatchOutput",
     "postclean": "npm run clean:ext",
     "clean": "rimraf dist coverage build",
-    "clean:ext": "rimraf ext/appsignal-agent ext/libappsignal.a ext/appsignal.* ext/*.tar.gz ext/*.report build/",
+    "clean:ext": "rimraf ext/appsignal-agent ext/._appsignal-agent ext/libappsignal.a ext/libappsignal.dylib ext/appsignal.* ext/*.tar.gz ext/*.report build/",
     "preinstall": "node scripts/extension/prebuild.js",
     "install": "node scripts/extension/extension.js",
     "link:npm": "npm link",


### PR DESCRIPTION
When running `npm run clean:ext` some files are left behind on macOS. Add these files to make sure it's clean after running this command.

[skip changeset]
[skip review]