### PR TITLE
Fix permissions issues on CI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@appsignal/nodejs",
-  "version": "3.0.24",
+  "version": "3.0.26",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@appsignal/nodejs",
-      "version": "3.0.24",
+      "version": "3.0.26",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/test/express-apollo/app/Dockerfile
+++ b/test/express-apollo/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16
+FROM node:18
 
 COPY run.sh /
 

--- a/test/express-apollo/app/run.sh
+++ b/test/express-apollo/app/run.sh
@@ -5,9 +5,6 @@ set -eu
 echo "Giving permission to all users on span directory"
 chmod -R 777 /spans
 
-echo "Installing compatible NPM version"
-npm install -g npm@7.18.1
-
 echo "Install, link and build integration"
 (
 cd /integration

--- a/test/express-knex/app/Dockerfile
+++ b/test/express-knex/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16
+FROM node:18
 
 COPY run.sh /
 

--- a/test/express-knex/app/run.sh
+++ b/test/express-knex/app/run.sh
@@ -5,9 +5,6 @@ set -eu
 echo "Giving permission to all users on span directory"
 chmod -R 777 /spans
 
-echo "Installing compatible NPM version"
-npm install -g npm@7.18.1
-
 echo "Install, link and build integration"
 (
   cd /integration

--- a/test/express-mongoose/app/Dockerfile
+++ b/test/express-mongoose/app/Dockerfile
@@ -1,6 +1,6 @@
-FROM node:16
+FROM node:18
 
-RUN apt-get update && apt-get install -y netcat
+RUN apt-get update && apt-get install -y netcat-openbsd
 
 COPY run.sh /
 

--- a/test/express-mongoose/app/run.sh
+++ b/test/express-mongoose/app/run.sh
@@ -13,9 +13,6 @@ export DATABASE_URL="mongodb://$DATABASE_HOST:27017/mongoose"
 echo "Giving permission to all users on span directory"
 chmod -R 777 /spans
 
-echo "Installing compatible NPM version"
-npm install -g npm@7.18.1
-
 echo "Install, link and build integration"
 (
 cd /integration

--- a/test/express-postgres/app/Dockerfile
+++ b/test/express-postgres/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16
+FROM node:18
 
 COPY run.sh /
 

--- a/test/express-postgres/app/run.sh
+++ b/test/express-postgres/app/run.sh
@@ -5,9 +5,6 @@ set -eu
 echo "Giving permission to all users on span directory"
 chmod -R 777 /spans
 
-echo "Installing compatible NPM version"
-npm install -g npm@7.18.1
-
 echo "Install, link and build integration"
 (
 cd /integration

--- a/test/express-prisma-mongo/app/Dockerfile
+++ b/test/express-prisma-mongo/app/Dockerfile
@@ -1,6 +1,6 @@
-FROM node:16
+FROM node:18
 
-RUN apt-get update && apt-get install -y netcat
+RUN apt-get update && apt-get install -y netcat-openbsd
 
 COPY run.sh /
 

--- a/test/express-prisma-mongo/app/run.sh
+++ b/test/express-prisma-mongo/app/run.sh
@@ -13,9 +13,6 @@ export DATABASE_URL="mongodb://$DATABASE_HOST:27017/prisma"
 echo "Giving permission to all users on span directory"
 chmod -R 777 /spans
 
-echo "Installing compatible NPM version"
-npm install -g npm@7.18.1
-
 echo "Install, link and build integration"
 (
 cd /integration

--- a/test/express-prisma-postgres/app/Dockerfile
+++ b/test/express-prisma-postgres/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16
+FROM node:18
 
 RUN apt-get update && apt-get install -y postgresql-client
 

--- a/test/express-prisma-postgres/app/run.sh
+++ b/test/express-prisma-postgres/app/run.sh
@@ -11,9 +11,6 @@ done
 echo "Giving permission to all users on span directory"
 chmod -R 777 /spans
 
-echo "Installing compatible NPM version"
-npm install -g npm@7.18.1
-
 echo "Install, link and build integration"
 (
 cd /integration

--- a/test/express-redis/app/Dockerfile
+++ b/test/express-redis/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16
+FROM node:18
 
 COPY run.sh /
 

--- a/test/express-redis/app/run.sh
+++ b/test/express-redis/app/run.sh
@@ -3,9 +3,6 @@
 echo "Giving permission to all users on spans directory"
 chmod -R 777 /spans
 
-echo "Installing compatible NPM version"
-npm install -g npm@7.18.1
-
 echo "Install, link and build integration"
 (
 cd /integration

--- a/test/express-yoga/app/Dockerfile
+++ b/test/express-yoga/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16
+FROM node:18
 
 COPY run.sh /
 

--- a/test/express-yoga/app/run.sh
+++ b/test/express-yoga/app/run.sh
@@ -5,9 +5,6 @@ set -eu
 echo "Giving permission to all users on span directory"
 chmod -R 777 /spans
 
-echo "Installing compatible NPM version"
-npm install -g npm@7.18.1
-
 echo "Install, link and build integration"
 (
 cd /integration

--- a/test/fastify/app/Dockerfile
+++ b/test/fastify/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16
+FROM node:18
 
 COPY run.sh /
 

--- a/test/fastify/app/run.sh
+++ b/test/fastify/app/run.sh
@@ -5,9 +5,6 @@ set -eu
 echo "Giving permission to all users on span directory"
 chmod -R 777 /spans
 
-echo "Installing compatible NPM version"
-npm install -g npm@7.18.1
-
 echo "Install, link and build integration"
 (
 cd /integration

--- a/test/koa-mongo/app/Dockerfile
+++ b/test/koa-mongo/app/Dockerfile
@@ -1,6 +1,6 @@
-FROM node:16
+FROM node:18
 
-RUN apt-get update && apt-get install -y netcat
+RUN apt-get update && apt-get install -y netcat-openbsd
 
 COPY run.sh /
 

--- a/test/koa-mongo/app/run.sh
+++ b/test/koa-mongo/app/run.sh
@@ -13,9 +13,6 @@ export DATABASE_URL="mongodb://$DATABASE_HOST:27017/mongo"
 echo "Giving permission to all users on span directory"
 chmod -R 777 /spans
 
-echo "Installing compatible NPM version"
-npm install -g npm@7.18.1
-
 echo "Install, link and build integration"
 (
 cd /integration

--- a/test/koa-mysql/app/Dockerfile
+++ b/test/koa-mysql/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16
+FROM node:18
 
 COPY run.sh /
 

--- a/test/koa-mysql/app/run.sh
+++ b/test/koa-mysql/app/run.sh
@@ -5,9 +5,6 @@ set -eu
 echo "Giving permission to all users on spans directory"
 chmod -R 777 /spans
 
-echo "Installing compatible NPM version"
-npm install -g npm@7.18.1
-
 echo "Install, link and build integration"
 (
 cd /integration

--- a/test/nestjs/app/Dockerfile
+++ b/test/nestjs/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16
+FROM node:18
 
 COPY run.sh /
 

--- a/test/nestjs/app/run.sh
+++ b/test/nestjs/app/run.sh
@@ -5,9 +5,6 @@ set -eu
 echo "Giving permission to all users on span directory"
 chmod -R 777 /spans
 
-echo "Installing compatible NPM version"
-npm install -g npm@7.18.1
-
 echo "Install, link and build integration"
 (
 cd /integration

--- a/test/nextjs/app/Dockerfile
+++ b/test/nextjs/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16
+FROM node:18
 
 COPY run.sh /
 

--- a/test/nextjs/app/run.sh
+++ b/test/nextjs/app/run.sh
@@ -5,9 +5,6 @@ set -eu
 echo "Giving permission to all users on spans directory"
 chmod -R 777 /spans
 
-echo "Installing compatible NPM version"
-npm install -g npm@7.18.1
-
 echo "Install, link and build integration"
 (
 cd /integration

--- a/test/restify/app/Dockerfile
+++ b/test/restify/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16
+FROM node:18
 
 COPY run.sh /
 

--- a/test/restify/app/run.sh
+++ b/test/restify/app/run.sh
@@ -5,9 +5,6 @@ set -eu
 echo "Giving permission to all users on span directory"
 chmod -R 777 /spans
 
-echo "Installing compatible NPM version"
-npm install -g npm@7.18.1
-
 echo "Install, link and build integration"
 (
   cd /integration


### PR DESCRIPTION
For some reason the Node.js 16 container broke with the error message below.

Update the Node.js version to 18 resolves the issue. I've also removed the installation of specific npm versions. It appears to work with the default installed version npm v8.

Change the netcat install to netcat-openbsd as that's the package name on this version of Debian.

```
npm ERR! code EACCES
npm ERR! syscall mkdir
npm ERR! path /root/.npm/_cacache/tmp
npm ERR! errno -13
npm ERR!
npm ERR! Your cache folder contains root-owned files, due to a bug in
npm ERR! previous versions of npm which has since been addressed.
npm ERR!
npm ERR! To permanently fix this problem, please run:
npm ERR!   sudo chown -R 1001:1001 "/root/.npm"
```


[skip changeset]