### PR TITLE
Update diagnose URLs in output and docs

### DIFF
--- a/.changesets/update-diagnose-tool-urls.md
+++ b/.changesets/update-diagnose-tool-urls.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Update the diagnose tool URLs printed by the CLI and package to the new location in our documentation.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@appsignal/nodejs",
-  "version": "3.0.26",
+  "version": "3.0.27",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@appsignal/nodejs",
-      "version": "3.0.26",
+      "version": "3.0.27",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/src/__tests__/extension.failure.test.ts
+++ b/src/__tests__/extension.failure.test.ts
@@ -23,7 +23,7 @@ describe("Extension", () => {
     require("../extension")
 
     expect(errorSpy).toHaveBeenLastCalledWith(
-      "[appsignal][ERROR] AppSignal failed to load the extension. Please run the diagnose tool and email us at support@appsignal.com: https://docs.appsignal.com/nodejs/command-line/diagnose.html\n",
+      "[appsignal][ERROR] AppSignal failed to load the extension. Please run the diagnose tool and email us at support@appsignal.com: https://docs.appsignal.com/nodejs/3.x/command-line/diagnose.html\n",
       expect.any(Object)
     )
   })
@@ -89,7 +89,7 @@ describe("Extension", () => {
         expect.any(Object)
       )
       expect(errorSpy).toHaveBeenLastCalledWith(
-        "[appsignal][ERROR] AppSignal failed to load the extension. Please run the diagnose tool and email us at support@appsignal.com: https://docs.appsignal.com/nodejs/command-line/diagnose.html\n",
+        "[appsignal][ERROR] AppSignal failed to load the extension. Please run the diagnose tool and email us at support@appsignal.com: https://docs.appsignal.com/nodejs/3.x/command-line/diagnose.html\n",
         expect.any(Object)
       )
     })

--- a/src/cli/diagnose.ts
+++ b/src/cli/diagnose.ts
@@ -151,7 +151,9 @@ export class Diagnose {
     this.print_newline()
 
     console.log(`Read more about how the diagnose config output is rendered`)
-    console.log(`https://docs.appsignal.com/nodejs/command-line/diagnose.html`)
+    console.log(
+      `https://docs.appsignal.com/nodejs/3.x/command-line/diagnose.html`
+    )
 
     this.print_newline()
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -217,7 +217,7 @@ export class Client {
   /**
    * Internal private function used by the demo CLI.
    *
-   * https://docs.appsignal.com/nodejs/command-line/demo.html
+   * https://docs.appsignal.com/nodejs/3.x/command-line/demo.html
    *
    * @private
    */

--- a/src/extension_wrapper.ts
+++ b/src/extension_wrapper.ts
@@ -41,7 +41,7 @@ try {
     )
   } else {
     console.error(
-      "[appsignal][ERROR] AppSignal failed to load the extension. Please run the diagnose tool and email us at support@appsignal.com: https://docs.appsignal.com/nodejs/command-line/diagnose.html\n",
+      "[appsignal][ERROR] AppSignal failed to load the extension. Please run the diagnose tool and email us at support@appsignal.com: https://docs.appsignal.com/nodejs/3.x/command-line/diagnose.html\n",
       error
     )
   }


### PR DESCRIPTION
Make sure we point to the right page for the diagnose command line tool.

Fixes https://github.com/appsignal/support/issues/301

[skip review]