### PR TITLE
Add OpenTelemetry diag logger

### DIFF
--- a/.changesets/add-opentelemetry-diag-logger.md
+++ b/.changesets/add-opentelemetry-diag-logger.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "add"
+---
+
+When the AppSignal log level is set to "trace". Additional information from the OpenTelemetry instrumentations is now logged.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@appsignal/nodejs",
-  "version": "3.0.28",
+  "version": "3.0.29",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@appsignal/nodejs",
-      "version": "3.0.28",
+      "version": "3.0.29",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/src/client.ts
+++ b/src/client.ts
@@ -9,6 +9,7 @@ import { demo } from "./demo"
 import { VERSION } from "./version"
 import { setParams, setSessionData } from "./helpers"
 import { BaseLogger, Logger, LoggerFormat, LoggerLevel } from "./logger"
+import { diag, DiagConsoleLogger, DiagLogLevel } from "@opentelemetry/api"
 
 import { Instrumentation } from "@opentelemetry/instrumentation"
 import {
@@ -157,6 +158,7 @@ export class Client {
         this.#metrics = new Metrics()
         if (this.config.data.initializeOpentelemetrySdk) {
           this.#sdk = this.initOpenTelemetry()
+          this.setUpOpenTelemetryLogger()
         }
       }
     } else {
@@ -414,6 +416,17 @@ export class Client {
     }
 
     return logger
+  }
+
+  /**
+   * Sets up the OpenTelemetry diag logger based on our integration logger level.
+   * If our integration logger level is "silly" ("trace"), the OpenTelemetry diag debug messages
+   * are logged.
+   */
+  private setUpOpenTelemetryLogger(): void {
+    if (this.config.data["logLevel"] === "trace") {
+      diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.DEBUG)
+    }
   }
 
   /**


### PR DESCRIPTION
In order to get more information when our users encounter issues, the OpenTelemetry diag logger is now enabled when the AppSignal log level is set to trace.

Closes #970 