### PR TITLE
Fix demo sample recognition by fixing the demo tag

### DIFF
--- a/.changesets/fix-demo-sample-recognition.md
+++ b/.changesets/fix-demo-sample-recognition.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Fix the demo sample recognition. Demo samples didn't show the helpful explanation box in the UI, because the `demo_sample` tag was set incorrectly as an attribute.

--- a/src/demo.ts
+++ b/src/demo.ts
@@ -23,7 +23,7 @@ export function demo(client: Client) {
     startSec + 1,
     startNsec * 1.2,
     "GET /demo",
-    { demo_sample: true },
+    { "appsignal.tag.demo_sample": true },
     "@opentelemetry/instrumentation-http"
   )
   performanceRootSpan.close()
@@ -53,7 +53,7 @@ export function demo(client: Client) {
     startSec + 1,
     startNsec + 200,
     "GET /demo",
-    { demo_sample: true },
+    { "appsignal.tag.demo_sample": true },
     "@opentelemetry/instrumentation-http"
   )
   try {


### PR DESCRIPTION
When `demo_sample` was passed as an attribute to the `createOpenTelemetrySpan` extension function it wasn't recognized as a tag for AppSignal. The UI only recognizes tags and not root level attributes for the demo samples box.

Use the attribute format described in our docs to transform the attribute into a tag.
https://docs.appsignal.com/opentelemetry/custom-instrumentation/attributes.html#tag

Fixes https://github.com/appsignal/appsignal-server/issues/10389