### PR TITLE
Bump agent to bfe19b1

### DIFF
--- a/.changesets/remove-deprecated-extension-functions.md
+++ b/.changesets/remove-deprecated-extension-functions.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "remove"
+---
+
+Remove the `appsignal_set_host_guage` and `appsignal_set_process_gauge` extension functions. These functions were already deprecated and did not report any metrics.

--- a/.changesets/update-probes-0.5.4.md
+++ b/.changesets/update-probes-0.5.4.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "change"
+---
+
+Fix disk usage returning a Vec with no entries on Alpine Linux when the `df --local` command fails.

--- a/scripts/extension/support/constants.js
+++ b/scripts/extension/support/constants.js
@@ -3,7 +3,7 @@
 // appsignal-agent repository.
 // Modifications to this file will be overwritten with the next agent release.
 
-const AGENT_VERSION = "8f31b1a"
+const AGENT_VERSION = "bfe19b1"
 const MIRRORS = [
   "https://appsignal-agent-releases.global.ssl.fastly.net",
   "https://d135dj0rjqvssy.cloudfront.net"
@@ -12,67 +12,67 @@ const MIRRORS = [
 const TRIPLES = {
   "x86_64-darwin": {
     checksum:
-      "b81667a886ef89319a9d177749dc4acf48814d0f834c2974d0d2b4639dd664e6",
+      "0985697683dc7f2bc0a353b637e3923a79b1945f730deceba73f65807cdcbb16",
     filename: "appsignal-x86_64-darwin-all-static.tar.gz"
   },
   "universal-darwin": {
     checksum:
-      "b81667a886ef89319a9d177749dc4acf48814d0f834c2974d0d2b4639dd664e6",
+      "0985697683dc7f2bc0a353b637e3923a79b1945f730deceba73f65807cdcbb16",
     filename: "appsignal-x86_64-darwin-all-static.tar.gz"
   },
   "aarch64-darwin": {
     checksum:
-      "a1b4aa1d7aaf756bcdc7bcec615033002531c6fb44aa7a2d00abda567bd4e9ab",
+      "8fe7adac3f265d47f9bff244b357b11551065c15542e22c5e5a10afa7d3d18f9",
     filename: "appsignal-aarch64-darwin-all-static.tar.gz"
   },
   "arm64-darwin": {
     checksum:
-      "a1b4aa1d7aaf756bcdc7bcec615033002531c6fb44aa7a2d00abda567bd4e9ab",
+      "8fe7adac3f265d47f9bff244b357b11551065c15542e22c5e5a10afa7d3d18f9",
     filename: "appsignal-aarch64-darwin-all-static.tar.gz"
   },
   "arm-darwin": {
     checksum:
-      "a1b4aa1d7aaf756bcdc7bcec615033002531c6fb44aa7a2d00abda567bd4e9ab",
+      "8fe7adac3f265d47f9bff244b357b11551065c15542e22c5e5a10afa7d3d18f9",
     filename: "appsignal-aarch64-darwin-all-static.tar.gz"
   },
   "aarch64-linux": {
     checksum:
-      "ce212c1672c247d1b72b92aee71a256c1270bb1d52ff7e91c5d48da423b6701d",
+      "8278a46232ab0b88dfbd5276a7253f147a950ea0f55ebb104ef825a528d24b73",
     filename: "appsignal-aarch64-linux-all-static.tar.gz"
   },
   "i686-linux": {
     checksum:
-      "e2a394ee9b9e4d11572e48cb3dd457f077453e87b8520f54e8150b889b4d7d43",
+      "2b0cfc65ccd05d1258719e73fc19323729100d02a33d936ba79bb12cdede3763",
     filename: "appsignal-i686-linux-all-static.tar.gz"
   },
   "x86-linux": {
     checksum:
-      "e2a394ee9b9e4d11572e48cb3dd457f077453e87b8520f54e8150b889b4d7d43",
+      "2b0cfc65ccd05d1258719e73fc19323729100d02a33d936ba79bb12cdede3763",
     filename: "appsignal-i686-linux-all-static.tar.gz"
   },
   "x86_64-linux": {
     checksum:
-      "0e4152b1b5e0924a70a3a24604d11bfa2c4df8faea43b30546d6e880b41f9a51",
+      "10bafbef6445ea1a37529b34fb103dd48e185f61f19f58f573377127d03f6a60",
     filename: "appsignal-x86_64-linux-all-static.tar.gz"
   },
   "x86_64-linux-musl": {
     checksum:
-      "26c4e0b857efe69b774cfe68a68ab97a91aee58c3c23ffd32955ca16f8c020fa",
+      "fba0b10a3dcac0854cd9d19773ab48649fc79a35261eacdfe28d6e70c267b98a",
     filename: "appsignal-x86_64-linux-musl-all-static.tar.gz"
   },
   "aarch64-linux-musl": {
     checksum:
-      "8b39b9180ac16ca7b99eb226e43fe9be74340fb07b2c002fe1054cb6d2e6b010",
+      "98e8aafa0f688b1f1a9c37daf9e9cc1e36edc7e0ad65f86d8402469d15b6a1d6",
     filename: "appsignal-aarch64-linux-musl-all-static.tar.gz"
   },
   "x86_64-freebsd": {
     checksum:
-      "2a0456b860c446938aae1d605193e6732578a39ef0df2a1247266335adc019e9",
+      "09ebc6406d81fdf81b2e76bef6c1344f34292e1b3727f7fc984c8df5c7698db5",
     filename: "appsignal-x86_64-freebsd-all-static.tar.gz"
   },
   "amd64-freebsd": {
     checksum:
-      "2a0456b860c446938aae1d605193e6732578a39ef0df2a1247266335adc019e9",
+      "09ebc6406d81fdf81b2e76bef6c1344f34292e1b3727f7fc984c8df5c7698db5",
     filename: "appsignal-x86_64-freebsd-all-static.tar.gz"
   }
 }


### PR DESCRIPTION
- Remove deprecated extension functions.
- Update probes library with fix for Alpine Linux disk usage stats.

[skip review]