### PR TITLE
Bump agent to version 0.31.2

### DIFF
--- a/.changesets/improve-missing-extractor-logs.md
+++ b/.changesets/improve-missing-extractor-logs.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "change"
+---
+
+Make the debug log message for OpenTelemetry spans from libraries we don't automatically recognize more clear. Mention the span id and the instrumentation library.

--- a/.changesets/remove-deprecated-extension-functions.md
+++ b/.changesets/remove-deprecated-extension-functions.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "remove"
+---
+
+Remove the `appsignal_set_host_guage` and `appsignal_set_process_gauge` extension functions. These functions were already deprecated and did not report any metrics.

--- a/.changesets/remove-deprecated-extension-functions.md
+++ b/.changesets/remove-deprecated-extension-functions.md
@@ -1,6 +1,0 @@
----
-bump: "patch"
-type: "remove"
----
-
-Remove the `appsignal_set_host_guage` and `appsignal_set_process_gauge` extension functions. These functions were already deprecated and did not report any metrics.

--- a/.changesets/update-probes-0.5.4.md
+++ b/.changesets/update-probes-0.5.4.md
@@ -1,6 +1,0 @@
----
-bump: "patch"
-type: "change"
----
-
-Fix disk usage returning a Vec with no entries on Alpine Linux when the `df --local` command fails.

--- a/.changesets/update-probes-0.5.4.md
+++ b/.changesets/update-probes-0.5.4.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "change"
+---
+
+Fix disk usage returning a Vec with no entries on Alpine Linux when the `df --local` command fails.

--- a/.changesets/update-sql_lexer-0.9.6.md
+++ b/.changesets/update-sql_lexer-0.9.6.md
@@ -1,0 +1,7 @@
+---
+bump: "patch"
+type: "change"
+---
+
+Fix an issue where queries containing a MySQL leading type indicator would only be partially sanitised.
+

--- a/scripts/extension/support/constants.js
+++ b/scripts/extension/support/constants.js
@@ -3,7 +3,7 @@
 // appsignal-agent repository.
 // Modifications to this file will be overwritten with the next agent release.
 
-const AGENT_VERSION = "bfe19b1"
+const AGENT_VERSION = "0.31.2"
 const MIRRORS = [
   "https://appsignal-agent-releases.global.ssl.fastly.net",
   "https://d135dj0rjqvssy.cloudfront.net"
@@ -12,67 +12,67 @@ const MIRRORS = [
 const TRIPLES = {
   "x86_64-darwin": {
     checksum:
-      "0985697683dc7f2bc0a353b637e3923a79b1945f730deceba73f65807cdcbb16",
+      "42cdf814a89e5d6bd6e5cd9ba84103df82b43418012bb4f9251e98d0c3627759",
     filename: "appsignal-x86_64-darwin-all-static.tar.gz"
   },
   "universal-darwin": {
     checksum:
-      "0985697683dc7f2bc0a353b637e3923a79b1945f730deceba73f65807cdcbb16",
+      "42cdf814a89e5d6bd6e5cd9ba84103df82b43418012bb4f9251e98d0c3627759",
     filename: "appsignal-x86_64-darwin-all-static.tar.gz"
   },
   "aarch64-darwin": {
     checksum:
-      "8fe7adac3f265d47f9bff244b357b11551065c15542e22c5e5a10afa7d3d18f9",
+      "8db9e31e090e767b1157d969521967f322be9dd73eb1b677b6192eb4c987af72",
     filename: "appsignal-aarch64-darwin-all-static.tar.gz"
   },
   "arm64-darwin": {
     checksum:
-      "8fe7adac3f265d47f9bff244b357b11551065c15542e22c5e5a10afa7d3d18f9",
+      "8db9e31e090e767b1157d969521967f322be9dd73eb1b677b6192eb4c987af72",
     filename: "appsignal-aarch64-darwin-all-static.tar.gz"
   },
   "arm-darwin": {
     checksum:
-      "8fe7adac3f265d47f9bff244b357b11551065c15542e22c5e5a10afa7d3d18f9",
+      "8db9e31e090e767b1157d969521967f322be9dd73eb1b677b6192eb4c987af72",
     filename: "appsignal-aarch64-darwin-all-static.tar.gz"
   },
   "aarch64-linux": {
     checksum:
-      "8278a46232ab0b88dfbd5276a7253f147a950ea0f55ebb104ef825a528d24b73",
+      "72873d1c7ad2d4d744fe3dd4370fb07b4c9d8a4f4d87febb8dbe08c532eebff8",
     filename: "appsignal-aarch64-linux-all-static.tar.gz"
   },
   "i686-linux": {
     checksum:
-      "2b0cfc65ccd05d1258719e73fc19323729100d02a33d936ba79bb12cdede3763",
+      "8779fdd2f02b034463900456b5b65a92d3a9165b87ba896b01baded96729685a",
     filename: "appsignal-i686-linux-all-static.tar.gz"
   },
   "x86-linux": {
     checksum:
-      "2b0cfc65ccd05d1258719e73fc19323729100d02a33d936ba79bb12cdede3763",
+      "8779fdd2f02b034463900456b5b65a92d3a9165b87ba896b01baded96729685a",
     filename: "appsignal-i686-linux-all-static.tar.gz"
   },
   "x86_64-linux": {
     checksum:
-      "10bafbef6445ea1a37529b34fb103dd48e185f61f19f58f573377127d03f6a60",
+      "36fc29655d13e4dfe7bcbe2c798bfc16d68194610ff354d43e977f3768f31458",
     filename: "appsignal-x86_64-linux-all-static.tar.gz"
   },
   "x86_64-linux-musl": {
     checksum:
-      "fba0b10a3dcac0854cd9d19773ab48649fc79a35261eacdfe28d6e70c267b98a",
+      "59b6cef9797746da9d6717effc0892a2f2219767734a0e76f8b3d1578dc0d9e0",
     filename: "appsignal-x86_64-linux-musl-all-static.tar.gz"
   },
   "aarch64-linux-musl": {
     checksum:
-      "98e8aafa0f688b1f1a9c37daf9e9cc1e36edc7e0ad65f86d8402469d15b6a1d6",
+      "ec3ab8fcc20d1f31df6003e2ca3dcf257abfeddd1b7912fa6189f1f6905a89ab",
     filename: "appsignal-aarch64-linux-musl-all-static.tar.gz"
   },
   "x86_64-freebsd": {
     checksum:
-      "09ebc6406d81fdf81b2e76bef6c1344f34292e1b3727f7fc984c8df5c7698db5",
+      "bd654d5c555f6006e4145d76e27f02c5d22b285f411675a520455d6db6c8e165",
     filename: "appsignal-x86_64-freebsd-all-static.tar.gz"
   },
   "amd64-freebsd": {
     checksum:
-      "09ebc6406d81fdf81b2e76bef6c1344f34292e1b3727f7fc984c8df5c7698db5",
+      "bd654d5c555f6006e4145d76e27f02c5d22b285f411675a520455d6db6c8e165",
     filename: "appsignal-x86_64-freebsd-all-static.tar.gz"
   }
 }


### PR DESCRIPTION
## Bump agent to version 0.31.2

The agent update and changesets are updated automatically.

[skip review]

## Remove changesets present in previous release

I didn't clean up these files in the agent repo so they ended up here automatically this release. Remove them.

## Fix diagnose tests agent version matcher

Update to the new numbered version matcher.

---

[skip review]
