### PR TITLE
Rename Integration to Internal Logger

### DIFF
--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -5,9 +5,9 @@ import {
 import { Extension } from "../extension"
 import { Client } from "../client"
 import { Metrics } from "../metrics"
-import { NoopIntegrationLogger, NoopLogger, NoopMetrics } from "../noops"
+import { NoopInternalLogger, NoopLogger, NoopMetrics } from "../noops"
 import { Instrumentation } from "@opentelemetry/instrumentation"
-import { BaseIntegrationLogger } from "../integration_logger"
+import { BaseInternalLogger } from "../internal_logger"
 import { BaseLogger } from "../logger"
 
 describe("Client", () => {
@@ -61,12 +61,12 @@ describe("Client", () => {
   })
 
   it("returns the integration logger from global object", () => {
-    expect(Client.integrationLogger).toEqual(client.integrationLogger)
+    expect(Client.internalLogger).toEqual(client.internalLogger)
   })
 
   it("returns a noop integration logger if the client has not been initialised", () => {
     global.__APPSIGNAL__ = undefined as any
-    expect(Client.integrationLogger).toBeInstanceOf(NoopIntegrationLogger)
+    expect(Client.internalLogger).toBeInstanceOf(NoopInternalLogger)
   })
 
   it("returns the user logger from global object if the client is active", () => {
@@ -84,28 +84,20 @@ describe("Client", () => {
   })
 
   it("sets the integration logger level to info by default and uses a file transport", () => {
-    expect((Client.integrationLogger as BaseIntegrationLogger).type).toEqual(
-      "file"
-    )
-    expect((Client.integrationLogger as BaseIntegrationLogger).level).toEqual(
-      "info"
-    )
+    expect((Client.internalLogger as BaseInternalLogger).type).toEqual("file")
+    expect((Client.internalLogger as BaseInternalLogger).level).toEqual("info")
   })
 
   it("sets the integration logger level to the translated one", () => {
     client = new Client({ ...DEFAULT_OPTS, logLevel: "trace" })
 
-    expect((Client.integrationLogger as BaseIntegrationLogger).level).toEqual(
-      "silly"
-    )
+    expect((Client.internalLogger as BaseInternalLogger).level).toEqual("silly")
   })
 
   it("uses a console transport for integration logging if specified", () => {
     client = new Client({ ...DEFAULT_OPTS, log: "stdout" })
 
-    expect((Client.integrationLogger as BaseIntegrationLogger).type).toEqual(
-      "stdout"
-    )
+    expect((Client.internalLogger as BaseInternalLogger).type).toEqual("stdout")
   })
 
   it("does not start the client if the config is not valid", () => {

--- a/src/__tests__/helpers.test.ts
+++ b/src/__tests__/helpers.test.ts
@@ -126,7 +126,7 @@ describe("Helpers", () => {
   })
 
   it("logs a debug warning when there is no active span", () => {
-    const debugMock = jest.spyOn(Client.integrationLogger, "debug")
+    const debugMock = jest.spyOn(Client.internalLogger, "debug")
 
     setCustomData({ chunky: "bacon" })
 
@@ -153,7 +153,7 @@ describe("Helpers", () => {
     })
 
     it("logs a debug warning when there is no active span", () => {
-      const debugMock = jest.spyOn(Client.integrationLogger, "debug")
+      const debugMock = jest.spyOn(Client.internalLogger, "debug")
 
       setError(new Error("Oh no!"))
 
@@ -163,7 +163,7 @@ describe("Helpers", () => {
     })
 
     it("logs a debug warning when the value is not an error", () => {
-      const debugMock = jest.spyOn(Client.integrationLogger, "debug")
+      const debugMock = jest.spyOn(Client.internalLogger, "debug")
 
       setError("Oh no!" as any as Error)
 
@@ -220,7 +220,7 @@ describe("Helpers", () => {
     })
 
     it("logs a debug warning when the value is not an error", () => {
-      const debugMock = jest.spyOn(Client.integrationLogger, "debug")
+      const debugMock = jest.spyOn(Client.internalLogger, "debug")
 
       sendError("Oh no!" as any as Error)
 
@@ -232,7 +232,7 @@ describe("Helpers", () => {
 
   describe("Optional span argument", () => {
     it("can optionally take a span to use instead of the active span", () => {
-      const debugMock = jest.spyOn(Client.integrationLogger, "debug")
+      const debugMock = jest.spyOn(Client.internalLogger, "debug")
 
       const tracer = trace.getTracer("test")
       tracer.startActiveSpan("Active span", span => {
@@ -295,7 +295,7 @@ describe("Helpers", () => {
 
   describe("instrumentationsLoaded (deprecated)", () => {
     it("returns a promise and a deprecation warning", () => {
-      const debugMock = jest.spyOn(Client.integrationLogger, "warn")
+      const debugMock = jest.spyOn(Client.internalLogger, "warn")
 
       expect(instrumentationsLoaded()).toBeInstanceOf(Promise)
       expect(debugMock).toHaveBeenCalledWith(

--- a/src/__tests__/integration_logger.test.ts
+++ b/src/__tests__/integration_logger.test.ts
@@ -1,10 +1,10 @@
-import { BaseIntegrationLogger } from "../integration_logger"
+import { BaseInternalLogger } from "../internal_logger"
 
-describe("BaseIntegrationLogger", () => {
-  let logger: BaseIntegrationLogger
+describe("BaseInternalLogger", () => {
+  let logger: BaseInternalLogger
 
   beforeEach(() => {
-    logger = new BaseIntegrationLogger("stdout", "trace")
+    logger = new BaseInternalLogger("stdout", "trace")
   })
 
   it("sends errors to winston", () => {
@@ -43,22 +43,22 @@ describe("BaseIntegrationLogger", () => {
   })
 
   it("sets the proper npm log levels from our log levels", () => {
-    logger = new BaseIntegrationLogger("stdout", "error")
+    logger = new BaseInternalLogger("stdout", "error")
     expect(logger.level).toEqual("error")
 
-    logger = new BaseIntegrationLogger("stdout", "warning")
+    logger = new BaseInternalLogger("stdout", "warning")
     expect(logger.level).toEqual("warn")
 
-    logger = new BaseIntegrationLogger("stdout", "info")
+    logger = new BaseInternalLogger("stdout", "info")
     expect(logger.level).toEqual("info")
 
-    logger = new BaseIntegrationLogger("stdout", "debug")
+    logger = new BaseInternalLogger("stdout", "debug")
     expect(logger.level).toEqual("debug")
 
-    logger = new BaseIntegrationLogger("stdout", "trace")
+    logger = new BaseInternalLogger("stdout", "trace")
     expect(logger.level).toEqual("silly")
 
-    logger = new BaseIntegrationLogger("stdout", "fooBarBaz")
+    logger = new BaseInternalLogger("stdout", "fooBarBaz")
     expect(logger.level).toEqual("info")
   })
 })

--- a/src/__tests__/logger.test.ts
+++ b/src/__tests__/logger.test.ts
@@ -14,19 +14,19 @@ describe("BaseLogger", () => {
 
   beforeEach(() => {
     client.extension.log = jest.fn()
-    client.integrationLogger.warn = jest.fn()
+    client.internalLogger.warn = jest.fn()
     logger = new BaseLogger(client, "groupname")
   })
 
   it("defaults to an info logger level", () => {
     expect(logger.severityThreshold).toEqual(3)
-    expect(client.integrationLogger.warn).not.toHaveBeenCalled()
+    expect(client.internalLogger.warn).not.toHaveBeenCalled()
   })
 
   it("sets an info logger level when the severity is unknown and logs a warning", () => {
     logger = new BaseLogger(client, "groupname", "bacon" as LoggerLevel)
     expect(logger.severityThreshold).toEqual(3)
-    expect(client.integrationLogger.warn).toHaveBeenCalledWith(
+    expect(client.internalLogger.warn).toHaveBeenCalledWith(
       expect.stringContaining(`"bacon"`)
     )
   })
@@ -54,7 +54,7 @@ describe("BaseLogger", () => {
 
   it("defaults to a plaintext logger format", () => {
     expect(logger.format).toEqual(0)
-    expect(client.integrationLogger.warn).not.toHaveBeenCalled()
+    expect(client.internalLogger.warn).not.toHaveBeenCalled()
   })
 
   it("sets a plaintext format level when the format is unknown and logs a warning", () => {
@@ -65,7 +65,7 @@ describe("BaseLogger", () => {
       "bacon" as LoggerFormat
     )
     expect(logger.format).toEqual(0)
-    expect(client.integrationLogger.warn).toHaveBeenCalledWith(
+    expect(client.internalLogger.warn).toHaveBeenCalledWith(
       expect.stringContaining(`"bacon"`)
     )
   })

--- a/src/client.ts
+++ b/src/client.ts
@@ -3,8 +3,8 @@ import { Extension } from "./extension"
 import { Configuration } from "./config"
 import { Metrics } from "./metrics"
 import * as gcProbe from "./probes/v8"
-import { BaseIntegrationLogger, IntegrationLogger } from "./integration_logger"
-import { NoopMetrics, noopIntegrationLogger, noopLogger } from "./noops"
+import { BaseInternalLogger, InternalLogger } from "./internal_logger"
+import { NoopMetrics, noopInternalLogger, noopLogger } from "./noops"
 import { demo } from "./demo"
 import { VERSION } from "./version"
 import { setParams, setSessionData } from "./helpers"
@@ -89,7 +89,7 @@ export class Client {
   readonly VERSION = VERSION
 
   config: Configuration
-  readonly integrationLogger: IntegrationLogger
+  readonly internalLogger: InternalLogger
   extension: Extension
 
   #metrics: Metrics
@@ -113,11 +113,11 @@ export class Client {
   /**
    * Global accessors for the AppSignal integration Logger
    */
-  static get integrationLogger(): IntegrationLogger {
+  static get internalLogger(): InternalLogger {
     if (this.client) {
-      return this.client.integrationLogger
+      return this.client.internalLogger
     } else {
-      return noopIntegrationLogger
+      return noopInternalLogger
     }
   }
 
@@ -144,12 +144,12 @@ export class Client {
 
     this.config = new Configuration(options)
     this.extension = new Extension()
-    this.integrationLogger = this.setUpIntegrationLogger()
+    this.internalLogger = this.setupInternalLogger()
     this.storeInGlobal()
 
     if (this.isActive) {
       if (process.env._APPSIGNAL_DIAGNOSE === "true") {
-        Client.integrationLogger.info(
+        Client.internalLogger.info(
           "Diagnose mode is enabled, not starting extension, SDK and probes"
         )
         this.#metrics = new NoopMetrics()
@@ -403,16 +403,16 @@ export class Client {
    * Sets up the AppSignal logger with the output based on the `log` config option. If
    * the log file is not accessible, stdout will be the output.
    */
-  private setUpIntegrationLogger(): IntegrationLogger {
+  private setupInternalLogger(): InternalLogger {
     const logFilePath = this.config.logFilePath
     const logLevel = String(this.config.data["logLevel"])
     const logType = String(this.config.data["log"])
     let logger
 
     if (logType == "file" && logFilePath) {
-      logger = new BaseIntegrationLogger(logType, logLevel, logFilePath)
+      logger = new BaseInternalLogger(logType, logLevel, logFilePath)
     } else {
-      logger = new BaseIntegrationLogger(logType, logLevel)
+      logger = new BaseInternalLogger(logType, logLevel)
     }
 
     return logger

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -10,7 +10,7 @@ function setAttribute(attribute: string, value: AttributeValue, span?: Span) {
   } else {
     const splitAttributes = attribute.split(".")
     const attributeSuffix = splitAttributes[splitAttributes.length - 1]
-    Client.integrationLogger.debug(
+    Client.internalLogger.debug(
       `There is no active span, cannot set \`${attributeSuffix}\``
     )
   }
@@ -106,12 +106,12 @@ export function setError(error: Error, span?: Span) {
         message: error.message
       })
     } else {
-      Client.integrationLogger.debug(
+      Client.internalLogger.debug(
         `There is no active span, cannot set \`${error.name}\``
       )
     }
   } else {
-    Client.integrationLogger.debug(
+    Client.internalLogger.debug(
       "Cannot set error, it is not an `Error`-like object"
     )
   }
@@ -127,7 +127,7 @@ export function sendError(error: Error, fn: () => void = () => {}) {
         span.end()
       })
   } else {
-    Client.integrationLogger.debug(
+    Client.internalLogger.debug(
       "Cannot send error, it is not an `Error`-like object"
     )
   }
@@ -137,7 +137,7 @@ export function sendError(error: Error, fn: () => void = () => {}) {
  * @deprecated This function is no longer required for manual instrumentation.
  */
 export function instrumentationsLoaded(): Promise<void> {
-  Client.integrationLogger.warn(
+  Client.internalLogger.warn(
     "instrumentationsLoaded() is deprecated, please remove it from your code as it'll be deleted in the next major release."
   )
 

--- a/src/internal_logger.ts
+++ b/src/internal_logger.ts
@@ -1,7 +1,7 @@
 import winston from "winston"
 const { combine, timestamp, printf } = winston.format
 
-export interface IntegrationLogger {
+export interface InternalLogger {
   error(message: string): void
   warn(message: string): void
   info(message: string): void
@@ -9,7 +9,7 @@ export interface IntegrationLogger {
   trace(message: string): void
 }
 
-export class BaseIntegrationLogger {
+export class BaseInternalLogger {
   type: string
   level: string
   logger: winston.Logger

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -66,7 +66,7 @@ export class BaseLogger implements Logger {
     this.format = get_format(format)
 
     if (this.severityThreshold == UNKNOWN_SEVERITY) {
-      this.#client.integrationLogger.warn(
+      this.#client.internalLogger.warn(
         `Logger level must be "trace", "debug", "info", "log", "warn" or "error", ` +
           `but "${level}" was given. Logger level set to "info".`
       )
@@ -74,7 +74,7 @@ export class BaseLogger implements Logger {
     }
 
     if (this.format == UNKNOWN_FORMAT) {
-      this.#client.integrationLogger.warn(
+      this.#client.internalLogger.warn(
         `Logger format must be "plaintext", "logfmt", or "json", ` +
           `but "${format}" was given. Logger format set to "plaintext".`
       )

--- a/src/noops/index.ts
+++ b/src/noops/index.ts
@@ -1,3 +1,3 @@
 export * from "./metrics"
-export * from "./integration_logger"
+export * from "./internal_logger"
 export * from "./logger"

--- a/src/noops/internal_logger.ts
+++ b/src/noops/internal_logger.ts
@@ -1,6 +1,6 @@
-import { IntegrationLogger } from "../integration_logger"
+import { InternalLogger } from "../internal_logger"
 
-export class NoopIntegrationLogger implements IntegrationLogger {
+export class NoopInternalLogger implements InternalLogger {
   error(_message: string) {
     // noop
   }
@@ -18,4 +18,4 @@ export class NoopIntegrationLogger implements IntegrationLogger {
   }
 }
 
-export const noopIntegrationLogger = new NoopIntegrationLogger()
+export const noopInternalLogger = new NoopInternalLogger()


### PR DESCRIPTION
In order to keep a uniform naming convention for our internal loggers, rename this one to `InternalLogger` from `IntegrationLogger`.

[skip changeset]