### PR TITLE
Bump agent and implement CPU count

### DIFF
--- a/.changesets/fix-asgi-events-showing-up-in-the--slow-api-requests--panel.md
+++ b/.changesets/fix-asgi-events-showing-up-in-the--slow-api-requests--panel.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Fix ASGI events (from Python ASGI applications) showing up in the "Slow API requests" panel.

--- a/.changesets/fix-asgi-events-showing-up-in-the--slow-api-requests--panel.md
+++ b/.changesets/fix-asgi-events-showing-up-in-the--slow-api-requests--panel.md
@@ -1,6 +1,0 @@
----
-bump: "patch"
-type: "fix"
----
-
-Fix ASGI events (from Python ASGI applications) showing up in the "Slow API requests" panel.

--- a/.changesets/implement-cpu-count-configuration-option.md
+++ b/.changesets/implement-cpu-count-configuration-option.md
@@ -1,0 +1,10 @@
+---
+bump: "patch"
+type: "add"
+---
+
+Implement CPU count configuration option. Use it to override the auto-detected, cgroups-provided number of CPUs that is used to calculate CPU usage percentages.
+
+To set it, use the `APPSIGNAL_CPU_COUNT` environment variable, the `cpu_count`
+configuration option in the Ruby, Elixir or Python integrations, the `cpuCount` attribute in the Node.js instrumentation, or the `cpu_count` configuration option in the stand-alone agent TOML configuration file.
+

--- a/.changesets/implement-cpu-count-configuration-option.md
+++ b/.changesets/implement-cpu-count-configuration-option.md
@@ -5,6 +5,5 @@ type: "add"
 
 Implement CPU count configuration option. Use it to override the auto-detected, cgroups-provided number of CPUs that is used to calculate CPU usage percentages.
 
-To set it, use the `APPSIGNAL_CPU_COUNT` environment variable, the `cpu_count`
-configuration option in the Ruby, Elixir or Python integrations, the `cpuCount` attribute in the Node.js instrumentation, or the `cpu_count` configuration option in the stand-alone agent TOML configuration file.
+To set it, use the `cpuCount` configuration option, or the `APPSIGNAL_CPU_COUNT` environment variable.
 

--- a/scripts/extension/support/constants.js
+++ b/scripts/extension/support/constants.js
@@ -3,7 +3,7 @@
 // appsignal-agent repository.
 // Modifications to this file will be overwritten with the next agent release.
 
-const AGENT_VERSION = "0.34.0"
+const AGENT_VERSION = "0.34.1"
 const MIRRORS = [
   "https://appsignal-agent-releases.global.ssl.fastly.net",
   "https://d135dj0rjqvssy.cloudfront.net"
@@ -12,67 +12,67 @@ const MIRRORS = [
 const TRIPLES = {
   "x86_64-darwin": {
     checksum:
-      "a6c7f10f8efc09f007306189e8af7a2f5335ffec181f76677fa8548f12b8b774",
+      "351f3dae916d3e84177d8cc35eaeaca5345f4deca9e0925a29353915cc0530d2",
     filename: "appsignal-x86_64-darwin-all-static.tar.gz"
   },
   "universal-darwin": {
     checksum:
-      "a6c7f10f8efc09f007306189e8af7a2f5335ffec181f76677fa8548f12b8b774",
+      "351f3dae916d3e84177d8cc35eaeaca5345f4deca9e0925a29353915cc0530d2",
     filename: "appsignal-x86_64-darwin-all-static.tar.gz"
   },
   "aarch64-darwin": {
     checksum:
-      "3c019c103d86b6d3a60d4da5fe5f9449d9980c6087d0f1494e24f91cd045d1d6",
+      "fd7359232fbd65f10ee565fcf65f4afa6d7a2ba1a8dead200c34736ca942df16",
     filename: "appsignal-aarch64-darwin-all-static.tar.gz"
   },
   "arm64-darwin": {
     checksum:
-      "3c019c103d86b6d3a60d4da5fe5f9449d9980c6087d0f1494e24f91cd045d1d6",
+      "fd7359232fbd65f10ee565fcf65f4afa6d7a2ba1a8dead200c34736ca942df16",
     filename: "appsignal-aarch64-darwin-all-static.tar.gz"
   },
   "arm-darwin": {
     checksum:
-      "3c019c103d86b6d3a60d4da5fe5f9449d9980c6087d0f1494e24f91cd045d1d6",
+      "fd7359232fbd65f10ee565fcf65f4afa6d7a2ba1a8dead200c34736ca942df16",
     filename: "appsignal-aarch64-darwin-all-static.tar.gz"
   },
   "aarch64-linux": {
     checksum:
-      "6025983af8d38ba9265795f5b384bc78421f0641a93b749d8aa941881c818199",
+      "dfbab18b7faa24684bf0ab57666b6b493356a3da43ecdba2e992b2d6d513cf31",
     filename: "appsignal-aarch64-linux-all-static.tar.gz"
   },
   "i686-linux": {
     checksum:
-      "99556d16c59053cb79d1fa7b88a60cb6b2881daac9e9e5789546c9799bdef658",
+      "ce4a819f3eaa4590795497915e4a20b3fe281a0821364b80d26ffd1391af67a8",
     filename: "appsignal-i686-linux-all-static.tar.gz"
   },
   "x86-linux": {
     checksum:
-      "99556d16c59053cb79d1fa7b88a60cb6b2881daac9e9e5789546c9799bdef658",
+      "ce4a819f3eaa4590795497915e4a20b3fe281a0821364b80d26ffd1391af67a8",
     filename: "appsignal-i686-linux-all-static.tar.gz"
   },
   "x86_64-linux": {
     checksum:
-      "48ace6181571418a8e8236f8180345f8c97ac152953741b0c394019d0bbefb63",
+      "e55f9ecb4e4b51e9232918216487712b63a7cfea9710763f61077e8d40d53dbe",
     filename: "appsignal-x86_64-linux-all-static.tar.gz"
   },
   "x86_64-linux-musl": {
     checksum:
-      "cb0b388ea1275f8b28547bf79bd127ceaba9b32027426f66eb45de8418a9592d",
+      "8963ebc98405648205a6d8aa371bafa49cb33cd104e0c3e6cc1856ba41fe3d8c",
     filename: "appsignal-x86_64-linux-musl-all-static.tar.gz"
   },
   "aarch64-linux-musl": {
     checksum:
-      "571fc4749c22701a6e9e4c68d1fa9fcad0c443e62c6125c1ef57fb9735d93659",
+      "34bb72678b896a2a8289a97611a61a297b5a0e6110f5085a683ad93857cdf26c",
     filename: "appsignal-aarch64-linux-musl-all-static.tar.gz"
   },
   "x86_64-freebsd": {
     checksum:
-      "5f47f08d1373a6d3e7ee579389a60780508b9a5ae6c69883c8a13a0ae6e09da7",
+      "68e882ba3bc87328953d9bfbb676b00d4199756a7090d5cdc265a4b32d857cc5",
     filename: "appsignal-x86_64-freebsd-all-static.tar.gz"
   },
   "amd64-freebsd": {
     checksum:
-      "5f47f08d1373a6d3e7ee579389a60780508b9a5ae6c69883c8a13a0ae6e09da7",
+      "68e882ba3bc87328953d9bfbb676b00d4199756a7090d5cdc265a4b32d857cc5",
     filename: "appsignal-x86_64-freebsd-all-static.tar.gz"
   }
 }

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -129,11 +129,15 @@ describe("Configuration", () => {
       process.env["APPSIGNAL_ENABLE_STATSD"] = "true"
       process.env["APPSIGNAL_ENABLE_HOST_METRICS"] = "false"
       process.env["APPSIGNAL_DNS_SERVERS"] = "8.8.8.8,8.8.4.4"
+      process.env["APPSIGNAL_CPU_COUNT"] = "1.5"
+
       const envOptions = {
         enableStatsd: true,
         enableHostMetrics: false,
-        dnsServers: ["8.8.8.8", "8.8.4.4"]
+        dnsServers: ["8.8.8.8", "8.8.4.4"],
+        cpuCount: 1.5
       }
+
       const expectedConfig = {
         ...expectedDefaultConfig,
         ...envOptions
@@ -319,6 +323,7 @@ describe("Configuration", () => {
       expect(env("_APPSIGNAL_APP_NAME")).toBeUndefined()
       expect(env("_APPSIGNAL_BIND_ADDRESS")).toBeUndefined()
       expect(env("_APPSIGNAL_CA_FILE_PATH")).toMatch(/cert\/cacert\.pem$/)
+      expect(env("_APPSIGNAL_CPU_COUNT")).toBeUndefined()
       expect(env("_APPSIGNAL_DNS_SERVERS")).toBeUndefined()
       expect(env("_APPSIGNAL_ENABLE_HOST_METRICS")).toEqual("true")
       expect(env("_APPSIGNAL_ENABLE_OPENTELEMETRY_HTTP")).toEqual("true")
@@ -367,6 +372,7 @@ describe("Configuration", () => {
           name,
           active: true,
           bindAddress: "0.0.0.0",
+          cpuCount: 1.5,
           pushApiKey,
           dnsServers: ["8.8.8.8", "8.8.4.4"],
           enableHostMetrics: false,
@@ -397,6 +403,7 @@ describe("Configuration", () => {
         expect(env("_APPSIGNAL_ACTIVE")).toEqual("true")
         expect(env("_APPSIGNAL_APP_NAME")).toEqual(name)
         expect(env("_APPSIGNAL_BIND_ADDRESS")).toEqual("0.0.0.0")
+        expect(env("_APPSIGNAL_CPU_COUNT")).toEqual("1.5")
         expect(env("_APPSIGNAL_DNS_SERVERS")).toEqual("8.8.8.8,8.8.4.4")
         expect(env("_APPSIGNAL_ENABLE_HOST_METRICS")).toEqual("false")
         expect(env("_APPSIGNAL_ENABLE_OPENTELEMETRY_HTTP")).toEqual("false")

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -3,6 +3,14 @@ import fs from "fs"
 
 import { VERSION } from "../version"
 import { Configuration } from "../config"
+import {
+  ENV_TO_KEY_MAPPING,
+  BOOL_KEYS,
+  FLOAT_KEYS,
+  LIST_KEYS,
+  LIST_OR_BOOL_KEYS,
+  STRING_KEYS
+} from "../config/configmap"
 
 describe("Configuration", () => {
   const name = "TEST APP"
@@ -71,6 +79,22 @@ describe("Configuration", () => {
   beforeEach(() => {
     jest.resetModules()
     resetEnv()
+  })
+
+  it("knows how to transform all environment variables into options", () => {
+    const allKeys = Object.keys(ENV_TO_KEY_MAPPING).sort()
+
+    const allKeyTransformations = [
+      BOOL_KEYS,
+      STRING_KEYS,
+      LIST_KEYS,
+      LIST_OR_BOOL_KEYS,
+      FLOAT_KEYS
+    ]
+      .flat()
+      .sort()
+
+    expect(allKeys).toEqual(allKeyTransformations)
   })
 
   describe("with only default options", () => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -11,7 +11,8 @@ import {
   BOOL_KEYS,
   STRING_KEYS,
   LIST_KEYS,
-  LIST_OR_BOOL_KEYS
+  LIST_OR_BOOL_KEYS,
+  FLOAT_KEYS
 } from "./config/configmap"
 
 /**
@@ -211,6 +212,18 @@ export class Configuration {
         conf[ENV_TO_KEY_MAPPING[k]] = false
       } else if (current) {
         conf[ENV_TO_KEY_MAPPING[k]] = current.split(",")
+      }
+    })
+
+    FLOAT_KEYS.forEach(k => {
+      const current = process.env[k]
+
+      if (current) {
+        const parsed = parseFloat(current)
+
+        if (!isNaN(parsed)) {
+          conf[ENV_TO_KEY_MAPPING[k]] = parsed
+        }
       }
     })
 

--- a/src/config/configmap.ts
+++ b/src/config/configmap.ts
@@ -1,6 +1,6 @@
 import type { AppsignalOptions } from "./options"
 
-export const ENV_TO_KEY_MAPPING: Record<string, keyof AppsignalOptions> = {
+export const ENV_TO_KEY_MAPPING = {
   APPSIGNAL_ACTIVE: "active",
   APPSIGNAL_APP_ENV: "environment",
   APPSIGNAL_APP_NAME: "name",
@@ -39,7 +39,7 @@ export const ENV_TO_KEY_MAPPING: Record<string, keyof AppsignalOptions> = {
   APPSIGNAL_STATSD_PORT: "statsdPort",
   APPSIGNAL_WORKING_DIRECTORY_PATH: "workingDirectoryPath",
   APP_REVISION: "revision"
-}
+} satisfies Record<string, keyof AppsignalOptions>
 
 export const PRIVATE_ENV_MAPPING: Record<string, keyof AppsignalOptions> = {
   _APPSIGNAL_ACTIVE: "active",
@@ -118,7 +118,7 @@ export const JS_TO_RUBY_MAPPING: Record<keyof AppsignalOptions, string> = {
   workingDirectoryPath: "working_directory_path"
 }
 
-export const BOOL_KEYS: string[] = [
+export const BOOL_KEYS: (keyof typeof ENV_TO_KEY_MAPPING)[] = [
   "APPSIGNAL_ACTIVE",
   "APPSIGNAL_ENABLE_HOST_METRICS",
   "APPSIGNAL_ENABLE_OPENTELEMETRY_HTTP",
@@ -132,7 +132,7 @@ export const BOOL_KEYS: string[] = [
   "APPSIGNAL_SEND_SESSION_DATA"
 ]
 
-export const STRING_KEYS: string[] = [
+export const STRING_KEYS: (keyof typeof ENV_TO_KEY_MAPPING)[] = [
   "APPSIGNAL_APP_ENV",
   "APPSIGNAL_APP_NAME",
   "APPSIGNAL_BIND_ADDRESS",
@@ -153,7 +153,7 @@ export const STRING_KEYS: string[] = [
   "APP_REVISION"
 ]
 
-export const LIST_KEYS: string[] = [
+export const LIST_KEYS: (keyof typeof ENV_TO_KEY_MAPPING)[] = [
   "APPSIGNAL_DNS_SERVERS",
   "APPSIGNAL_FILTER_PARAMETERS",
   "APPSIGNAL_FILTER_SESSION_DATA",
@@ -163,8 +163,10 @@ export const LIST_KEYS: string[] = [
   "APPSIGNAL_REQUEST_HEADERS"
 ]
 
-export const LIST_OR_BOOL_KEYS: string[] = [
+export const LIST_OR_BOOL_KEYS: (keyof typeof ENV_TO_KEY_MAPPING)[] = [
   "APPSIGNAL_DISABLE_DEFAULT_INSTRUMENTATIONS"
 ]
 
-export const FLOAT_KEYS: string[] = ["APPSIGNAL_CPU_COUNT"]
+export const FLOAT_KEYS: (keyof typeof ENV_TO_KEY_MAPPING)[] = [
+  "APPSIGNAL_CPU_COUNT"
+]

--- a/src/config/configmap.ts
+++ b/src/config/configmap.ts
@@ -6,6 +6,7 @@ export const ENV_TO_KEY_MAPPING: Record<string, keyof AppsignalOptions> = {
   APPSIGNAL_APP_NAME: "name",
   APPSIGNAL_BIND_ADDRESS: "bindAddress",
   APPSIGNAL_CA_FILE_PATH: "caFilePath",
+  APPSIGNAL_CPU_COUNT: "cpuCount",
   APPSIGNAL_DISABLE_DEFAULT_INSTRUMENTATIONS: "disableDefaultInstrumentations",
   APPSIGNAL_DNS_SERVERS: "dnsServers",
   APPSIGNAL_ENABLE_HOST_METRICS: "enableHostMetrics",
@@ -46,6 +47,7 @@ export const PRIVATE_ENV_MAPPING: Record<string, keyof AppsignalOptions> = {
   _APPSIGNAL_APP_NAME: "name",
   _APPSIGNAL_BIND_ADDRESS: "bindAddress",
   _APPSIGNAL_CA_FILE_PATH: "caFilePath",
+  _APPSIGNAL_CPU_COUNT: "cpuCount",
   _APPSIGNAL_DNS_SERVERS: "dnsServers",
   _APPSIGNAL_ENABLE_HOST_METRICS: "enableHostMetrics",
   _APPSIGNAL_ENABLE_OPENTELEMETRY_HTTP: "enableOpentelemetryHttp",
@@ -80,6 +82,7 @@ export const JS_TO_RUBY_MAPPING: Record<keyof AppsignalOptions, string> = {
   bindAddress: "bind_address",
   pushApiKey: "push_api_key",
   caFilePath: "ca_file_path",
+  cpuCount: "cpu_count",
   disableDefaultInstrumentations: "disable_default_instrumentations",
   dnsServers: "dns_servers",
   enableHostMetrics: "enable_host_metrics",
@@ -163,3 +166,5 @@ export const LIST_KEYS: string[] = [
 export const LIST_OR_BOOL_KEYS: string[] = [
   "APPSIGNAL_DISABLE_DEFAULT_INSTRUMENTATIONS"
 ]
+
+export const FLOAT_KEYS: string[] = ["APPSIGNAL_CPU_COUNT"]

--- a/src/config/options.ts
+++ b/src/config/options.ts
@@ -4,6 +4,7 @@ export type AppsignalOptions = {
   active: boolean
   bindAddress: string
   caFilePath: string
+  cpuCount: number
   disableDefaultInstrumentations: DefaultInstrumentationName[] | boolean
   dnsServers: string[]
   enableHostMetrics: boolean


### PR DESCRIPTION
### [Bump agent to version 0.34.1](https://github.com/appsignal/appsignal-nodejs/commit/d42693a6f12c4234e9d4e0cb6ffe0f8159d799b6)

The agent update and changesets are updated automatically.

### [Remove irrelevant agent changesets](https://github.com/appsignal/appsignal-nodejs/commit/0cfd268700060c2466af1e910488b62d694a2927)

Remove changesets from the agent that are not relevant to the Node.js
integration.

### [Add cpuCount configuration option](https://github.com/appsignal/appsignal-nodejs/commit/b336f81f4b07775b30765a2b86cc58316ec5d4a9)

Implement the `cpuCount` (`APPSIGNAL_CPU_COUNT` environment variable)
configuration option for the AppSignal for Node.js integration.