### PR TITLE
Add `ignoreLogs` configuration option

### DIFF
--- a/.changesets/implement-ignore-logs.md
+++ b/.changesets/implement-ignore-logs.md
@@ -1,0 +1,14 @@
+---
+bump: "patch"
+integrations: "all"
+type: "add"
+---
+
+Implement the `ignoreLogs` configuration option, which can also be configured as the `APPSIGNAL_IGNORE_LOGS` environment variable.
+
+The value of `ignoreLogs` is a list (comma-separated, when using the environment variable) of log line messages that should be ignored. For example, the value `"start"` will cause any message containing the word "start" to be ignored. Any log line message containing a value in `ignoreLogs` will not be reported to AppSignal.
+
+The values can use a small subset of regular expression syntax (specifically, `^`, `$` and `.*`) to narrow or expand the scope of lines that should be matched.
+
+For example, the value `"^start$"` can be used to ignore any message that is _exactly_ the word "start", but not messages that merely contain it, like "Process failed to start". The value `"Task .* succeeded"` can be used to ignore messages about task success regardless of the specific task name.
+

--- a/scripts/extension/support/constants.js
+++ b/scripts/extension/support/constants.js
@@ -3,7 +3,7 @@
 // appsignal-agent repository.
 // Modifications to this file will be overwritten with the next agent release.
 
-const AGENT_VERSION = "0.35.1"
+const AGENT_VERSION = "0.35.2"
 const MIRRORS = [
   "https://appsignal-agent-releases.global.ssl.fastly.net",
   "https://d135dj0rjqvssy.cloudfront.net"
@@ -12,67 +12,67 @@ const MIRRORS = [
 const TRIPLES = {
   "x86_64-darwin": {
     checksum:
-      "f2e1cf5de6d75a06c1068177b09dc84f3d58dfcd48b4a0a729ce9d62ce8588af",
+      "4a01803fae744971e2da08a325acb88a5f79bf44cbde03456652affb91fa0817",
     filename: "appsignal-x86_64-darwin-all-static.tar.gz"
   },
   "universal-darwin": {
     checksum:
-      "f2e1cf5de6d75a06c1068177b09dc84f3d58dfcd48b4a0a729ce9d62ce8588af",
+      "4a01803fae744971e2da08a325acb88a5f79bf44cbde03456652affb91fa0817",
     filename: "appsignal-x86_64-darwin-all-static.tar.gz"
   },
   "aarch64-darwin": {
     checksum:
-      "2d3717377200fb605238625335c133448eaa76d9a9c4ae70308b0cbb8442f18b",
+      "c80fa534a0f34d0056102ed5ec21cb558b714b17dc2a91f62fabdb992acc8a54",
     filename: "appsignal-aarch64-darwin-all-static.tar.gz"
   },
   "arm64-darwin": {
     checksum:
-      "2d3717377200fb605238625335c133448eaa76d9a9c4ae70308b0cbb8442f18b",
+      "c80fa534a0f34d0056102ed5ec21cb558b714b17dc2a91f62fabdb992acc8a54",
     filename: "appsignal-aarch64-darwin-all-static.tar.gz"
   },
   "arm-darwin": {
     checksum:
-      "2d3717377200fb605238625335c133448eaa76d9a9c4ae70308b0cbb8442f18b",
+      "c80fa534a0f34d0056102ed5ec21cb558b714b17dc2a91f62fabdb992acc8a54",
     filename: "appsignal-aarch64-darwin-all-static.tar.gz"
   },
   "aarch64-linux": {
     checksum:
-      "50574d6a519997a34b54db741c8948e3b72c19fcf73e5fda1e4449e21bbcc434",
+      "71236975f40316d67c2b0e797814d52a49df8c5941375c0aed81c6870d82f299",
     filename: "appsignal-aarch64-linux-all-static.tar.gz"
   },
   "i686-linux": {
     checksum:
-      "2af64d99df4834cf5a12b8b2e1f5da7bd11d44f2a3a1ae55a1ac9b8243c685ff",
+      "00ab0d029ede31225b2d134cdfab1e2c75e15e96229ef9e89ac14f51b8329988",
     filename: "appsignal-i686-linux-all-static.tar.gz"
   },
   "x86-linux": {
     checksum:
-      "2af64d99df4834cf5a12b8b2e1f5da7bd11d44f2a3a1ae55a1ac9b8243c685ff",
+      "00ab0d029ede31225b2d134cdfab1e2c75e15e96229ef9e89ac14f51b8329988",
     filename: "appsignal-i686-linux-all-static.tar.gz"
   },
   "x86_64-linux": {
     checksum:
-      "db6f60201d5dcc982c69b1a4c7fe0c8300642aebebb503bbe9810e94e1221724",
+      "2e96245f692f47ee8fd12cca92b620baf79845ec920fb19b38612dd1cb051961",
     filename: "appsignal-x86_64-linux-all-static.tar.gz"
   },
   "x86_64-linux-musl": {
     checksum:
-      "f8381060a355dfaac7db9b38a922cde0baf3ef50808b13223914406c9c838cb8",
+      "a99ebcdf993cd740dc556de9fba6e7ce1c802704c290c4d8b842cb4dc971473a",
     filename: "appsignal-x86_64-linux-musl-all-static.tar.gz"
   },
   "aarch64-linux-musl": {
     checksum:
-      "ab2101aea771f0b714e167c101f6dfee89304973be9270bacb34b7dfe50c73ce",
+      "874542de2899dc7ef6d286f1cb719614877651c6cafc9f5ae73d37d1aa0e61da",
     filename: "appsignal-aarch64-linux-musl-all-static.tar.gz"
   },
   "x86_64-freebsd": {
     checksum:
-      "70291d0d5839d5b0019435e2b4dfa41e4b2d4ddf689a620d5ded88f7513f186a",
+      "f30c529ed4fffe4f0668bcb59881061b22050813d9d10acf5a4bf03f4547a51b",
     filename: "appsignal-x86_64-freebsd-all-static.tar.gz"
   },
   "amd64-freebsd": {
     checksum:
-      "70291d0d5839d5b0019435e2b4dfa41e4b2d4ddf689a620d5ded88f7513f186a",
+      "f30c529ed4fffe4f0668bcb59881061b22050813d9d10acf5a4bf03f4547a51b",
     filename: "appsignal-x86_64-freebsd-all-static.tar.gz"
   }
 }

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -36,6 +36,7 @@ describe("Configuration", () => {
     filterSessionData: [],
     ignoreActions: [],
     ignoreErrors: [],
+    ignoreLogs: [],
     ignoreNamespaces: [],
     initializeOpentelemetrySdk: true,
     log: "file",
@@ -360,6 +361,7 @@ describe("Configuration", () => {
       expect(env("_APPSIGNAL_HTTP_PROXY")).toBeUndefined()
       expect(env("_APPSIGNAL_IGNORE_ACTIONS")).toBeUndefined()
       expect(env("_APPSIGNAL_IGNORE_ERRORS")).toBeUndefined()
+      expect(env("_APPSIGNAL_IGNORE_LOGS")).toBeUndefined()
       expect(env("_APPSIGNAL_IGNORE_NAMESPACES")).toBeUndefined()
       expect(env("_APPSIGNAL_LOG")).toEqual("file")
       expect(env("_APPSIGNAL_LOG_LEVEL")).toBeUndefined()
@@ -412,6 +414,7 @@ describe("Configuration", () => {
           httpProxy: "http://localhost",
           ignoreActions: ["MyAction", "MyOtherAction"],
           ignoreErrors: ["MyError", "MyOtherError"],
+          ignoreLogs: ["^start$", "^Completed 2.* in .*ms$"],
           ignoreNamespaces: ["MyNamespace", "MyOtherNamespace"],
           logLevel: "debug",
           logPath: "/tmp/other",
@@ -445,6 +448,9 @@ describe("Configuration", () => {
           "MyAction,MyOtherAction"
         )
         expect(env("_APPSIGNAL_IGNORE_ERRORS")).toEqual("MyError,MyOtherError")
+        expect(env("_APPSIGNAL_IGNORE_LOGS")).toEqual(
+          "^start$,^Completed 2.* in .*ms$"
+        )
         expect(env("_APPSIGNAL_IGNORE_NAMESPACES")).toEqual(
           "MyNamespace,MyOtherNamespace"
         )

--- a/src/config.ts
+++ b/src/config.ts
@@ -135,6 +135,7 @@ export class Configuration {
       filterSessionData: [],
       ignoreActions: [],
       ignoreErrors: [],
+      ignoreLogs: [],
       ignoreNamespaces: [],
       initializeOpentelemetrySdk: true,
       log: "file",

--- a/src/config/configmap.ts
+++ b/src/config/configmap.ts
@@ -22,6 +22,7 @@ export const ENV_TO_KEY_MAPPING = {
   APPSIGNAL_HTTP_PROXY: "httpProxy",
   APPSIGNAL_IGNORE_ACTIONS: "ignoreActions",
   APPSIGNAL_IGNORE_ERRORS: "ignoreErrors",
+  APPSIGNAL_IGNORE_LOGS: "ignoreLogs",
   APPSIGNAL_IGNORE_NAMESPACES: "ignoreNamespaces",
   APPSIGNAL_INITIALIZE_OPENTELEMETRY_SDK: "initializeOpentelemetrySdk",
   APPSIGNAL_LOG: "log",
@@ -61,6 +62,7 @@ export const PRIVATE_ENV_MAPPING: Record<string, keyof AppsignalOptions> = {
   _APPSIGNAL_HTTP_PROXY: "httpProxy",
   _APPSIGNAL_IGNORE_ACTIONS: "ignoreActions",
   _APPSIGNAL_IGNORE_ERRORS: "ignoreErrors",
+  _APPSIGNAL_IGNORE_LOGS: "ignoreLogs",
   _APPSIGNAL_IGNORE_NAMESPACES: "ignoreNamespaces",
   _APPSIGNAL_LOG: "log",
   _APPSIGNAL_LOG_LEVEL: "logLevel",
@@ -100,6 +102,7 @@ export const JS_TO_RUBY_MAPPING: Record<keyof AppsignalOptions, string> = {
   httpProxy: "http_proxy",
   ignoreActions: "ignore_actions",
   ignoreErrors: "ignore_errors",
+  ignoreLogs: "ignore_logs",
   ignoreNamespaces: "ignore_namespaces",
   initializeOpentelemetrySdk: "initialize_opentelemetry_sdk",
   log: "log",
@@ -159,6 +162,7 @@ export const LIST_KEYS: (keyof typeof ENV_TO_KEY_MAPPING)[] = [
   "APPSIGNAL_FILTER_SESSION_DATA",
   "APPSIGNAL_IGNORE_ACTIONS",
   "APPSIGNAL_IGNORE_ERRORS",
+  "APPSIGNAL_IGNORE_LOGS",
   "APPSIGNAL_IGNORE_NAMESPACES",
   "APPSIGNAL_REQUEST_HEADERS"
 ]

--- a/src/config/options.ts
+++ b/src/config/options.ts
@@ -22,6 +22,7 @@ export type AppsignalOptions = {
   httpProxy: string
   ignoreActions: string[]
   ignoreErrors: string[]
+  ignoreLogs: string[]
   ignoreNamespaces: string[]
   initializeOpentelemetrySdk: boolean
   log: string


### PR DESCRIPTION
Read the `ignoreLogs` config option from `appsignal.cjs`, or the `APPSIGNAL_IGNORE_LOGS` environment variable, and re-export it for the AppSignal agent as the `_APPSIGNAL_IGNORE_LOGS` environment variable.

[skip changeset] because the corresponding changeset will be added (modified slightly) from the [agent PR][agent]

[agent]: appsignal/appsignal-agent#1127