### PR TITLE
Fix MySQL Docker container in Koa test app

### DIFF
--- a/test/koa-mysql/app/src/app.ts
+++ b/test/koa-mysql/app/src/app.ts
@@ -1,7 +1,7 @@
 import Koa from "koa"
 import Router from "@koa/router"
 import bodyParser from "koa-bodyparser"
-import mysql, { Connection } from "mysql"
+import mysql from "mysql"
 import mysql2 from "mysql2"
 
 const mysqlConfig = {
@@ -10,6 +10,68 @@ const mysqlConfig = {
   password: process.env.MYSQL_PASSWORD,
   database: process.env.MYSQL_DATABASE
 }
+
+type MaybeMysqlError = mysql.MysqlError | mysql2.QueryError | null | undefined
+
+interface MysqlConnection {
+  connect(callback: (err: MaybeMysqlError) => void): void
+  query(
+    sql: string,
+    callback: (err: MaybeMysqlError, rows: any, fields: any) => void
+  ): void
+  end(callback: (err: MaybeMysqlError) => void): void
+}
+
+function connectionPromise(mysqlClient: MysqlModule): Promise<MysqlConnection> {
+  return new Promise((resolve, reject) => {
+    const connection = mysqlClient.createConnection(mysqlConfig)
+
+    connection.connect((err: MaybeMysqlError) => {
+      if (err) reject(err)
+      resolve(connection)
+    })
+  })
+}
+
+function dummyQueryPromise(connection: MysqlConnection): Promise<any> {
+  return new Promise((resolve, reject) => {
+    connection.query(
+      "SELECT 1 + 1 AS solution",
+      (err: MaybeMysqlError, rows: any, _fields: any) => {
+        if (err) reject(err)
+        try {
+          resolve(rows[0].solution)
+        } catch (err) {
+          reject(err)
+        }
+      }
+    )
+  })
+}
+
+function endConnectionPromise(connection: MysqlConnection): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    connection.end((err: MaybeMysqlError) => {
+      if (err) reject(err)
+      resolve()
+    })
+  })
+}
+
+async function dummyQuery(mysqlClient: MysqlModule): Promise<any> {
+  const connection = await connectionPromise(mysqlClient)
+  const result = await dummyQueryPromise(connection)
+  await endConnectionPromise(connection)
+
+  return result
+}
+
+interface MysqlModule {
+  createConnection(config: typeof mysqlConfig): MysqlConnection
+}
+
+const mysqlModule: MysqlModule = mysql
+const mysql2Module: MysqlModule = mysql2
 
 const app = new Koa()
 const router = new Router()
@@ -26,31 +88,16 @@ router.get("/error", async (_ctx: any) => {
 })
 
 router.get("/mysql-query", async (ctx: any) => {
-  await dummyQuery(mysql)
+  await dummyQuery(mysqlModule)
 
   ctx.body = "MySQL query received!"
 })
 
 router.get("/mysql2-query", async (ctx: any) => {
-  await dummyQuery(mysql2)
+  await dummyQuery(mysql2Module)
 
   ctx.body = "MySQL2 query received!"
 })
-
-function dummyQuery(mysqlClient: any) {
-  let connection: Connection
-
-  return new Promise((resolve, reject) => {
-    connection = mysqlClient.createConnection(mysqlConfig)
-
-    connection.connect()
-
-    connection.query("SELECT 1 + 1 AS solution", (err, rows, _fields) => {
-      if (err) reject(err)
-      resolve(rows[0].solution)
-    })
-  }).finally(() => connection.end())
-}
 
 app.use(router.routes()).use(router.allowedMethods())
 

--- a/test/koa-mysql/docker-compose.yml
+++ b/test/koa-mysql/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   mysql:
-    image: mysql
+    image: mysql:8.3
     command: --default-authentication-plugin=mysql_native_password
     restart: always
     env_file:


### PR DESCRIPTION
The MySQL database container failed to start. It failed with this error:

> unknown variable 'default-authentication-plugin=mysql_native_password'.

Removing the config seems to work.

I also locked the image to a more specific version so this kind of issue doesn't happen again on unplanned image upgrades.

Locally you might need to prune the local volumes. For me it wouldn't start until I did, complaining about the database needing to be upgraded before it could start.

[skip changeset]