### PR TITLE
Remove stray conflict mark from package-lock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,20 +1,12 @@
 {
   "name": "@appsignal/nodejs",
-<<<<<<< HEAD
-  "version": "3.4.0",
-=======
-  "version": "3.3.2",
->>>>>>> 74754a0 (Add support for amqplib)
+  "version": "3.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@appsignal/nodejs",
-<<<<<<< HEAD
-      "version": "3.4.0",
-=======
-      "version": "3.3.2",
->>>>>>> 74754a0 (Add support for amqplib)
+      "version": "3.4.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
Git conflict marks made it to main preventing the package from building. This commit removes them.

[skip changeset]