### PR TITLE
Only report extension load errors on start

### DIFF
--- a/.changesets/improve-error-reporting-during-initialisation.md
+++ b/.changesets/improve-error-reporting-during-initialisation.md
@@ -1,0 +1,10 @@
+---
+bump: "patch"
+type: "change"
+---
+
+### Improve error reporting during initialisation
+
+Do not report an error with the extension installation when AppSignal is imported -- instead, report it when attempting to initialise AppSignal. Do not report an error with the extension if AppSignal is not configured to be active.
+
+When AppSignal does not start due to its configuration (`active` is set to `false`, or the push API key is missing) report the specific reason why.

--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -27,19 +27,19 @@ describe("Client", () => {
     await client.stop()
   })
 
-  it("starts the client", () => {
+  it("starts the extension when the client is active", () => {
     const startSpy = jest.spyOn(Extension.prototype, "start")
-    client.start()
+    client = new Client({ ...DEFAULT_OPTS, active: true })
     expect(startSpy).toHaveBeenCalled()
   })
 
-  it("stops the client", async () => {
+  it("stops the extension when the client is stopped", async () => {
     const extensionStopSpy = jest.spyOn(Extension.prototype, "stop")
     await client.stop()
     expect(extensionStopSpy).toHaveBeenCalled()
   })
 
-  it("stops the probes when the client is active", async () => {
+  it("starts and stops the probes when the client is active", async () => {
     client = new Client({ ...DEFAULT_OPTS, active: true })
     const probes = client.metrics().probes()
     expect(probes.isRunning).toEqual(true)

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -477,25 +477,30 @@ describe("Configuration", () => {
     })
   })
 
-  describe(".isValid", () => {
-    it("is valid if pushApiKey is present", () => {
-      config = new Configuration({ pushApiKey })
-      expect(config.isValid).toBeTruthy()
+  describe(".validationError", () => {
+    it("is valid if pushApiKey is present and active is not false", () => {
+      config = new Configuration({ pushApiKey: "something", active: true })
+      expect(config.validationError()).toBeFalsy()
     })
 
     it("is invalid if pushApiKey is not present", () => {
-      config = new Configuration({ name })
-      expect(config.isValid).toBeFalsy()
+      config = new Configuration({ active: true })
+      expect(config.validationError()).toEqual("Push API key is not present")
     })
 
     it("is invalid if pushApiKey is an empty string", () => {
-      config = new Configuration({ name, pushApiKey: "" })
-      expect(config.isValid).toBeFalsy()
+      config = new Configuration({ pushApiKey: "", active: true })
+      expect(config.validationError()).toEqual("Push API key is not present")
     })
 
     it("is invalid if pushApiKey is a string with only whitespaces", () => {
-      config = new Configuration({ name, pushApiKey: "  " })
-      expect(config.isValid).toBeFalsy()
+      config = new Configuration({ pushApiKey: "  ", active: true })
+      expect(config.validationError()).toEqual("Push API key is not present")
+    })
+
+    it("is invalid if active is false", () => {
+      config = new Configuration({ pushApiKey: "something", active: false })
+      expect(config.validationError()).toEqual("AppSignal is not active")
     })
   })
 })

--- a/src/__tests__/extension.failure.test.ts
+++ b/src/__tests__/extension.failure.test.ts
@@ -1,28 +1,38 @@
 import fs from "fs"
 import { Extension } from "../extension"
+import { Client } from "../client"
 import {
   reportPath,
   processTarget
 } from "../../scripts/extension/support/helpers"
 
+const CLIENT_OPTIONS = {
+  name: "app",
+  pushApiKey: "yes",
+  active: true
+}
+
 describe("Extension", () => {
   let ext: Extension
+  let client: Client | undefined
 
   beforeEach(() => {
     ext = new Extension()
+    client = undefined
   })
 
   afterEach(() => {
     ext.stop()
+    if (client) client.stop()
   })
 
-  it("logs an error when the module is required", () => {
+  it("logs an error when an active client is initialised", () => {
     const errorSpy = jest.spyOn(console, "error")
 
     jest.resetModules()
-    require("../extension")
+    client = new Client(CLIENT_OPTIONS)
 
-    expect(errorSpy).toHaveBeenLastCalledWith(
+    expect(errorSpy).toHaveBeenCalledWith(
       "[appsignal][ERROR] AppSignal failed to load the extension. Please run the diagnose tool and email us at support@appsignal.com: https://docs.appsignal.com/nodejs/3.x/command-line/diagnose.html\n",
       expect.any(Object)
     )
@@ -56,9 +66,9 @@ describe("Extension", () => {
       const arch = process.arch
 
       jest.resetModules()
-      require("../extension")
+      client = new Client(CLIENT_OPTIONS)
 
-      expect(errorSpy).toHaveBeenLastCalledWith(
+      expect(errorSpy).toHaveBeenCalledWith(
         `[appsignal][ERROR] The AppSignal extension was installed for architecture 'dummyArch-dummyTarget', but the current architecture is '${arch}-${target}'. Please reinstall the AppSignal package on the host the app is started.`
       )
     })
@@ -82,13 +92,13 @@ describe("Extension", () => {
       const errorSpy = jest.spyOn(console, "error")
 
       jest.resetModules()
-      require("../extension")
+      client = new Client(CLIENT_OPTIONS)
 
       expect(errorSpy).toHaveBeenCalledWith(
         "[appsignal][ERROR] Unable to fetch install report:",
         expect.any(Object)
       )
-      expect(errorSpy).toHaveBeenLastCalledWith(
+      expect(errorSpy).toHaveBeenCalledWith(
         "[appsignal][ERROR] AppSignal failed to load the extension. Please run the diagnose tool and email us at support@appsignal.com: https://docs.appsignal.com/nodejs/3.x/command-line/diagnose.html\n",
         expect.any(Object)
       )

--- a/src/config.ts
+++ b/src/config.ts
@@ -43,10 +43,19 @@ export class Configuration {
   }
 
   /**
-   * Returns `true` if the current configuration is valid.
+   * Returns a (truthy) validation error message string if the current
+   * configuration is invalid, or `false` if the configuration is valid.
    */
-  public get isValid(): boolean {
-    return (this.data.pushApiKey || "").trim() !== ""
+  public validationError(): string | false {
+    if (this.data.active === false) {
+      return "AppSignal is not active"
+    }
+
+    if ((this.data.pushApiKey || "").trim() === "") {
+      return "Push API key is not present"
+    }
+
+    return false
   }
 
   public get logFilePath(): string | undefined {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -86,4 +86,8 @@ export class Extension {
   public runningInContainer(): boolean {
     return extension.runningInContainer()
   }
+
+  public logLoadingErrors() {
+    extension.logLoadingErrors()
+  }
 }

--- a/src/extension_wrapper.ts
+++ b/src/extension_wrapper.ts
@@ -27,25 +27,6 @@ try {
   mod = require("../build/Release/extension.node") as ExtensionWrapper
   mod.isLoaded = true
 } catch (error) {
-  const [installArch, installTarget] = fetchInstalledArch()
-  const arch = process.arch
-  const target = processTarget()
-
-  if (
-    installArch &&
-    installTarget &&
-    (arch !== installArch || target !== installTarget)
-  ) {
-    console.error(
-      `[appsignal][ERROR] The AppSignal extension was installed for architecture '${installArch}-${installTarget}', but the current architecture is '${arch}-${target}'. Please reinstall the AppSignal package on the host the app is started.`
-    )
-  } else {
-    console.error(
-      "[appsignal][ERROR] AppSignal failed to load the extension. Please run the diagnose tool and email us at support@appsignal.com: https://docs.appsignal.com/nodejs/3.x/command-line/diagnose.html\n",
-      error
-    )
-  }
-
   mod = {
     isLoaded: false,
     extension: {
@@ -66,6 +47,26 @@ try {
       },
       log() {
         return
+      },
+      logLoadingErrors() {
+        const [installArch, installTarget] = fetchInstalledArch()
+        const arch = process.arch
+        const target = processTarget()
+
+        if (
+          installArch &&
+          installTarget &&
+          (arch !== installArch || target !== installTarget)
+        ) {
+          console.error(
+            `[appsignal][ERROR] The AppSignal extension was installed for architecture '${installArch}-${installTarget}', but the current architecture is '${arch}-${target}'. Please reinstall the AppSignal package on the host the app is started.`
+          )
+        } else {
+          console.error(
+            "[appsignal][ERROR] AppSignal failed to load the extension. Please run the diagnose tool and email us at support@appsignal.com: https://docs.appsignal.com/nodejs/3.x/command-line/diagnose.html\n",
+            error
+          )
+        }
       }
     }
   } as ExtensionWrapper


### PR DESCRIPTION
Before this change, extension load errors would be reported whenever
`@appsignal/nodejs` or the `client.ts` file was imported. Now they
will only be reported whenever `Client` fails to initialise.

This fixes an issue where the extension load errors would be reported
when running `npm install` in the `appsignal-nodejs` folder.

Rearrange the way that the client is initialised. Remove the
`client.start()` method, as starting is done automatically during
initialisation. Use early returns to clearly distinguish the client
initialisation failure scenarios. Emit distinct error messages for
different configuration-related failures.

Change the `Client.isActive` method to reflect whether the client
was actually initialised, rather than whether several factors in
the configuration should mean that the client was initialised.

This is an improvement to https://github.com/appsignal/appsignal-nodejs/issues/960, as AppSignal will no longer show an error about the extension not loading when `active` is set to `false`. It would still be nice to have a dedicated, non-scary Windows error.