### PR TITLE
Add BullMQ instrumentation

### DIFF
--- a/.changesets/add-bullmq-support.md
+++ b/.changesets/add-bullmq-support.md
@@ -1,0 +1,11 @@
+---
+bump: patch
+type: add
+integrations: nodejs
+---
+
+Add BullMQ support through the `@appsignal/opentelemetry-instrumentation-bullmq` instrumentation. AppSignal will automatically instrument the use of BullMQ in your application.
+
+Calls to functions that enqueue jobs, such as `Queue.add` and others, will be instrumented as an event in the event timeline for the performance sample in which it takes place.
+
+When a BullMQ `Worker` processes a job, this will result in a performance sample in the `background` namespace.

--- a/.changesets/add-opentelemetry-messaging-support.md
+++ b/.changesets/add-opentelemetry-messaging-support.md
@@ -1,0 +1,9 @@
+---
+bump: patch
+type: add
+integrations:
+- nodejs
+- python
+---
+
+Add basic OpenTelemetry messaging support. This adds support for any OpenTelemetry instrumentation that complies with the OpenTelemetry Semantic Conventions specification for messaging.

--- a/.changesets/fix-redis-events-misidentified-as-http-events.md
+++ b/.changesets/fix-redis-events-misidentified-as-http-events.md
@@ -1,0 +1,9 @@
+---
+bump: patch
+type: fix
+integrations:
+- nodejs
+- python
+---
+
+Fix an issue where Redis events are misidentified as HTTP events.

--- a/.changesets/rename-hostname-tag-to-request_host.md
+++ b/.changesets/rename-hostname-tag-to-request_host.md
@@ -1,0 +1,12 @@
+---
+bump: patch
+type: change
+integrations:
+- nodejs
+- python
+---
+
+Rename the `hostname` tag, which contains the host of the URI that an HTTP request was made against, to `request_host`.
+
+This fixes an issue where the `hostname` tag would later be internally overriden to the hostname of the machine processing the request, but notifications would still be emitted containing the previous `hostname` value.
+

--- a/.changesets/use-global-message-extractor-for-amqplib.md
+++ b/.changesets/use-global-message-extractor-for-amqplib.md
@@ -1,0 +1,8 @@
+---
+bump: patch
+type: change
+integrations: nodejs
+---
+
+Improve the amqlib instrumentation by parsing it like other messaging spans following the OpenTelemetry messaging spec.
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
+        "@appsignal/opentelemetry-instrumentation-bullmq": ">= 0.7.0 < 0.8.0",
         "@opentelemetry/api": ">= 1.7.0 < 1.8.0",
         "@opentelemetry/core": ">= 1.21.0 < 1.22.0",
         "@opentelemetry/exporter-metrics-otlp-proto": ">= 0.48.0 < 0.49",
@@ -79,6 +80,57 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@appsignal/opentelemetry-instrumentation-bullmq": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@appsignal/opentelemetry-instrumentation-bullmq/-/opentelemetry-instrumentation-bullmq-0.7.0.tgz",
+      "integrity": "sha512-lHdn/XHszXdLnkjn/05R4zi3YS9R2rHzidC+N49Kg5vkW2m6iV/eOOJ8ypWS1yDiI1Vgug4YxFKcigx/HoY23w==",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0",
+        "@opentelemetry/instrumentation": "^0.34.0",
+        "@opentelemetry/semantic-conventions": "^1.25.0",
+        "flat": "^5.0.2"
+      },
+      "peerDependencies": {
+        "bullmq": "^2 || ^3 || ^4 || ^5"
+      }
+    },
+    "node_modules/@appsignal/opentelemetry-instrumentation-bullmq/node_modules/@opentelemetry/instrumentation": {
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.34.0.tgz",
+      "integrity": "sha512-VET/bOh4StOQV4vf1sAvn2JD67BhW2vPZ/ynl2gHXyafme2yB8Hs9+tr1TLzFwNGo7jwMFviFQkZjCYxMuK0AA==",
+      "dependencies": {
+        "require-in-the-middle": "^5.0.3",
+        "semver": "^7.3.2",
+        "shimmer": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@appsignal/opentelemetry-instrumentation-bullmq/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.25.0.tgz",
+      "integrity": "sha512-M+kkXKRAIAiAP6qYyesfrC5TOmDpDVtsxuGfPcqd9B/iBrac+E14jYwrgm0yZBUIbIP2OnqC3j+UgkXLm1vxUQ==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@appsignal/opentelemetry-instrumentation-bullmq/node_modules/require-in-the-middle": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-5.2.0.tgz",
+      "integrity": "sha512-efCx3b+0Z69/LGJmm9Yvi4cqEdxnoGnxYxGxBghkkTTFeXRtTCmmhO0AnAfHz59k957uTSuy8WaHqOs8wbYUWg==",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "module-details-from-path": "^1.0.3",
+        "resolve": "^1.22.1"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/@aws-crypto/ie11-detection": {
@@ -1496,6 +1548,12 @@
       "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
       "dev": true
     },
+    "node_modules/@ioredis/commands": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.2.0.tgz",
+      "integrity": "sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg==",
+      "peer": true
+    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -1995,6 +2053,84 @@
       "dependencies": {
         "sparse-bitfield": "^3.0.3"
       }
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.3.tgz",
+      "integrity": "sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-x64": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.3.tgz",
+      "integrity": "sha512-mdzd3AVzYKuUmiWOQ8GNhl64/IoFGol569zNRdkLReh6LRLHOXxU4U8eq0JwaD8iFHdVGqSy4IjFL4reoWCDFw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.3.tgz",
+      "integrity": "sha512-fg0uy/dG/nZEXfYilKoRe7yALaNmHoYeIoJuJ7KJ+YyU2bvY8vPv27f7UKhGRpY6euFYqEVhxCFZgAUNQBM3nw==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm64": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.3.tgz",
+      "integrity": "sha512-YxQL+ax0XqBJDZiKimS2XQaf+2wDGVa1enVRGzEvLLVFeqa5kx2bWbtcSXgsxjQB7nRqqIGFIcLteF/sHeVtQg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-x64": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.3.tgz",
+      "integrity": "sha512-cvwNfbP07pKUfq1uH+S6KJ7dT9K8WOE4ZiAcsrSes+UY55E/0jLYc+vq+DO7jlmqRb5zAggExKm0H7O/CBaesg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-win32-x64": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.3.tgz",
+      "integrity": "sha512-x0fWaQtYp4E6sktbsdAqnehxDgEc/VwM7uLsRCYWaiGu0ykYdZPiS8zCWdnjHwyiumousxfBm4SO31eXqwEZhQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -5013,6 +5149,21 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true
     },
+    "node_modules/bullmq": {
+      "version": "5.7.15",
+      "resolved": "https://registry.npmjs.org/bullmq/-/bullmq-5.7.15.tgz",
+      "integrity": "sha512-XR5sTA8BPUY67sS37sMKGCDvSLaVpMq7aaQG8FGSKOUnPoJMRf17n1TibVWP3+yK0xKLdK5Y7PY9D874Fpeqpg==",
+      "peer": true,
+      "dependencies": {
+        "cron-parser": "^4.6.0",
+        "ioredis": "^5.4.1",
+        "msgpackr": "^1.10.1",
+        "node-abort-controller": "^3.1.1",
+        "semver": "^7.5.4",
+        "tslib": "^2.0.0",
+        "uuid": "^9.0.0"
+      }
+    },
     "node_modules/cacache": {
       "version": "18.0.3",
       "resolved": "https://registry.npmjs.org/cacache/-/cacache-18.0.3.tgz",
@@ -5290,6 +5441,15 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -5408,6 +5568,18 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/cron-parser": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/cron-parser/-/cron-parser-4.9.0.tgz",
+      "integrity": "sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q==",
+      "peer": true,
+      "dependencies": {
+        "luxon": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/cross-spawn": {
@@ -5557,9 +5729,18 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
       "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
-      "dev": true,
       "engines": {
         "node": ">=0.10"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
+      "integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/detect-newline": {
@@ -6261,6 +6442,14 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/flat": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+      "bin": {
+        "flat": "cli.js"
+      }
+    },
     "node_modules/flat-cache": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
@@ -6851,6 +7040,30 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/ioredis": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.4.1.tgz",
+      "integrity": "sha512-2YZsvl7jopIa1gaePkeMtd9rAcSjOOjPtpcLlOeusyO+XH2SK5ZcT+UCrElPP+WVIInh2TzeI4XW9ENaSLVVHA==",
+      "peer": true,
+      "dependencies": {
+        "@ioredis/commands": "^1.1.1",
+        "cluster-key-slot": "^1.1.0",
+        "debug": "^4.3.4",
+        "denque": "^2.1.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.isarguments": "^3.1.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0",
+        "standard-as-callback": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ioredis"
       }
     },
     "node_modules/ip-address": {
@@ -8197,6 +8410,18 @@
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA=="
     },
+    "node_modules/lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
+      "peer": true
+    },
+    "node_modules/lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==",
+      "peer": true
+    },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -8309,6 +8534,15 @@
       "dev": true,
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/luxon": {
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.4.4.tgz",
+      "integrity": "sha512-zobTr7akeGHnv7eBOXcRgMeCP6+uyYsczwmeRCauvpvaAltgNyTbLH/+VaEAPUeWBT+1GuNmz4wC/6jtQzbbVA==",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/make-dir": {
@@ -8678,6 +8912,37 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
+    "node_modules/msgpackr": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.10.2.tgz",
+      "integrity": "sha512-L60rsPynBvNE+8BWipKKZ9jHcSGbtyJYIwjRq0VrIvQ08cRjntGXJYW/tmciZ2IHWIY8WEW32Qa2xbh5+SKBZA==",
+      "peer": true,
+      "optionalDependencies": {
+        "msgpackr-extract": "^3.0.2"
+      }
+    },
+    "node_modules/msgpackr-extract": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-3.0.3.tgz",
+      "integrity": "sha512-P0efT1C9jIdVRefqjzOQ9Xml57zpOXnIuS+csaB4MdZbTdmGDLo8XhzBG1N7aO11gKDDkJvBLULeFTo46wwreA==",
+      "hasInstallScript": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "node-gyp-build-optional-packages": "5.2.2"
+      },
+      "bin": {
+        "download-msgpackr-prebuilds": "bin/download-prebuilds.js"
+      },
+      "optionalDependencies": {
+        "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.3"
+      }
+    },
     "node_modules/mysql2": {
       "version": "3.9.8",
       "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.9.8.tgz",
@@ -8767,6 +9032,12 @@
         "node": ">= 10.13"
       }
     },
+    "node_modules/node-abort-controller": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-3.1.1.tgz",
+      "integrity": "sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==",
+      "peer": true
+    },
     "node_modules/node-addon-api": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
@@ -8793,6 +9064,21 @@
       },
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/node-gyp-build-optional-packages": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.2.2.tgz",
+      "integrity": "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "detect-libc": "^2.0.1"
+      },
+      "bin": {
+        "node-gyp-build-optional-packages": "bin.js",
+        "node-gyp-build-optional-packages-optional": "optional.js",
+        "node-gyp-build-optional-packages-test": "build-test.js"
       }
     },
     "node_modules/node-gyp/node_modules/brace-expansion": {
@@ -9735,6 +10021,27 @@
         "node": ">= 6"
       }
     },
+    "node_modules/redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
+      "peer": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+      "peer": true,
+      "dependencies": {
+        "redis-errors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.2.tgz",
@@ -10311,6 +10618,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/standard-as-callback": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
+      "peer": true
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
@@ -10961,12 +11274,10 @@
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
       "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "dev": true,
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
-      "optional": true,
       "bin": {
         "uuid": "dist/bin/uuid"
       }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "appsignal-diagnose": "./bin/diagnose"
   },
   "dependencies": {
+    "@appsignal/opentelemetry-instrumentation-bullmq": ">= 0.7.0 < 0.8.0",
     "@opentelemetry/api": ">= 1.7.0 < 1.8.0",
     "@opentelemetry/core": ">= 1.21.0 < 1.22.0",
     "@opentelemetry/exporter-metrics-otlp-proto": ">= 0.48.0 < 0.49",

--- a/scripts/extension/support/constants.js
+++ b/scripts/extension/support/constants.js
@@ -3,7 +3,7 @@
 // appsignal-agent repository.
 // Modifications to this file will be overwritten with the next agent release.
 
-const AGENT_VERSION = "0.35.10"
+const AGENT_VERSION = "0.35.12"
 const MIRRORS = [
   "https://appsignal-agent-releases.global.ssl.fastly.net",
   "https://d135dj0rjqvssy.cloudfront.net"
@@ -12,67 +12,67 @@ const MIRRORS = [
 const TRIPLES = {
   "x86_64-darwin": {
     checksum:
-      "8bdf6b162e03c5f63bc06f2d49ae789bb14e111636524ed78262bd543587a971",
+      "61210c40be70e0616a356d06040961b096e2d47332021a52f3779912a9fe0e4c",
     filename: "appsignal-x86_64-darwin-all-static.tar.gz"
   },
   "universal-darwin": {
     checksum:
-      "8bdf6b162e03c5f63bc06f2d49ae789bb14e111636524ed78262bd543587a971",
+      "61210c40be70e0616a356d06040961b096e2d47332021a52f3779912a9fe0e4c",
     filename: "appsignal-x86_64-darwin-all-static.tar.gz"
   },
   "aarch64-darwin": {
     checksum:
-      "c6453bb54a68cdb0b42864747b328e60a14b5b99921f11757de03db42041bed2",
+      "9b97c42561450f9af9ae63816d32b8db69be6f2745226f63d6eada4369c68a20",
     filename: "appsignal-aarch64-darwin-all-static.tar.gz"
   },
   "arm64-darwin": {
     checksum:
-      "c6453bb54a68cdb0b42864747b328e60a14b5b99921f11757de03db42041bed2",
+      "9b97c42561450f9af9ae63816d32b8db69be6f2745226f63d6eada4369c68a20",
     filename: "appsignal-aarch64-darwin-all-static.tar.gz"
   },
   "arm-darwin": {
     checksum:
-      "c6453bb54a68cdb0b42864747b328e60a14b5b99921f11757de03db42041bed2",
+      "9b97c42561450f9af9ae63816d32b8db69be6f2745226f63d6eada4369c68a20",
     filename: "appsignal-aarch64-darwin-all-static.tar.gz"
   },
   "aarch64-linux": {
     checksum:
-      "4e90ec4bce1e632316a26fdaf03ccd8773bf7a9615eb7a1739c8c53f3fa5221a",
+      "358db07cfa85d6bd048bd2bb05fc9607d4fe0d4396fd023d658e945e4a675fba",
     filename: "appsignal-aarch64-linux-all-static.tar.gz"
   },
   "i686-linux": {
     checksum:
-      "f5bcb9f732cb5af53a5de2f2c916156bdd6677c0e563ddafd23f09576440dfdc",
+      "315bf1fc5d9c97b6f26e61f5e39919e0ba425b1d96ea6243cdb2f650487c407e",
     filename: "appsignal-i686-linux-all-static.tar.gz"
   },
   "x86-linux": {
     checksum:
-      "f5bcb9f732cb5af53a5de2f2c916156bdd6677c0e563ddafd23f09576440dfdc",
+      "315bf1fc5d9c97b6f26e61f5e39919e0ba425b1d96ea6243cdb2f650487c407e",
     filename: "appsignal-i686-linux-all-static.tar.gz"
   },
   "x86_64-linux": {
     checksum:
-      "6faa14f508f7c27b65d912eedb31f7808e1e2fb1dcaa077db2426c321e1f5c65",
+      "3fe42df2a52706c23f967b8421ac816fa37a38998bd24b1d6aafd59a324b23ff",
     filename: "appsignal-x86_64-linux-all-static.tar.gz"
   },
   "x86_64-linux-musl": {
     checksum:
-      "8f54b734e56eae7867b5474c7ad4d79e049fd4063202e1b80989795708354e49",
+      "1fe0ed0c0ca51eccd4c2ec3bb94bb1834bae19bc2c185b67c3f940f704abe9fc",
     filename: "appsignal-x86_64-linux-musl-all-static.tar.gz"
   },
   "aarch64-linux-musl": {
     checksum:
-      "b3d247d632e3465b2233dd8bb2e977f248f14286ca870e9bd7b855b550ba1c00",
+      "5027782008872f8091608cc5531a6dd90f0652e9ebb0404f7e86eb73f0807ba0",
     filename: "appsignal-aarch64-linux-musl-all-static.tar.gz"
   },
   "x86_64-freebsd": {
     checksum:
-      "1cce550eac963e2edf405e551a613ffd15ae69e4b817b6155b8a5783a9fa9b7f",
+      "1337268caaddd66bb170298968d50d76cc66f17e808c46a677ba00d1b78eb317",
     filename: "appsignal-x86_64-freebsd-all-static.tar.gz"
   },
   "amd64-freebsd": {
     checksum:
-      "1cce550eac963e2edf405e551a613ffd15ae69e4b817b6155b8a5783a9fa9b7f",
+      "1337268caaddd66bb170298968d50d76cc66f17e808c46a677ba00d1b78eb317",
     filename: "appsignal-x86_64-freebsd-all-static.tar.gz"
   }
 }

--- a/scripts/extension/support/constants.js
+++ b/scripts/extension/support/constants.js
@@ -3,7 +3,7 @@
 // appsignal-agent repository.
 // Modifications to this file will be overwritten with the next agent release.
 
-const AGENT_VERSION = "0.35.12"
+const AGENT_VERSION = "0.35.16"
 const MIRRORS = [
   "https://appsignal-agent-releases.global.ssl.fastly.net",
   "https://d135dj0rjqvssy.cloudfront.net"
@@ -12,67 +12,67 @@ const MIRRORS = [
 const TRIPLES = {
   "x86_64-darwin": {
     checksum:
-      "61210c40be70e0616a356d06040961b096e2d47332021a52f3779912a9fe0e4c",
+      "730635d12cd05bfb06f94de576f56544446d12adbe1966779c2fe6c7ea3ed3e8",
     filename: "appsignal-x86_64-darwin-all-static.tar.gz"
   },
   "universal-darwin": {
     checksum:
-      "61210c40be70e0616a356d06040961b096e2d47332021a52f3779912a9fe0e4c",
+      "730635d12cd05bfb06f94de576f56544446d12adbe1966779c2fe6c7ea3ed3e8",
     filename: "appsignal-x86_64-darwin-all-static.tar.gz"
   },
   "aarch64-darwin": {
     checksum:
-      "9b97c42561450f9af9ae63816d32b8db69be6f2745226f63d6eada4369c68a20",
+      "172ad3396a9857fff0984b9ddb082e582a6af5bcdfa2c1a59784c9de0ed78da6",
     filename: "appsignal-aarch64-darwin-all-static.tar.gz"
   },
   "arm64-darwin": {
     checksum:
-      "9b97c42561450f9af9ae63816d32b8db69be6f2745226f63d6eada4369c68a20",
+      "172ad3396a9857fff0984b9ddb082e582a6af5bcdfa2c1a59784c9de0ed78da6",
     filename: "appsignal-aarch64-darwin-all-static.tar.gz"
   },
   "arm-darwin": {
     checksum:
-      "9b97c42561450f9af9ae63816d32b8db69be6f2745226f63d6eada4369c68a20",
+      "172ad3396a9857fff0984b9ddb082e582a6af5bcdfa2c1a59784c9de0ed78da6",
     filename: "appsignal-aarch64-darwin-all-static.tar.gz"
   },
   "aarch64-linux": {
     checksum:
-      "358db07cfa85d6bd048bd2bb05fc9607d4fe0d4396fd023d658e945e4a675fba",
+      "8961bbf100d1e4c81bec1776552d7bb86740eaa48d59c3c8ad0c529a73c0d67a",
     filename: "appsignal-aarch64-linux-all-static.tar.gz"
   },
   "i686-linux": {
     checksum:
-      "315bf1fc5d9c97b6f26e61f5e39919e0ba425b1d96ea6243cdb2f650487c407e",
+      "12be94f908a3f3156c729cf5bd15947116c957826c21fcd811643c1e5bb0e869",
     filename: "appsignal-i686-linux-all-static.tar.gz"
   },
   "x86-linux": {
     checksum:
-      "315bf1fc5d9c97b6f26e61f5e39919e0ba425b1d96ea6243cdb2f650487c407e",
+      "12be94f908a3f3156c729cf5bd15947116c957826c21fcd811643c1e5bb0e869",
     filename: "appsignal-i686-linux-all-static.tar.gz"
   },
   "x86_64-linux": {
     checksum:
-      "3fe42df2a52706c23f967b8421ac816fa37a38998bd24b1d6aafd59a324b23ff",
+      "4b2324dff70ab29b76311511a7b4c763f002e359bd306fd528ade347cded922f",
     filename: "appsignal-x86_64-linux-all-static.tar.gz"
   },
   "x86_64-linux-musl": {
     checksum:
-      "1fe0ed0c0ca51eccd4c2ec3bb94bb1834bae19bc2c185b67c3f940f704abe9fc",
+      "a285df98244e4c478b68c478f211ea8f886653bd84f65cef1c67af0887e60747",
     filename: "appsignal-x86_64-linux-musl-all-static.tar.gz"
   },
   "aarch64-linux-musl": {
     checksum:
-      "5027782008872f8091608cc5531a6dd90f0652e9ebb0404f7e86eb73f0807ba0",
+      "c171f6c45860b7ccc7db9d2a620787d3cf904be42a35b158dc527b4d0087473c",
     filename: "appsignal-aarch64-linux-musl-all-static.tar.gz"
   },
   "x86_64-freebsd": {
     checksum:
-      "1337268caaddd66bb170298968d50d76cc66f17e808c46a677ba00d1b78eb317",
+      "7045790a8554491c85c42d3f29ab6b2276028883f9b95688c3c9d5f0cfb597d3",
     filename: "appsignal-x86_64-freebsd-all-static.tar.gz"
   },
   "amd64-freebsd": {
     checksum:
-      "1337268caaddd66bb170298968d50d76cc66f17e808c46a677ba00d1b78eb317",
+      "7045790a8554491c85c42d3f29ab6b2276028883f9b95688c3c9d5f0cfb597d3",
     filename: "appsignal-x86_64-freebsd-all-static.tar.gz"
   }
 }

--- a/src/client.ts
+++ b/src/client.ts
@@ -15,6 +15,7 @@ import { OTLPMetricExporter } from "@opentelemetry/exporter-metrics-otlp-proto"
 
 import type { Instrumentation } from "@opentelemetry/instrumentation"
 import { AmqplibInstrumentation } from "@opentelemetry/instrumentation-amqplib"
+import { BullMQInstrumentation } from "@appsignal/opentelemetry-instrumentation-bullmq"
 import {
   ExpressInstrumentation,
   ExpressLayerType
@@ -48,6 +49,7 @@ import { SpanProcessor, TestModeSpanProcessor } from "./span_processor"
 import { Heartbeat } from "./heartbeat"
 
 const DefaultInstrumentations = {
+  "@appsignal/opentelemetry-instrumentation-bullmq": BullMQInstrumentation,
   "@opentelemetry/instrumentation-amqplib": AmqplibInstrumentation,
   "@opentelemetry/instrumentation-express": ExpressInstrumentation,
   "@opentelemetry/instrumentation-fastify": FastifyInstrumentation,
@@ -279,6 +281,11 @@ export class Client {
     const requestHeaders = this.config.data.requestHeaders
 
     return {
+      "@appsignal/opentelemetry-instrumentation-bullmq": {
+        emitCreateSpansForBulk: false,
+        emitCreateSpansForFlow: true,
+        requireParentSpanForPublish: true
+      },
       "@opentelemetry/instrumentation-express": {
         requestHook: function (_span, info) {
           if (info.layerType === ExpressLayerType.REQUEST_HANDLER) {


### PR DESCRIPTION
Add the `@appsignal/opentelemetry-bullmq-instrumentation` as a default
instrumentation for the integration.

### To do / see also

- [x] Implement extractor
  - [x] Base: https://github.com/appsignal/appsignal-agent/pull/1171
  - [x] Improvements: https://github.com/appsignal/appsignal-agent/pull/1172
- [x] Add test setup: https://github.com/appsignal/test-setups/pull/211