### PR TITLE
Pass timestamp on OpenTelemetry span close

### DIFF
--- a/.changesets/fix-incorrect-span-durations.md
+++ b/.changesets/fix-incorrect-span-durations.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: fix
+---
+
+Fix an issue where a later span close time than accurate, and therefore a longer span duration, is reported to AppSignal under certain circumstances.

--- a/ext/appsignal_extension.cpp
+++ b/ext/appsignal_extension.cpp
@@ -358,6 +358,23 @@ Napi::Value CloseSpan(const Napi::CallbackInfo &info) {
   return env.Null();
 }
 
+Napi::Value CloseSpanWithTimestamp(const Napi::CallbackInfo &info) {
+  Napi::Env env = info.Env();
+
+  Napi::External<appsignal_span_t> span =
+      info[0].As<Napi::External<appsignal_span_t>>();
+
+  Napi::Number endTimeSec = info[1].As<Napi::Number>();
+  Napi::Number endTimeNsec = info[2].As<Napi::Number>();
+
+  appsignal_close_span_with_timestamp(span.Data(),
+    endTimeSec.Int64Value(),
+    endTimeNsec.Int32Value()
+  );
+
+  return env.Null();
+}
+
 // Metrics
 
 Napi::Value SetGauge(const Napi::CallbackInfo &info) {
@@ -494,6 +511,8 @@ Napi::Object CreateSpanObject(Napi::Env env, Napi::Object exports) {
 
   span.Set(Napi::String::New(env, "closeSpan"),
            Napi::Function::New(env, CloseSpan));
+  span.Set(Napi::String::New(env, "closeSpanWithTimestamp"),
+           Napi::Function::New(env, CloseSpanWithTimestamp));
   span.Set(Napi::String::New(env, "addSpanError"),
            Napi::Function::New(env, AddSpanError));
   span.Set(Napi::String::New(env, "spanToJSON"),

--- a/src/span.ts
+++ b/src/span.ts
@@ -26,8 +26,12 @@ export class Span {
     this.#ref = ref
   }
 
-  public close(): this {
-    span.closeSpan(this.#ref)
+  public close({ timestamp }: { timestamp?: [number, number] } = {}): this {
+    if (timestamp !== undefined) {
+      span.closeSpanWithTimestamp(this.#ref, timestamp[0], timestamp[1])
+    } else {
+      span.closeSpan(this.#ref)
+    }
     return this
   }
 

--- a/src/span_processor.ts
+++ b/src/span_processor.ts
@@ -60,7 +60,7 @@ export class SpanProcessor implements OpenTelemetrySpanProcessor {
       }
     })
 
-    opentelemetrySpan.close()
+    opentelemetrySpan.close({ timestamp: [span.endTime[0], span.endTime[1]] })
   }
 
   shutdown(): Promise<void> {


### PR DESCRIPTION
When the SpanProcessor closes a span, before this commit, it would call `span.close()`, which would call the `appsignal_close_span` function in the extension, which would override the end time passed as an argument when calling `createOpenTelemetrySpan`.

To fix this, pass the end time provided by OpenTelemetry _again_ to `span.close()` when closing the span, re-wiring it so that, if a timestamp is passed, it calls `appsignal_close_span_with_timestamp` instead. This function already existed in the extension, but a NAPI bridge for it needed to be created.