### PR TITLE
Do not pass timestamp on OpenTelemetry span close

### DIFF
--- a/.changesets/fix-different-spans-being-shown-with-the-same-body.md
+++ b/.changesets/fix-different-spans-being-shown-with-the-same-body.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: fix
+---
+
+Fix different spans of the same category incorrectly being reported with the same body.

--- a/ext/appsignal_extension.cpp
+++ b/ext/appsignal_extension.cpp
@@ -358,23 +358,6 @@ Napi::Value CloseSpan(const Napi::CallbackInfo &info) {
   return env.Null();
 }
 
-Napi::Value CloseSpanWithTimestamp(const Napi::CallbackInfo &info) {
-  Napi::Env env = info.Env();
-
-  Napi::External<appsignal_span_t> span =
-      info[0].As<Napi::External<appsignal_span_t>>();
-
-  Napi::Number endTimeSec = info[1].As<Napi::Number>();
-  Napi::Number endTimeNsec = info[2].As<Napi::Number>();
-
-  appsignal_close_span_with_timestamp(span.Data(),
-    endTimeSec.Int64Value(),
-    endTimeNsec.Int32Value()
-  );
-
-  return env.Null();
-}
-
 // Metrics
 
 Napi::Value SetGauge(const Napi::CallbackInfo &info) {
@@ -511,8 +494,6 @@ Napi::Object CreateSpanObject(Napi::Env env, Napi::Object exports) {
 
   span.Set(Napi::String::New(env, "closeSpan"),
            Napi::Function::New(env, CloseSpan));
-  span.Set(Napi::String::New(env, "closeSpanWithTimestamp"),
-           Napi::Function::New(env, CloseSpanWithTimestamp));
   span.Set(Napi::String::New(env, "addSpanError"),
            Napi::Function::New(env, AddSpanError));
   span.Set(Napi::String::New(env, "spanToJSON"),

--- a/src/span.ts
+++ b/src/span.ts
@@ -26,12 +26,8 @@ export class Span {
     this.#ref = ref
   }
 
-  public close({ timestamp }: { timestamp?: [number, number] } = {}): this {
-    if (timestamp !== undefined) {
-      span.closeSpanWithTimestamp(this.#ref, timestamp[0], timestamp[1])
-    } else {
-      span.closeSpan(this.#ref)
-    }
+  public close(): this {
+    span.closeSpan(this.#ref)
     return this
   }
 

--- a/src/span_processor.ts
+++ b/src/span_processor.ts
@@ -60,7 +60,7 @@ export class SpanProcessor implements OpenTelemetrySpanProcessor {
       }
     })
 
-    opentelemetrySpan.close({ timestamp: [span.endTime[0], span.endTime[1]] })
+    opentelemetrySpan.close()
   }
 
   shutdown(): Promise<void> {


### PR DESCRIPTION
This reverts commit 0d60a9bc05a4dd792ea69485b30219d1dfef0655 (#1064)

This did not fix the issue for the customer that I thought it would. Furthermore, I think my whole mental model of how the spans were being closed and the timestamps being set was wrong.

Either way, turns out `appsignal_close_span_with_timestamp` forces a recalculation of the span digest, which is something we don't want to do, as the span digest is calculated differently, from the OpenTelemetry extractor output, and the `SpanInProgress` instance does not have the necessary attributes to calculate it correctly.