### PR TITLE
Do not instrument transmitter requests

### DIFF
--- a/.changesets/prevent-internal-appsignal-requests-from-being-instrumented.md
+++ b/.changesets/prevent-internal-appsignal-requests-from-being-instrumented.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: fix
+---
+
+Prevent internal AppSignal requests from being instrumented and appearing in the "Slow API requests" panel.


### PR DESCRIPTION
Requests performed by the transmitter after the integration has been initialised, such as those performed by the heartbeats module, were being instrumented by OpenTelemetry. This commit uses `suppressTracing` to prevent that.

Noticed this while testing the heartbeat rename PR.