### PR TITLE
Implement heartbeat check-ins

### DIFF
--- a/.changesets/add-heartbeat-check-ins.md
+++ b/.changesets/add-heartbeat-check-ins.md
@@ -1,0 +1,30 @@
+---
+bump: minor
+type: add
+---
+
+Add support for heartbeat check-ins.
+
+Use the `checkIn.heartbeat` method to send a single heartbeat check-in event from your application. This can be used, for example, in your application's main loop:
+
+```js
+import { checkIn } from "@appsignal/nodejs"
+
+while (true) {
+  checkIn.heartbeat("job_processor")
+  await processJob()
+}
+```
+
+Heartbeats are deduplicated and sent asynchronously, without blocking the current thread. Regardless of how often the `.heartbeat` method is called, at most one heartbeat with the same identifier will be sent every ten seconds.
+
+Pass `{continuous: true}` as the second argument to send heartbeats continuously during the entire lifetime of the current process. This can be used, for example, after your application has finished its boot process:
+
+```js
+import { checkIn } from "@appsignal/nodejs"
+
+function main() {
+  checkIn.heartbeat("job_processor", {continuous: true})
+  startApp()
+}
+```

--- a/src/__tests__/check_in/event.test.ts
+++ b/src/__tests__/check_in/event.test.ts
@@ -1,0 +1,198 @@
+import { Event, EventCheckInType } from "../../check_in/event"
+
+describe("Event", () => {
+  describe(".describe()", () => {
+    it("describes an empty list of events", () => {
+      expect(Event.describe([])).toBe("no check-in events")
+    })
+
+    it("describes a list of many events by count", () => {
+      const events = [
+        new Event({ identifier: "1", check_in_type: "cron" }),
+        new Event({ identifier: "2", check_in_type: "cron" })
+      ]
+      expect(Event.describe(events)).toBe("2 check-in events")
+    })
+
+    it("describes a single cron event", () => {
+      const event = new Event({
+        identifier: "identifier",
+        check_in_type: "cron",
+        kind: "start",
+        digest: "some-digest"
+      })
+      expect(Event.describe([event])).toBe(
+        "cron check-in `identifier` start event (digest some-digest)"
+      )
+    })
+
+    it("describes a single heartbeat event", () => {
+      const event = new Event({
+        identifier: "identifier",
+        check_in_type: "heartbeat"
+      })
+      expect(Event.describe([event])).toBe(
+        "heartbeat check-in `identifier` event"
+      )
+    })
+
+    it("describes a single unknown event", () => {
+      const event = new Event({
+        identifier: "identifier",
+        check_in_type: "unknown" as EventCheckInType
+      })
+      expect(Event.describe([event])).toBe("unknown check-in event")
+    })
+  })
+
+  describe(".isRedundant()", () => {
+    it("returns false if the events have different types", () => {
+      const event = new Event({ identifier: "1", check_in_type: "cron" })
+      const newEvent = new Event({
+        identifier: "1",
+        check_in_type: "heartbeat"
+      })
+
+      expect(event.isRedundant(newEvent)).toBe(false)
+    })
+
+    it("returns false if the events have an unknown type", () => {
+      const event = new Event({
+        identifier: "1",
+        check_in_type: "unknown" as EventCheckInType
+      })
+      const newEvent = new Event({
+        identifier: "1",
+        check_in_type: "unknown" as EventCheckInType
+      })
+
+      expect(event.isRedundant(newEvent)).toBe(false)
+    })
+
+    it("returns false if heartbeat events have different identifiers", () => {
+      const event = new Event({ identifier: "1", check_in_type: "heartbeat" })
+      const newEvent = new Event({
+        identifier: "2",
+        check_in_type: "heartbeat"
+      })
+
+      expect(event.isRedundant(newEvent)).toBe(false)
+    })
+
+    it("returns true if heartbeat events have the same identifier", () => {
+      const event = new Event({ identifier: "1", check_in_type: "heartbeat" })
+      const newEvent = new Event({
+        identifier: "1",
+        check_in_type: "heartbeat"
+      })
+
+      expect(event.isRedundant(newEvent)).toBe(true)
+    })
+
+    it("returns false if cron events have different identifiers", () => {
+      const event = new Event({ identifier: "1", check_in_type: "cron" })
+      const newEvent = new Event({ identifier: "2", check_in_type: "cron" })
+
+      expect(event.isRedundant(newEvent)).toBe(false)
+    })
+
+    it("returns false if cron events have different digests", () => {
+      const event = new Event({
+        identifier: "1",
+        digest: "1",
+        check_in_type: "cron"
+      })
+      const newEvent = new Event({
+        identifier: "1",
+        digest: "2",
+        check_in_type: "cron"
+      })
+
+      expect(event.isRedundant(newEvent)).toBe(false)
+    })
+
+    it("returns false if cron events have different kinds", () => {
+      const event = new Event({
+        identifier: "1",
+        kind: "start",
+        check_in_type: "cron"
+      })
+      const newEvent = new Event({
+        identifier: "1",
+        kind: "finish",
+        check_in_type: "cron"
+      })
+
+      expect(event.isRedundant(newEvent)).toBe(false)
+    })
+
+    it("returns true if cron events have the same identifier, digest, and kind", () => {
+      const event = new Event({
+        identifier: "1",
+        digest: "1",
+        kind: "start",
+        check_in_type: "cron"
+      })
+      const newEvent = new Event({
+        identifier: "1",
+        digest: "1",
+        kind: "start",
+        check_in_type: "cron"
+      })
+
+      expect(event.isRedundant(newEvent)).toBe(true)
+    })
+  })
+
+  describe("JSON serialization", () => {
+    it("serializes a heartbeat event", () => {
+      const event = new Event({
+        identifier: "1",
+        check_in_type: "heartbeat"
+      })
+
+      const serialised = JSON.stringify(event)
+
+      expect(serialised).toMatch('"identifier":"1"')
+      expect(serialised).toMatch('"check_in_type":"heartbeat"')
+      expect(serialised).toMatch('"timestamp":')
+      expect(serialised).not.toMatch('"digest":')
+      expect(serialised).not.toMatch('"kind":')
+
+      const parsed = JSON.parse(serialised)
+
+      expect(parsed).toEqual({
+        identifier: "1",
+        check_in_type: "heartbeat",
+        timestamp: expect.any(Number)
+      })
+    })
+
+    it("serializes a cron event", () => {
+      const event = new Event({
+        identifier: "1",
+        check_in_type: "cron",
+        kind: "start",
+        digest: "digest"
+      })
+
+      const serialised = JSON.stringify(event)
+
+      expect(serialised).toMatch('"identifier":"1"')
+      expect(serialised).toMatch('"check_in_type":"cron"')
+      expect(serialised).toMatch('"kind":"start"')
+      expect(serialised).toMatch('"digest":"digest"')
+      expect(serialised).toMatch('"timestamp":')
+
+      const parsed = JSON.parse(serialised)
+
+      expect(parsed).toEqual({
+        identifier: "1",
+        check_in_type: "cron",
+        kind: "start",
+        digest: "digest",
+        timestamp: expect.any(Number)
+      })
+    })
+  })
+})

--- a/src/check_in/cron.ts
+++ b/src/check_in/cron.ts
@@ -1,15 +1,6 @@
 import { scheduler } from "./scheduler"
 import crypto from "crypto"
-
-export type EventKind = "start" | "finish"
-
-export type Event = {
-  identifier: string
-  digest: string
-  kind: EventKind
-  timestamp: number
-  check_in_type: "cron"
-}
+import { Event } from "./event"
 
 export class Cron {
   identifier: string
@@ -21,20 +12,10 @@ export class Cron {
   }
 
   public start(): void {
-    scheduler.schedule(this.event("start"))
+    scheduler.schedule(Event.cron(this, "start"))
   }
 
   public finish(): void {
-    scheduler.schedule(this.event("finish"))
-  }
-
-  private event(kind: EventKind): Event {
-    return {
-      identifier: this.identifier,
-      digest: this.digest,
-      kind: kind,
-      timestamp: Math.floor(Date.now() / 1000),
-      check_in_type: "cron"
-    }
+    scheduler.schedule(Event.cron(this, "finish"))
   }
 }

--- a/src/check_in/event.ts
+++ b/src/check_in/event.ts
@@ -1,8 +1,11 @@
 import type { Cron } from "./cron"
 
+/** @internal */
 export type EventKind = "start" | "finish"
+/** @internal */
 export type EventCheckInType = "cron" | "heartbeat"
 
+/** @internal */
 export class Event {
   identifier: string
   digest?: string

--- a/src/check_in/event.ts
+++ b/src/check_in/event.ts
@@ -1,0 +1,101 @@
+import type { Cron } from "./cron"
+
+export type EventKind = "start" | "finish"
+export type EventCheckInType = "cron" | "heartbeat"
+
+export class Event {
+  identifier: string
+  digest?: string
+  kind?: EventKind
+  timestamp: number
+  check_in_type: EventCheckInType
+
+  constructor({
+    identifier,
+    digest,
+    kind,
+    check_in_type
+  }: {
+    identifier: string
+    digest?: string
+    kind?: EventKind
+    check_in_type: EventCheckInType
+  }) {
+    this.identifier = identifier
+    this.digest = digest
+    this.kind = kind
+    this.timestamp = Math.floor(Date.now() / 1000)
+    this.check_in_type = check_in_type
+  }
+
+  static cron(cron: Cron, kind: EventKind) {
+    return new Event({
+      identifier: cron.identifier,
+      digest: cron.digest,
+      kind,
+      check_in_type: "cron"
+    })
+  }
+
+  static heartbeat(identifier: string) {
+    return new Event({
+      identifier,
+      check_in_type: "heartbeat"
+    })
+  }
+
+  isRedundant(newEvent: Event): boolean {
+    if (this.check_in_type === "cron") {
+      // Consider any existing cron check-in event redundant if it has the
+      // same identifier, digest and kind as the one we're adding.
+      if (
+        newEvent.check_in_type === "cron" &&
+        this.identifier === newEvent.identifier &&
+        this.kind === newEvent.kind &&
+        this.digest === newEvent.digest
+      ) {
+        return true
+      }
+    } else if (this.check_in_type === "heartbeat") {
+      // Consider any existing heartbeat check-in event redundant if it has
+      // the same identifier as the one we're adding.
+      if (
+        newEvent.check_in_type === "heartbeat" &&
+        this.identifier === newEvent.identifier
+      ) {
+        return true
+      }
+    }
+
+    return false
+  }
+
+  static describe(events: Event[]): string {
+    const count = events.length
+    if (count === 0) {
+      // This shouldn't happen.
+      return "no check-in events"
+    } else if (count === 1) {
+      const event = events[0]
+      if (event.check_in_type === "cron") {
+        return (
+          "cron check-in `" +
+          (event.identifier || "unknown") +
+          "` " +
+          (event.kind || "unknown") +
+          " event (digest " +
+          (event.digest || "unknown") +
+          ")"
+        )
+      } else if (event.check_in_type === "heartbeat") {
+        return (
+          "heartbeat check-in `" + (event.identifier || "unknown") + "` event"
+        )
+      } else {
+        return "unknown check-in event"
+      }
+    } else {
+      return `${count} check-in events`
+    }
+  }
+}

--- a/src/check_in/heartbeat.ts
+++ b/src/check_in/heartbeat.ts
@@ -1,0 +1,18 @@
+import { stubbable } from "../utils"
+
+const HEARTBEAT_INTERVAL_MILLISECONDS = 30_000
+
+export const heartbeatInterval = stubbable(
+  () => HEARTBEAT_INTERVAL_MILLISECONDS
+)
+
+let continuousHeartbeats: NodeJS.Timeout[] = []
+
+export function addContinuousHeartbeat(interval: NodeJS.Timeout) {
+  continuousHeartbeats.push(interval)
+}
+
+export function killContinuousHeartbeats() {
+  continuousHeartbeats.forEach(clearInterval)
+  continuousHeartbeats = []
+}

--- a/src/check_in/heartbeat.ts
+++ b/src/check_in/heartbeat.ts
@@ -2,16 +2,19 @@ import { stubbable } from "../utils"
 
 const HEARTBEAT_INTERVAL_MILLISECONDS = 30_000
 
+/** @internal */
 export const heartbeatInterval = stubbable(
   () => HEARTBEAT_INTERVAL_MILLISECONDS
 )
 
 let continuousHeartbeats: NodeJS.Timeout[] = []
 
+/** @internal */
 export function addContinuousHeartbeat(interval: NodeJS.Timeout) {
   continuousHeartbeats.push(interval)
 }
 
+/** @internal */
 export function killContinuousHeartbeats() {
   continuousHeartbeats.forEach(clearInterval)
   continuousHeartbeats = []

--- a/src/check_in/index.ts
+++ b/src/check_in/index.ts
@@ -1,6 +1,11 @@
+import { scheduler } from "./scheduler"
+
 import { Cron } from "./cron"
 export { Cron }
-export type { EventKind, Event } from "./cron"
+
+import { Event } from "./event"
+
+import { heartbeatInterval, addContinuousHeartbeat } from "./heartbeat"
 
 export function cron(identifier: string): void
 export function cron<T>(identifier: string, fn: () => T): T
@@ -20,4 +25,17 @@ export function cron<T>(identifier: string, fn?: () => T): T | undefined {
   }
 
   return output
+}
+
+export function heartbeat(
+  identifier: string,
+  options?: { continuous: boolean }
+): void {
+  if (options?.continuous) {
+    addContinuousHeartbeat(
+      setInterval(heartbeat, heartbeatInterval(), identifier).unref()
+    )
+  }
+
+  scheduler.schedule(Event.heartbeat(identifier))
 }

--- a/src/check_in/scheduler.ts
+++ b/src/check_in/scheduler.ts
@@ -6,6 +6,7 @@ import { ndjsonStringify, stubbable } from "../utils"
 const INITIAL_DEBOUNCE_MILLISECONDS = 100
 const BETWEEN_TRANSMISSIONS_DEBOUNCE_MILLISECONDS = 10_000
 
+/** @internal */
 export const debounceTime = stubbable(
   (lastTransmission: number | undefined): number => {
     if (lastTransmission === undefined) {
@@ -33,6 +34,7 @@ class PendingPromiseSet<T> extends Set<Promise<T>> {
   }
 }
 
+/** @internal */
 export class Scheduler {
   pendingTransmissions: PendingPromiseSet<any> = new PendingPromiseSet()
   events: Event[] = []
@@ -146,8 +148,10 @@ export class Scheduler {
   }
 }
 
+/** @internal */
 export let scheduler = new Scheduler()
 
+/** @internal */
 export async function resetScheduler() {
   await scheduler.shutdown()
   scheduler = new Scheduler()

--- a/src/check_in/scheduler.ts
+++ b/src/check_in/scheduler.ts
@@ -1,33 +1,25 @@
-import type { Event } from "./cron"
+import { Event } from "./event"
 import { Transmitter } from "../transmitter"
 import { Client } from "../client"
-import { ndjsonStringify } from "../utils"
+import { ndjsonStringify, stubbable } from "../utils"
 
 const INITIAL_DEBOUNCE_MILLISECONDS = 100
 const BETWEEN_TRANSMISSIONS_DEBOUNCE_MILLISECONDS = 10_000
 
-const originalDebounceTime = (lastTransmission: number | undefined): number => {
-  if (lastTransmission === undefined) {
-    return INITIAL_DEBOUNCE_MILLISECONDS
+export const debounceTime = stubbable(
+  (lastTransmission: number | undefined): number => {
+    if (lastTransmission === undefined) {
+      return INITIAL_DEBOUNCE_MILLISECONDS
+    }
+
+    const elapsed = Date.now() - lastTransmission
+
+    return Math.max(
+      INITIAL_DEBOUNCE_MILLISECONDS,
+      BETWEEN_TRANSMISSIONS_DEBOUNCE_MILLISECONDS - elapsed
+    )
   }
-
-  const elapsed = Date.now() - lastTransmission
-
-  return Math.max(
-    INITIAL_DEBOUNCE_MILLISECONDS,
-    BETWEEN_TRANSMISSIONS_DEBOUNCE_MILLISECONDS - elapsed
-  )
-}
-
-export let debounceTime: typeof originalDebounceTime = originalDebounceTime
-
-export function setDebounceTime(fn: typeof originalDebounceTime) {
-  debounceTime = fn
-}
-
-export function resetDebounceTime() {
-  debounceTime = originalDebounceTime
-}
+)
 
 class PendingPromiseSet<T> extends Set<Promise<T>> {
   add(promise: Promise<T>) {
@@ -61,19 +53,19 @@ export class Scheduler {
   schedule(event: Event) {
     if (Client.client === undefined || !Client.client.isActive) {
       Client.internalLogger.debug(
-        `Cannot schedule ${this.describe([event])}: AppSignal is not active`
+        `Cannot schedule ${Event.describe([event])}: AppSignal is not active`
       )
       return
     }
 
     if (this.isShuttingDown) {
       Client.internalLogger.debug(
-        `Cannot schedule ${this.describe([event])}: AppSignal is stopped`
+        `Cannot schedule ${Event.describe([event])}: AppSignal is stopped`
       )
       return
     }
 
-    Client.internalLogger.trace(`Scheduling ${this.describe([event])}`)
+    Client.internalLogger.trace(`Scheduling ${Event.describe([event])}`)
 
     this.addEvent(event)
     this.scheduleWaker()
@@ -83,31 +75,17 @@ export class Scheduler {
     // Remove redundant events, keeping the newly added one, which
     // should be the one with the most recent timestamp.
     this.events = this.events.filter(existingEvent => {
-      return !this.isRedundantEvent(existingEvent, event)
+      const isRedundant = existingEvent.isRedundant(event)
+
+      if (isRedundant) {
+        Client.internalLogger.debug(
+          `Replacing previously scheduled ${Event.describe([existingEvent])}`
+        )
+      }
+
+      return !isRedundant
     })
     this.events.push(event)
-  }
-
-  private isRedundantEvent(existingEvent: Event, newEvent: Event): boolean {
-    let isRedundant = false
-
-    if (newEvent.check_in_type === "cron") {
-      // Consider any existing cron check-in event redundant if it has the
-      // same identifier, digest and kind as the one we're adding.
-      isRedundant =
-        existingEvent.identifier === newEvent.identifier &&
-        existingEvent.kind === newEvent.kind &&
-        existingEvent.digest === newEvent.digest &&
-        existingEvent.check_in_type === "cron"
-    }
-
-    if (isRedundant) {
-      Client.internalLogger.debug(
-        `Replacing previously scheduled ${this.describe([existingEvent])}`
-      )
-    }
-
-    return isRedundant
   }
 
   private scheduleWaker() {
@@ -139,7 +117,7 @@ export class Scheduler {
   }
 
   private transmit(events: Event[]) {
-    const description = this.describe(events)
+    const description = Event.describe(events)
 
     const promise = new Transmitter(
       `${Client.config.data.loggingEndpoint}/check_ins/json`,
@@ -165,31 +143,6 @@ export class Scheduler {
       })
 
     this.pendingTransmissions.add(handledPromise)
-  }
-
-  private describe(events: Event[]): string {
-    const count = events.length
-    if (count === 0) {
-      // This shouldn't happen.
-      return "no check-in events"
-    } else if (count === 1) {
-      const event = events[0]
-      if (event.check_in_type === "cron") {
-        return (
-          "cron check-in `" +
-          (event.identifier || "unknown") +
-          "` " +
-          (event.kind || "unknown") +
-          " event (digest " +
-          (event.digest || "unknown") +
-          ")"
-        )
-      } else {
-        return "unknown check-in event"
-      }
-    } else {
-      return `${count} check-in events`
-    }
   }
 }
 

--- a/src/config/configmap.ts
+++ b/src/config/configmap.ts
@@ -1,5 +1,6 @@
 import type { AppsignalOptions } from "./options"
 
+/** @internal */
 export const ENV_TO_KEY_MAPPING = {
   APPSIGNAL_ACTIVE: "active",
   APPSIGNAL_APP_ENV: "environment",
@@ -42,6 +43,7 @@ export const ENV_TO_KEY_MAPPING = {
   APP_REVISION: "revision"
 } satisfies Record<string, keyof AppsignalOptions>
 
+/** @internal */
 export const PRIVATE_ENV_MAPPING: Record<string, keyof AppsignalOptions> = {
   _APPSIGNAL_ACTIVE: "active",
   _APPSIGNAL_APP_ENV: "environment",
@@ -79,6 +81,7 @@ export const PRIVATE_ENV_MAPPING: Record<string, keyof AppsignalOptions> = {
   _APP_REVISION: "revision"
 }
 
+/** @internal */
 export const JS_TO_RUBY_MAPPING: Record<keyof AppsignalOptions, string> = {
   active: "active",
   bindAddress: "bind_address",
@@ -121,6 +124,7 @@ export const JS_TO_RUBY_MAPPING: Record<keyof AppsignalOptions, string> = {
   workingDirectoryPath: "working_directory_path"
 }
 
+/** @internal */
 export const BOOL_KEYS: (keyof typeof ENV_TO_KEY_MAPPING)[] = [
   "APPSIGNAL_ACTIVE",
   "APPSIGNAL_ENABLE_HOST_METRICS",
@@ -135,6 +139,7 @@ export const BOOL_KEYS: (keyof typeof ENV_TO_KEY_MAPPING)[] = [
   "APPSIGNAL_SEND_SESSION_DATA"
 ]
 
+/** @internal */
 export const STRING_KEYS: (keyof typeof ENV_TO_KEY_MAPPING)[] = [
   "APPSIGNAL_APP_ENV",
   "APPSIGNAL_APP_NAME",
@@ -156,6 +161,7 @@ export const STRING_KEYS: (keyof typeof ENV_TO_KEY_MAPPING)[] = [
   "APP_REVISION"
 ]
 
+/** @internal */
 export const LIST_KEYS: (keyof typeof ENV_TO_KEY_MAPPING)[] = [
   "APPSIGNAL_DNS_SERVERS",
   "APPSIGNAL_FILTER_PARAMETERS",
@@ -167,10 +173,12 @@ export const LIST_KEYS: (keyof typeof ENV_TO_KEY_MAPPING)[] = [
   "APPSIGNAL_REQUEST_HEADERS"
 ]
 
+/** @internal */
 export const LIST_OR_BOOL_KEYS: (keyof typeof ENV_TO_KEY_MAPPING)[] = [
   "APPSIGNAL_DISABLE_DEFAULT_INSTRUMENTATIONS"
 ]
 
+/** @internal */
 export const FLOAT_KEYS: (keyof typeof ENV_TO_KEY_MAPPING)[] = [
   "APPSIGNAL_CPU_COUNT"
 ]

--- a/src/extension_wrapper.ts
+++ b/src/extension_wrapper.ts
@@ -72,4 +72,5 @@ try {
   } as ExtensionWrapper
 }
 
+/** @internal */
 export = mod

--- a/src/heartbeat.ts
+++ b/src/heartbeat.ts
@@ -1,6 +1,6 @@
 import { Client } from "./client"
 import { cron, Cron } from "./check_in"
-export type { Event, EventKind } from "./check_in"
+export type { Event, EventKind } from "./check_in/event"
 
 type OnceFn = {
   (): void

--- a/src/heartbeat.ts
+++ b/src/heartbeat.ts
@@ -1,6 +1,5 @@
 import { Client } from "./client"
 import { cron, Cron } from "./check_in"
-export type { Event, EventKind } from "./check_in/event"
 
 type OnceFn = {
   (): void
@@ -32,6 +31,7 @@ function consoleAndLoggerWarn(message: string) {
   Client.internalLogger.warn(message)
 }
 
+/** @internal */
 export const heartbeatClassWarnOnce = once(
   consoleAndLoggerWarn,
   "The class `Heartbeat` has been deprecated. " +
@@ -40,6 +40,7 @@ export const heartbeatClassWarnOnce = once(
     "in order to remove this message."
 )
 
+/** @internal */
 export const heartbeatHelperWarnOnce = once(
   consoleAndLoggerWarn,
   "The helper `heartbeat` has been deprecated. " +
@@ -48,6 +49,7 @@ export const heartbeatHelperWarnOnce = once(
     "in order to remove this message."
 )
 
+/** @deprecated Use `checkIn.cron` (`import { checkIn } from "@appsignal/nodejs"`) instead. */
 export function heartbeat(name: string): void
 export function heartbeat<T>(name: string, fn: () => T): T
 export function heartbeat<T>(name: string, fn?: () => T): T | undefined {
@@ -56,6 +58,7 @@ export function heartbeat<T>(name: string, fn?: () => T): T | undefined {
   return (cron as (name: string, fn?: () => T) => T | undefined)(name, fn)
 }
 
+/** @deprecated Use `checkIn.Cron` (`import { checkIn } from "@appsignal/nodejs"`) instead. */
 export const Heartbeat = new Proxy(Cron, {
   construct(target, args: ConstructorParameters<typeof Cron>) {
     heartbeatClassWarnOnce()

--- a/src/internal/data.ts
+++ b/src/internal/data.ts
@@ -1,5 +1,6 @@
 import { datamap, dataarray } from "../extension_wrapper"
 
+/** @internal */
 export class Data {
   public static generate(data: Array<any> | Record<string, any>) {
     if (data.constructor.name === "Object") {

--- a/src/internal_logger.ts
+++ b/src/internal_logger.ts
@@ -9,6 +9,7 @@ export interface InternalLogger {
   trace(message: string): void
 }
 
+/** @internal */
 export class BaseInternalLogger {
   type: string
   level: string

--- a/src/noops/internal_logger.ts
+++ b/src/noops/internal_logger.ts
@@ -1,5 +1,6 @@
 import { InternalLogger } from "../internal_logger"
 
+/** @internal */
 export class NoopInternalLogger implements InternalLogger {
   error(_message: string) {
     // noop
@@ -18,4 +19,5 @@ export class NoopInternalLogger implements InternalLogger {
   }
 }
 
+/** @internal */
 export const noopInternalLogger = new NoopInternalLogger()

--- a/src/noops/logger.ts
+++ b/src/noops/logger.ts
@@ -1,5 +1,6 @@
 import { Logger, LoggerAttributes } from "../logger"
 
+/** @internal */
 export class NoopLogger implements Logger {
   trace(_message: string, _attributes?: LoggerAttributes) {
     // noop
@@ -21,4 +22,5 @@ export class NoopLogger implements Logger {
   }
 }
 
+/** @internal */
 export const noopLogger = new NoopLogger()

--- a/src/noops/metrics.ts
+++ b/src/noops/metrics.ts
@@ -1,6 +1,7 @@
 import { Metrics } from "../metrics"
 import { Probes } from "../probes"
 
+/** @internal */
 export class NoopMetrics extends Metrics {
   #probes = new Probes({ run: false })
 

--- a/src/probes/index.ts
+++ b/src/probes/index.ts
@@ -43,6 +43,7 @@ export class Probes {
   }
 }
 
+/** @internal */
 type ProbeRunner = {
   readonly count: number
   register(name: string, fn: () => void): void
@@ -50,6 +51,7 @@ type ProbeRunner = {
   clear(): void
 }
 
+/** @internal */
 class BaseProbeRunner extends EventEmitter implements ProbeRunner {
   #timers = new Map<string, NodeJS.Timeout>()
 
@@ -98,6 +100,7 @@ class BaseProbeRunner extends EventEmitter implements ProbeRunner {
   }
 }
 
+/** @internal */
 class NoopProbeRunner implements ProbeRunner {
   readonly count: number = 0
 

--- a/src/probes/v8/index.ts
+++ b/src/probes/v8/index.ts
@@ -3,8 +3,10 @@ import v8 from "v8"
 import os from "os"
 import { Client } from "../../client"
 
+/** @internal */
 export const PROBE_NAME = "v8_stats"
 
+/** @internal */
 export function init(meter: Metrics) {
   function setGauge(key: string, value: number) {
     const hostname = Client.config.data.hostname || os.hostname()

--- a/src/span_processor.ts
+++ b/src/span_processor.ts
@@ -68,6 +68,7 @@ export class SpanProcessor implements OpenTelemetrySpanProcessor {
   }
 }
 
+/** @internal */
 export class TestModeSpanProcessor implements OpenTelemetrySpanProcessor {
   #filePath: string
 

--- a/src/transmitter.ts
+++ b/src/transmitter.ts
@@ -36,6 +36,7 @@ class MaxRedirectsError extends Error {
   }
 }
 
+/** @internal */
 export class Transmitter {
   #config: Configuration
   #url: string

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -67,3 +67,33 @@ export function ndjsonStringify(elements: any[]): string {
 export function ndjsonParse(data: string): any[] {
   return data.split("\n").map(line => JSON.parse(line))
 }
+
+export type Stub<F extends (...args: any[]) => any> = F & {
+  set: (fn: F) => void
+  reset: () => void
+}
+
+export function stubbable<T extends any[], U>(
+  original: (...args: T) => U
+): Stub<(...args: T) => U> {
+  let current: (...args: T) => U = original
+
+  const stub = {
+    [original.name]: function (...args: T): U {
+      return current(...args)
+    }
+  }[original.name] as Stub<(...args: T) => U>
+
+  function set(fn: (...args: T) => U) {
+    current = fn
+  }
+
+  function reset() {
+    current = original
+  }
+
+  stub.set = set
+  stub.reset = reset
+
+  return stub
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -10,6 +10,7 @@ const SECOND_TO_NANOSECONDS = Math.pow(10, NANOSECOND_DIGITS)
  * seconds and nanoseconds.
  *
  * @function
+ * @internal
  */
 export function getAgentTimestamps(timestamp: number) {
   const sec = Math.round(timestamp / 1000)
@@ -21,6 +22,7 @@ export function getAgentTimestamps(timestamp: number) {
 
 /**
  * Checks if the given path is writable by the process.
+ * @internal
  */
 export function isWritable(path: string) {
   try {
@@ -35,6 +37,7 @@ export function isWritable(path: string) {
  * Returns a high-resolution time tuple containing the current time in seconds and nanoseconds.
  *
  * @function
+ * @internal
  */
 export function hrTime(performance = perf_hooks.performance): {
   sec: number
@@ -56,23 +59,28 @@ function numberToHrtime(epochMillis: number) {
   return [seconds, nanoseconds]
 }
 
+/** @internal */
 export function processGetuid() {
   return (process.getuid ?? (() => -1))()
 }
 
+/** @internal */
 export function ndjsonStringify(elements: any[]): string {
   return elements.map(element => JSON.stringify(element)).join("\n")
 }
 
+/** @internal */
 export function ndjsonParse(data: string): any[] {
   return data.split("\n").map(line => JSON.parse(line))
 }
 
+/** @internal */
 export type Stub<F extends (...args: any[]) => any> = F & {
   set: (fn: F) => void
   reset: () => void
 }
 
+/** @internal */
 export function stubbable<T extends any[], U>(
   original: (...args: T) => U
 ): Stub<(...args: T) => U> {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,9 +6,7 @@
   ],
   "compilerOptions": {
     "rootDir": "./src",
-    "outDir": "./dist"
-  },
-  "compilerOptions": {
+    "outDir": "./dist",
     /* Basic Options */
     // "incremental": true,                   /* Enable incremental compilation */
     "target": "es2018",                       /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */
@@ -68,5 +66,6 @@
     /* Experimental Options */
     // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
     // "emitDecoratorMetadata": true          /* Enables experimental support for emitting type metadata for decorators. */
+    "stripInternal": true,
   }
 }


### PR DESCRIPTION
Part of https://github.com/appsignal/integration-guide/issues/169.

Add an `Appsignal.checkIn.heartbeat` helper that emits a single heartbeat for the check-in identifier given.

When given `{continuous: true}` as the second argument, it starts an interval that emits a heartbeat every thirty seconds. This is a convenience method for the use case where the heartbeat is only meant as a check that the process is alive.

Split functions that deal with different event kinds out of the scheduler and test them independently.