### PR TITLE
Skip cache delete job for forked PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,6 +226,8 @@ jobs:
     needs:
     - test_22_unit
     - test_22_extra_diagnose
+    if: github.actor != 'dependabot[bot]' && github.event.pull_request.head.repo.fork
+      == false
     runs-on: ubuntu-latest
     steps:
     - name: Checkout project
@@ -342,6 +344,8 @@ jobs:
     needs:
     - test_20_unit
     - test_20_extra_diagnose
+    if: github.actor != 'dependabot[bot]' && github.event.pull_request.head.repo.fork
+      == false
     runs-on: ubuntu-latest
     steps:
     - name: Checkout project
@@ -458,6 +462,8 @@ jobs:
     needs:
     - test_18_unit
     - test_18_extra_diagnose
+    if: github.actor != 'dependabot[bot]' && github.event.pull_request.head.repo.fork
+      == false
     runs-on: ubuntu-latest
     steps:
     - name: Checkout project

--- a/Rakefile
+++ b/Rakefile
@@ -197,6 +197,10 @@ namespace :build_matrix do
             unit_test_job_key,
             diagnose_job_key
           ],
+          # Skip this job for dependabot and forked PRs as they do not
+          # have write permissions to the repository to delete caches
+          "if" => "github.actor != 'dependabot[bot]' && " \
+            "github.event.pull_request.head.repo.fork == false",
           "runs-on" => "ubuntu-latest",
           "steps" => [
             {


### PR DESCRIPTION
Dependabot and forked PRs don't have 'write' permission to delete the GitHub Actions caches.

Skip this step for those kinds of PRs. It will keep the caches around for longer than we'd like, but at least it won't balloon in size if we skip this for all PRs.

[skip changeset]
[skip review]