### PR TITLE
Log warning when no span is active

### DIFF
--- a/.changesets/log-warning-when-no-span-is-active.md
+++ b/.changesets/log-warning-when-no-span-is-active.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: change
+---
+
+Bump the log message when no span is active and one of our sample data helpers are used like `setParams`, `setSessionData`, `setCustomData`, etc from debug to warning.

--- a/src/__tests__/helpers.test.ts
+++ b/src/__tests__/helpers.test.ts
@@ -126,11 +126,11 @@ describe("Helpers", () => {
   })
 
   it("logs a debug warning when there is no active span", () => {
-    const debugMock = jest.spyOn(Client.internalLogger, "debug")
+    const warnMock = jest.spyOn(Client.internalLogger, "warn")
 
     setCustomData({ chunky: "bacon" })
 
-    expect(debugMock).toHaveBeenCalledWith(
+    expect(warnMock).toHaveBeenCalledWith(
       "There is no active span, cannot set `custom_data`"
     )
   })

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -10,7 +10,7 @@ function setAttribute(attribute: string, value: AttributeValue, span?: Span) {
   } else {
     const splitAttributes = attribute.split(".")
     const attributeSuffix = splitAttributes[splitAttributes.length - 1]
-    Client.internalLogger.debug(
+    Client.internalLogger.warn(
       `There is no active span, cannot set \`${attributeSuffix}\``
     )
   }


### PR DESCRIPTION
In support, it would be nice to see this warning right away rather than when the debug log level is set. Hopefully speeds up our support time.