### PR TITLE
Support histograms by patching temporality

### DIFF
--- a/.changesets/support-opentelemetry-histograms.md
+++ b/.changesets/support-opentelemetry-histograms.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: add
+---
+
+Add support for OpenTelemetry histograms.


### PR DESCRIPTION
Fixes #1166, by doing within the integration [the same changes that used to be done in the collector test setup](https://github.com/appsignal/test-setups/commit/f29193a33059ec1cd0d16b252ae02b535eac731e). Although the collector has now been amended to support cumulative aggregation temporality histograms, this improvement has not been backported to the agent.

---

Patch the OpenTelemetry metric exporter to customise the aggregation temporality used for metrics -- specifically, changing it to use delta aggregation temporality instead of cumulative aggregation temporality for histograms. This matches the expectations of the AppSignal agent.