### PR TITLE
State that we no longer support Node.js 16

### DIFF
--- a/.changesets/drop-support-for-node-js-16.md
+++ b/.changesets/drop-support-for-node-js-16.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: remove
+---
+
+Drop support for Node.js 16

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "lint:write": "eslint --fix ."
   },
   "engines": {
-    "node": ">= 12"
+    "node": ">= 18"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Set a minimum requirement of `>= 18` on the `engines` property of the `package.json` file.

This only acknowledges the changes that were already merged in #1186. See https://github.com/appsignal/appsignal-nodejs/pull/1186#issuecomment-2766535530 for details.