### PR TITLE
Remove redundant cron check-in pairs

### DIFF
--- a/.changesets/remove-redundant-cron-check-in-pairs.md
+++ b/.changesets/remove-redundant-cron-check-in-pairs.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: change
+---
+
+Remove redundant cron check-in pairs. When more than one pair of start and finish cron check-in events is reported for the same identifier in the same period, only one of them will be reported to AppSignal.

--- a/src/check_in/event.ts
+++ b/src/check_in/event.ts
@@ -101,4 +101,70 @@ export class Event {
       return `${count} check-in events`
     }
   }
+
+  static deduplicateCron(events: Event[]) {
+    // Remove redundant cron check-in events from the given list of events.
+    // This is done by removing redundant *pairs* of events -- that is,
+    // for each identifier, only send one complete pair of start and
+    // finish events. Remove all other complete pairs of start and finish
+    // events for that identifier, but keep any other start or finish events
+    // that don't have a matching pair.
+    //
+    // Note that this method assumes that the events in this list have already
+    // been rejected based on `Event.isRedundant`, so we don't check to remove
+    // check-in events that are functionally identical.
+
+    const start_digests = new Map<string, Set<string | undefined>>()
+    const finish_digests = new Map<string, Set<string | undefined>>()
+    const complete_digests = new Map<string, Set<string | undefined>>()
+    const keep_digest = new Map<string, string | undefined>()
+
+    events.forEach(event => {
+      if (event.check_in_type != "cron") {
+        return
+      }
+
+      let other_set = undefined
+
+      if (!start_digests.has(event.identifier)) {
+        start_digests.set(event.identifier, new Set())
+        finish_digests.set(event.identifier, new Set())
+        complete_digests.set(event.identifier, new Set())
+      }
+
+      if (event.kind == "start") {
+        start_digests.get(event.identifier)?.add(event.digest)
+        other_set = finish_digests
+      }
+
+      if (event.kind == "finish") {
+        finish_digests.get(event.identifier)?.add(event.digest)
+        other_set = start_digests
+      }
+
+      if (other_set?.get(event.identifier)?.has(event.digest)) {
+        complete_digests.get(event.identifier)?.add(event.digest)
+        keep_digest.set(event.identifier, event.digest)
+      }
+    })
+
+    for (let i = 0; i < events.length; i++) {
+      const event = events[i]
+
+      if (
+        event.check_in_type != "cron" ||
+        (event.kind != "start" && event.kind != "finish")
+      ) {
+        continue
+      }
+
+      if (
+        complete_digests?.get(event.identifier)?.has(event.digest) &&
+        keep_digest?.get(event.identifier) != event.digest
+      ) {
+        events.splice(i, 1)
+        i--
+      }
+    }
+  }
 }

--- a/src/check_in/scheduler.ts
+++ b/src/check_in/scheduler.ts
@@ -111,6 +111,7 @@ export class Scheduler {
     }
 
     const events = this.events
+    Event.deduplicateCron(events)
     this.events = []
     if (events.length !== 0) {
       // The events array may be empty when this function is called on shutdown.


### PR DESCRIPTION
See https://github.com/appsignal/appsignal-ruby/pull/1407 for context. This commit reimplements that in Node.js.

Before submitting a batch of cron check-in events, check for any pairs of events that are redundant with other pairs of cron check-in events. This would happen, for example, when running a `cron` block for a given identifier many times in quick succession.

A redundant pair of cron check-in events is a pair of start and finish cron check-in events for a given identifier, given that another pair of start and finish check-in events exists for that identifier.