### PR TITLE
Dependabot ignore test apps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    ignore:
+      - dependency-name: "*"
+        paths:
+          - "test/**"


### PR DESCRIPTION
We don't need to be notified about dependency updates for test apps.

[skip changeset]
[skip review]
[skip ci]