### PR TITLE
Disable distributed OpenTelemetry propagation

### DIFF
--- a/.changesets/disable-opentelemetry-propagation.md
+++ b/.changesets/disable-opentelemetry-propagation.md
@@ -1,0 +1,6 @@
+---
+bump: minor
+type: change
+---
+
+Disable the OpenTelemetry propagation across applications. If multiple applications are instrumented with AppSignal for Node.js using OpenTelemetry, the propagation across applications could lead to application data being reported the wrong application in AppSignal.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@appsignal/nodejs",
-  "version": "3.6.5",
+  "version": "3.6.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@appsignal/nodejs",
-      "version": "3.6.5",
+      "version": "3.6.7",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/src/client.ts
+++ b/src/client.ts
@@ -15,6 +15,7 @@ import {
   AggregationTemporality,
   InstrumentType
 } from "@opentelemetry/sdk-metrics"
+import { CompositePropagator } from "@opentelemetry/core"
 import { OTLPMetricExporter } from "@opentelemetry/exporter-metrics-otlp-proto"
 
 import type { Instrumentation } from "@opentelemetry/instrumentation"
@@ -420,7 +421,8 @@ export class Client {
     const sdk = new NodeSDK({
       instrumentations,
       spanProcessor,
-      metricReader
+      metricReader,
+      textMapPropagator: new CompositePropagator()
     })
 
     sdk.start()

--- a/src/client.ts
+++ b/src/client.ts
@@ -16,6 +16,8 @@ import {
   InstrumentType
 } from "@opentelemetry/sdk-metrics"
 import { CompositePropagator } from "@opentelemetry/core"
+import { B3Propagator, B3InjectEncoding } from "@opentelemetry/propagator-b3"
+import { W3CBaggagePropagator } from "@opentelemetry/core"
 import { OTLPMetricExporter } from "@opentelemetry/exporter-metrics-otlp-proto"
 
 import type { Instrumentation } from "@opentelemetry/instrumentation"
@@ -422,7 +424,13 @@ export class Client {
       instrumentations,
       spanProcessor,
       metricReader,
-      textMapPropagator: new CompositePropagator()
+      textMapPropagator: new CompositePropagator({
+        propagators: [
+          new W3CBaggagePropagator(),
+          new B3Propagator(),
+          new B3Propagator({ injectEncoding: B3InjectEncoding.MULTI_HEADER })
+        ]
+      })
     })
 
     sdk.start()


### PR DESCRIPTION
Prevent OpenTelemetry from sending tracing headers to other applications through HTTP requests.

Use an unconfigured `CompositePropagator` to disable HTTP propagation headers while maintaining local trace correlation. It is not configured with any other propagators, so it will not add the headers to the outgoing requests.

I hope this fixes the issue with app data being reported to the wrong app, if one app makes a request to another app and they're both instrumented with OpenTelemetry.

## To do

- [ ] Inform [this customer](https://app.intercom.com/a/inbox/yzor8gyw/inbox/conversation/215469972929521?view=List) upon release.

## Resources

- [Internal private dev discussion about the change](https://appsignal.slack.com/archives/C7XHXQ7N0/p1753337899481699)