### PR TITLE
Fix package version in lock file on publish

### DIFF
--- a/mono.yml
+++ b/mono.yml
@@ -2,3 +2,5 @@
 language: nodejs
 repo: "https://github.com/appsignal/appsignal-nodejs"
 npm_client: "npm"
+git-commit:
+  pre: "npm install"


### PR DESCRIPTION
After we publish a new version of the package, the `package-lock.json` file is always out-of-sync, containing the old version number of the package until `npm install` is run.

Run `npm install` before the Git commit step so that the lock file is updated with the latest version.

[skip changeset]
[skip review]