### PR TITLE
Auto detect log format

### DIFF
--- a/.changesets/auto-detect-log-format.md
+++ b/.changesets/auto-detect-log-format.md
@@ -1,0 +1,11 @@
+---
+bump: patch
+type: change
+---
+
+Detect the log format automatically. We now detect if a log line is in the JSON, Logfmt, or plaintext format. No further config needed when calling our logger, like so: 
+
+```javascript
+const logger = Appsignal.logger("app");
+logger.info("message");
+```

--- a/src/__tests__/logger.test.ts
+++ b/src/__tests__/logger.test.ts
@@ -52,7 +52,7 @@ describe("BaseLogger", () => {
     ).toEqual(6)
   })
 
-  it("defaults to a plaintext logger format", () => {
+  it("defaults to the autodetect logger format", () => {
     expect(logger.format).toEqual(3)
     expect(client.internalLogger.warn).not.toHaveBeenCalled()
   })

--- a/src/__tests__/logger.test.ts
+++ b/src/__tests__/logger.test.ts
@@ -53,18 +53,18 @@ describe("BaseLogger", () => {
   })
 
   it("defaults to a plaintext logger format", () => {
-    expect(logger.format).toEqual(0)
+    expect(logger.format).toEqual(3)
     expect(client.internalLogger.warn).not.toHaveBeenCalled()
   })
 
-  it("sets a plaintext format level when the format is unknown and logs a warning", () => {
+  it("sets the autodetect format level when the format is unknown and logs a warning", () => {
     logger = new BaseLogger(
       client,
       "groupname",
       "trace" as LoggerLevel,
       "bacon" as LoggerFormat
     )
-    expect(logger.format).toEqual(0)
+    expect(logger.format).toEqual(3)
     expect(client.internalLogger.warn).toHaveBeenCalledWith(
       expect.stringContaining(`"bacon"`)
     )
@@ -80,6 +80,9 @@ describe("BaseLogger", () => {
     expect(new BaseLogger(client, "groupname", "trace", "json").format).toEqual(
       2
     )
+    expect(
+      new BaseLogger(client, "groupname", "trace", "autodetect").format
+    ).toEqual(3)
   })
 
   it("logs to the extension if at or above the logger level", () => {
@@ -96,28 +99,28 @@ describe("BaseLogger", () => {
     expect(client.extension.log).toHaveBeenCalledWith(
       "groupname",
       3,
-      0,
+      3,
       "info message",
       attributes
     )
     expect(client.extension.log).toHaveBeenCalledWith(
       "groupname",
       4,
-      0,
+      3,
       "log message",
       attributes
     )
     expect(client.extension.log).toHaveBeenCalledWith(
       "groupname",
       5,
-      0,
+      3,
       "warn message",
       attributes
     )
     expect(client.extension.log).toHaveBeenCalledWith(
       "groupname",
       6,
-      0,
+      3,
       "error message",
       attributes
     )

--- a/src/__tests__/winston_transport.test.ts
+++ b/src/__tests__/winston_transport.test.ts
@@ -35,7 +35,7 @@ describe("BaseLogger", () => {
     expect(client.extension.log).toHaveBeenCalledWith(
       "groupname",
       3,
-      0,
+      3,
       "some data and some more data",
       { foo: 123, bar: 456 }
     )
@@ -47,7 +47,7 @@ describe("BaseLogger", () => {
     expect(client.extension.log).toHaveBeenCalledWith(
       "childgroup",
       3,
-      0,
+      3,
       "child logger message",
       { child: "foo", argument: 123 }
     )
@@ -62,7 +62,7 @@ describe("BaseLogger", () => {
     expect(client.extension.log).toHaveBeenCalledWith(
       "groupname",
       3,
-      0,
+      3,
       "no nested keys",
       { argument: 123 }
     )
@@ -73,7 +73,7 @@ describe("BaseLogger", () => {
     expect(client.extension.log).toHaveBeenCalledWith(
       "groupname",
       3,
-      0,
+      3,
       "no arrays",
       { argument: 123 }
     )
@@ -89,7 +89,7 @@ describe("BaseLogger", () => {
     expect(client.extension.log).toHaveBeenCalledWith(
       "groupname",
       3,
-      0,
+      3,
       "no color for me",
       { argument: 123 }
     )
@@ -104,7 +104,7 @@ describe("BaseLogger", () => {
     expect(client.extension.log).toHaveBeenCalledWith(
       "groupname",
       3,
-      0,
+      3,
       "no timestamp for me",
       { argument: 123 }
     )
@@ -118,7 +118,7 @@ describe("BaseLogger", () => {
     expect(client.extension.log).toHaveBeenCalledWith(
       "groupname",
       3,
-      0,
+      3,
       "info message",
       {}
     )
@@ -140,7 +140,7 @@ describe("BaseLogger", () => {
     expect(client.extension.log).toHaveBeenCalledWith(
       "groupname",
       1,
-      0,
+      3,
       "silly message",
       {}
     )
@@ -159,7 +159,7 @@ describe("BaseLogger", () => {
     expect(client.extension.log).toHaveBeenCalledWith(
       "groupname",
       3,
-      0,
+      3,
       "foobar message",
       {}
     )
@@ -188,35 +188,35 @@ describe("BaseLogger", () => {
     expect(client.extension.log).toHaveBeenCalledWith(
       "groupname",
       1,
-      0,
+      3,
       "trace message",
       {}
     )
     expect(client.extension.log).toHaveBeenCalledWith(
       "groupname",
       2,
-      0,
+      3,
       "debug message",
       {}
     )
     expect(client.extension.log).toHaveBeenCalledWith(
       "groupname",
       3,
-      0,
+      3,
       "info message",
       {}
     )
     expect(client.extension.log).toHaveBeenCalledWith(
       "groupname",
       5,
-      0,
+      3,
       "warn message",
       {}
     )
     expect(client.extension.log).toHaveBeenCalledWith(
       "groupname",
       6,
-      0,
+      3,
       "error message",
       {}
     )
@@ -240,49 +240,49 @@ describe("BaseLogger", () => {
     expect(client.extension.log).toHaveBeenCalledWith(
       "groupname",
       1,
-      0,
+      3,
       "silly message",
       {}
     )
     expect(client.extension.log).toHaveBeenCalledWith(
       "groupname",
       2,
-      0,
+      3,
       "debug message",
       {}
     )
     expect(client.extension.log).toHaveBeenCalledWith(
       "groupname",
       2,
-      0,
+      3,
       "verbose message",
       {}
     )
     expect(client.extension.log).toHaveBeenCalledWith(
       "groupname",
       3,
-      0,
+      3,
       "http message",
       {}
     )
     expect(client.extension.log).toHaveBeenCalledWith(
       "groupname",
       3,
-      0,
+      3,
       "http message",
       {}
     )
     expect(client.extension.log).toHaveBeenCalledWith(
       "groupname",
       5,
-      0,
+      3,
       "warn message",
       {}
     )
     expect(client.extension.log).toHaveBeenCalledWith(
       "groupname",
       6,
-      0,
+      3,
       "error message",
       {}
     )
@@ -308,56 +308,56 @@ describe("BaseLogger", () => {
     expect(client.extension.log).toHaveBeenCalledWith(
       "groupname",
       9,
-      0,
+      3,
       "emerg message",
       {}
     )
     expect(client.extension.log).toHaveBeenCalledWith(
       "groupname",
       8,
-      0,
+      3,
       "alert message",
       {}
     )
     expect(client.extension.log).toHaveBeenCalledWith(
       "groupname",
       7,
-      0,
+      3,
       "crit message",
       {}
     )
     expect(client.extension.log).toHaveBeenCalledWith(
       "groupname",
       6,
-      0,
+      3,
       "error message",
       {}
     )
     expect(client.extension.log).toHaveBeenCalledWith(
       "groupname",
       5,
-      0,
+      3,
       "warning message",
       {}
     )
     expect(client.extension.log).toHaveBeenCalledWith(
       "groupname",
       4,
-      0,
+      3,
       "notice message",
       {}
     )
     expect(client.extension.log).toHaveBeenCalledWith(
       "groupname",
       3,
-      0,
+      3,
       "info message",
       {}
     )
     expect(client.extension.log).toHaveBeenCalledWith(
       "groupname",
       2,
-      0,
+      3,
       "debug message",
       {}
     )

--- a/src/client.ts
+++ b/src/client.ts
@@ -144,7 +144,7 @@ export class Client {
   static logger(
     group: string,
     level: LoggerLevel = "info",
-    format: LoggerFormat = "plaintext"
+    format: LoggerFormat = "autodetect"
   ): Logger {
     if (this.client) {
       return this.client.logger(group, level, format)

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -19,12 +19,13 @@ function severity(level: LoggerLevel) {
   return LOGGER_LEVEL_SEVERITY[level] ?? UNKNOWN_SEVERITY
 }
 
-export type LoggerFormat = "plaintext" | "logfmt" | "json"
+export type LoggerFormat = "plaintext" | "logfmt" | "json" | "autodetect"
 
 export const LOGGER_FORMAT: Record<LoggerFormat, number> = {
   plaintext: 0,
   logfmt: 1,
-  json: 2
+  json: 2,
+  autodetect: 3
 }
 
 const UNKNOWN_FORMAT = -1
@@ -52,7 +53,7 @@ export class BaseLogger implements Logger {
     client: Client,
     group: string,
     level: LoggerLevel = "info",
-    format: LoggerFormat = "plaintext"
+    format: LoggerFormat = "autodetect"
   ) {
     if (typeof group != "string") {
       throw new TypeError(
@@ -75,10 +76,10 @@ export class BaseLogger implements Logger {
 
     if (this.format == UNKNOWN_FORMAT) {
       this.#client.internalLogger.warn(
-        `Logger format must be "plaintext", "logfmt", or "json", ` +
-          `but "${format}" was given. Logger format set to "plaintext".`
+        `Logger format must be "plaintext", "logfmt", "json", or "autodetect", ` +
+          `but "${format}" was given. Logger format set to "autodetect".`
       )
-      this.format = 0
+      this.format = 3
     }
   }
 

--- a/src/pino_transport.ts
+++ b/src/pino_transport.ts
@@ -30,7 +30,7 @@ async function sendLogs(extension: Extension, group: string, data: LogData) {
   extension.log(
     group,
     data.severity,
-    LOGGER_FORMAT.plaintext,
+    LOGGER_FORMAT.autodetect,
     data.message,
     data.attributes
   )

--- a/src/winston_transport.ts
+++ b/src/winston_transport.ts
@@ -1,6 +1,9 @@
 import Transport, { TransportStreamOptions } from "winston-transport"
 import { Client } from "./client"
-import { LOGGER_LEVEL_SEVERITY as RUST_LOGGER_LEVEL_SECURITY } from "./logger"
+import {
+  LOGGER_LEVEL_SEVERITY as RUST_LOGGER_LEVEL_SECURITY,
+  LOGGER_FORMAT
+} from "./logger"
 
 const NPM_LOGGER_LEVEL_SEVERITY = {
   error: 6,
@@ -76,7 +79,7 @@ export class WinstonTransport extends Transport {
     client.extension.log(
       group || this.#group,
       levelSeverity,
-      0,
+      LOGGER_FORMAT.autodetect,
       message,
       attributes
     )


### PR DESCRIPTION
Change the default log format from 'plaintext' to 'autodetect'. Our processor will automatically try to detect the correct log format, which should create a better experience than the default being plaintext.

Part of https://github.com/appsignal/integration-guide/issues/174