### PR TITLE
Handle `pino` logs with undefined message

### DIFF
--- a/.changesets/handle-pino-logs-with-no-message.md
+++ b/.changesets/handle-pino-logs-with-no-message.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: fix
+---
+
+Handle `pino` logs without a `msg` attribute.

--- a/src/__tests__/pino_transport.test.ts
+++ b/src/__tests__/pino_transport.test.ts
@@ -1,0 +1,36 @@
+const pinoTransport = require("../pino_transport")
+const { Extension } = require("../extension")
+
+jest.mock("../extension")
+
+describe("pino transport", () => {
+  it("handles undefined message", async () => {
+    const extensionMock = {
+      log: jest.fn()
+    }
+
+    Extension.mockImplementation(() => extensionMock)
+
+    const transport = pinoTransport({ group: "test" })
+
+    const done = new Promise((resolve, reject) => {
+      transport.on("finish", resolve)
+      transport.on("error", reject)
+    })
+
+    transport.write('{"level":30,"foo":"bar"}\n')
+    transport.end()
+
+    await done
+
+    await new Promise(r => setTimeout(r, 1000))
+
+    expect(extensionMock.log).toHaveBeenCalledWith(
+      "test",
+      expect.any(Number),
+      expect.any(Number),
+      "",
+      { foo: "bar" }
+    )
+  })
+})

--- a/src/pino_transport.ts
+++ b/src/pino_transport.ts
@@ -36,8 +36,12 @@ async function sendLogs(extension: Extension, group: string, data: LogData) {
   )
 }
 
-function parseInfo(obj: Record<string, any>): LogData {
-  const { level, msg, ...attributes } = obj
+function parseInfo(obj: {
+  level?: number
+  msg?: string
+  [key: string]: unknown
+}): LogData {
+  const { level = 0, msg = "", ...attributes } = obj
 
   return {
     severity: getSeverity(level),


### PR DESCRIPTION
Pino allows calling log methods (`logger.info`, `logger.error`, etc.) without a message. Some frameworks emit message-less logs during initialization. This breaks our current `pino_transport`, resulting in a fatal error from the `Extension.log` method, which expects `message` to be `string`. See #1244 for more context.

This change updates the type signature of `parseInfo` function to a narrower set of types and handles the missing `msg` attribute. It also adds a test for this specific case. 

Unlike `winston` transport, `pino` uses a separate worker thread for the transport. To allow mocking the `Extension`, the test initializes transport in the main thread and manually passes messages to it via `transport.write(...)`.

Fixes #1244.