### PR TITLE
Require parent span on DB/HTTP instrumentations

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -325,10 +325,12 @@ export class Client {
       "@opentelemetry/instrumentation-http": {
         headersToSpanAttributes: {
           server: { requestHeaders }
-        }
+        },
+        requireParentforOutgoingSpans: true
       },
       "@opentelemetry/instrumentation-ioredis": {
-        dbStatementSerializer: RedisDbStatementSerializer
+        dbStatementSerializer: RedisDbStatementSerializer,
+        requireParentSpan: true
       },
       "@opentelemetry/instrumentation-koa": {
         requestHook: function (span, info) {
@@ -338,11 +340,19 @@ export class Client {
           }
         }
       },
+      "@opentelemetry/instrumentation-mongoose": {
+        requireParentSpan: true
+      },
+      "@opentelemetry/instrumentation-pg": {
+        requireParentSpan: true
+      },
       "@opentelemetry/instrumentation-redis": {
-        dbStatementSerializer: RedisDbStatementSerializer
+        dbStatementSerializer: RedisDbStatementSerializer,
+        requireParentSpan: true
       },
       "@opentelemetry/instrumentation-redis-4": {
-        dbStatementSerializer: RedisDbStatementSerializer
+        dbStatementSerializer: RedisDbStatementSerializer,
+        requireParentSpan: true
       },
       "@opentelemetry/instrumentation-restify": {
         requestHook: (span, info) => {


### PR DESCRIPTION
Derived from a customer call.

When an instrumentation produces spans that should take place within a broader instrumented context, such as spans for database queries or for HTTP outgoing requests, configure the instrumentation to only emit spans if a parent span is active, if such configuration option exists.

This prevents those spans from showing up as independent actions, increasing the requests quota for misconfigured applications.