### PR TITLE
Fix Express Mongoose test description

### DIFF
--- a/test/express-mongoose/tests/spec/app_spec.rb
+++ b/test/express-mongoose/tests/spec/app_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "Prisma app" do
+RSpec.describe "Express Mongoose app" do
   before(:all) do
     @test_app_url = ConfigHelper.test_app_url
   end


### PR DESCRIPTION
## Summary
Fixes the Express Mongoose integration test description, which incorrectly referred to the app as "Prisma app".

## Testing
- `docker compose up --build` in `test/express-mongoose`