### PR TITLE
Fix Prisma integration test descriptions

### DIFF
--- a/test/express-prisma-mongo/tests/spec/app_spec.rb
+++ b/test/express-prisma-mongo/tests/spec/app_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "Prisma app" do
+RSpec.describe "Express Prisma Mongo app" do
   before(:all) do
     @test_app_url = ConfigHelper.test_app_url
   end

--- a/test/express-prisma-postgres/tests/spec/app_spec.rb
+++ b/test/express-prisma-postgres/tests/spec/app_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "Prisma app" do
+RSpec.describe "Express Prisma Postgres app" do
   before(:all) do
     @test_app_url = ConfigHelper.test_app_url
   end


### PR DESCRIPTION
## Summary

Fix the top-level RSpec descriptions for the Prisma integration tests so they match the actual test fixtures:

- `express-prisma-mongo` -> `Express Prisma Mongo app`
- `express-prisma-postgres` -> `Express Prisma Postgres app`

## Testing

- Not run