### PR TITLE
Clear stale private config environment variables

### DIFF
--- a/.changesets/clear-stale-private-env.md
+++ b/.changesets/clear-stale-private-env.md
@@ -1,0 +1,7 @@
+---
+bump: patch
+type: fix
+integrations: all
+---
+
+Clear stale private environment variables when later configurations omit them.

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -392,6 +392,24 @@ describe("Configuration", () => {
       expect(env("_APPSIGNAL_APP_PATH")).toEqual(process.cwd())
     })
 
+    it("clears private env values when a later config omits them", () => {
+      new Configuration({
+        name,
+        active: true,
+        pushApiKey
+      })
+
+      expect(env("_APPSIGNAL_APP_NAME")).toEqual(name)
+
+      config = new Configuration({
+        active: true,
+        pushApiKey
+      })
+
+      expect(config.data.name).toBeUndefined()
+      expect(env("_APPSIGNAL_APP_NAME")).toBeUndefined()
+    })
+
     describe("with config options set to non-default values", () => {
       beforeEach(() => {
         jest.spyOn(fs, "accessSync").mockImplementation(() => {})

--- a/src/config.ts
+++ b/src/config.ts
@@ -250,6 +250,8 @@ export class Configuration {
     const logFilePath = this.logFilePath
     if (logFilePath) {
       process.env["_APPSIGNAL_LOG_FILE_PATH"] = logFilePath
+    } else {
+      delete process.env["_APPSIGNAL_LOG_FILE_PATH"]
     }
 
     // write to a "private" environment variable if it exists in the
@@ -257,13 +259,19 @@ export class Configuration {
     Object.entries(PRIVATE_ENV_MAPPING).forEach(([k, v]) => {
       const current = config[v]
 
-      if (current && Array.isArray(current)) {
-        if (current.length === 0) return
+      if (Array.isArray(current)) {
+        if (current.length === 0) {
+          delete process.env[k]
+          return
+        }
         process.env[k] = current.join(",")
+        return
       }
 
       if (current || typeof current === "boolean") {
         process.env[k] = String(current)
+      } else {
+        delete process.env[k]
       }
     })
   }


### PR DESCRIPTION
## Summary

Fix an issue where private AppSignal environment variables could keep stale values when a later configuration omits them.

`Configuration#writePrivateConfig` writes internal `_APPSIGNAL_*` environment variables from the merged config. Before this change, it only updated values when a current value existed, but it did not clear previously written values when a later configuration no longer provided them.

This could leave old private env vars behind across repeated initializations in the same process.

## What changed

- Clear mapped private `_APPSIGNAL_*` environment variables when the current merged config no longer has a value for them
- Clear `_APPSIGNAL_LOG_FILE_PATH` when no current log file path is resolved
- Add a regression test covering repeated initialization where the first config sets `name` and the second config omits it

## Reproduction

Before this change, this kind of sequence could leave stale state behind:

1. Initialize AppSignal with a config that sets `name`
2. Initialize AppSignal again in the same process with a valid partial config that omits `name`
3. `config.data.name` is `undefined` on the second config, but `_APPSIGNAL_APP_NAME` still keeps the old value

The new test covers this behavior and verifies the stale private env var is cleared.

## Testing

- `npx jest src/__tests__/config.test.ts --runInBand -t "clears private env values when a later config omits them"`
- `npx jest src/__tests__/config.test.ts --runInBand`