### PR TITLE
Ensure sendError closes spans when callbacks throw

### DIFF
--- a/.changesets/fix-send-error-callback-span.md
+++ b/.changesets/fix-send-error-callback-span.md
@@ -1,0 +1,7 @@
+---
+bump: patch
+type: fix
+integrations: all
+---
+
+Ensure `sendError` ends its span even when the callback throws.

--- a/src/__tests__/helpers.test.ts
+++ b/src/__tests__/helpers.test.ts
@@ -219,6 +219,31 @@ describe("Helpers", () => {
       })
     })
 
+    it("still ends the error span if the callback throws", () => {
+      let callbackError: Error | undefined
+
+      try {
+        throwError()
+      } catch (err) {
+        try {
+          sendError(err as Error, () => {
+            throw new Error("Callback failure")
+          })
+        } catch (callbackThrownError) {
+          callbackError = callbackThrownError as Error
+        }
+      }
+
+      expect(callbackError).toMatchObject({
+        message: "Callback failure"
+      })
+
+      expect(spans.length).toEqual(1)
+      expect(spans[0].name).toEqual("Error")
+      expect(spans[0].events.length).toEqual(1)
+      expectErrorEvent(spans[0].events[0])
+    })
+
     it("logs a debug warning when the value is not an error", () => {
       const debugMock = jest.spyOn(Client.internalLogger, "debug")
 

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -123,8 +123,11 @@ export function sendError(error: Error, fn: () => void = () => {}) {
       .getTracer("Appsignal.sendError")
       .startActiveSpan(error.name, { root: true }, span => {
         setError(error)
-        fn()
-        span.end()
+        try {
+          fn()
+        } finally {
+          span.end()
+        }
       })
   } else {
     Client.internalLogger.debug(


### PR DESCRIPTION
## Summary

Fix an issue where `sendError(error, fn)` could leave the created error span unfinished if the callback threw.

Before this change, `sendError` recorded the error, ran the callback, and only then ended the span. If the callback threw while attaching extra data, `span.end()` was never reached, so the error span could be lost.

## What changed

* Wrap the `sendError` callback execution in `try/finally`
* Always call `span.end()`, even if the callback throws
* Add a regression test covering the callback-throws case

## Reproduction

Before this change, a flow like this could leave the error span unfinished:

```ts
try {
  throw new Error("Boom")
} catch (err) {
  sendError(err as Error, () => {
    throw new Error("Callback failure")
  })
}
```

In that case, the callback error would bubble out, but the created error span would never be ended.

## Testing

```bash
npx jest src/__tests__/helpers.test.ts --runInBand -t "still ends the error span if the callback throws"

npx jest src/__tests__/helpers.test.ts --runInBand
```