### PR TITLE
fix: handle BigInt serialization in helper functions

### DIFF
--- a/.changesets/fix-bigint-serialization.md
+++ b/.changesets/fix-bigint-serialization.md
@@ -1,0 +1,7 @@
+---
+bump: patch
+type: fix
+integrations: all
+---
+
+Fix BigInt serialization crash in helper functions. BigInt values passed to `setCustomData`, `setParams`, or `setSessionData` no longer throw a TypeError.

--- a/src/__tests__/helpers.test.ts
+++ b/src/__tests__/helpers.test.ts
@@ -125,6 +125,18 @@ describe("Helpers", () => {
     })
   })
 
+  it("handles BigInt values without throwing a TypeError", () => {
+    trace.getTracer("test").startActiveSpan("Some span", span => {
+      setCustomData({ userId: BigInt("123456789012345678") })
+      span.end()
+    })
+
+    expect(spans.length).toEqual(1)
+    expect(spans[0].attributes).toMatchObject({
+      "appsignal.custom_data": '{"userId":"123456789012345678"}'
+    })
+  })
+
   it("logs a debug warning when there is no active span", () => {
     const warnMock = jest.spyOn(Client.internalLogger, "warn")
 

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -20,6 +20,10 @@ function circularReplacer() {
   const seenValue: any[] = []
   const seenKey: string[] = []
   return (key: string, value: any) => {
+    if (typeof value === "bigint") {
+      return value.toString()
+    }
+
     if (typeof value === "object" && value !== null) {
       const i = seenValue.indexOf(value)
       if (i !== -1) {


### PR DESCRIPTION
## Summary

Fix an issue where serializing objects containing `BigInt` values crashed the host application with a `TypeError: Do not know how to serialize a BigInt`.

Before this change, helper functions like `setCustomData`, `setParams`, or `setSessionData` (which use `JSON.stringify` internally via `setSerialisedAttribute`) would crash if any property in the object was a `BigInt` because `JSON.stringify` does not natively support `BigInt` serialization.

## What changed

- Check for `bigint` type in `circularReplacer` inside `src/helpers.ts` and return its string representation using `.toString()`
- Add a regression test to `src/__tests__/helpers.test.ts` to cover objects containing `BigInt` values
- Create a patch changeset to document the fix in the changelog

## Reproduction

Before this change, a flow like this would crash the application with a `TypeError`:

```javascript
const Appsignal = require("@appsignal/nodejs");

const client = new Appsignal.Client({
  active: true,
  pushApiKey: "TEST"
});

// This throws: TypeError: Do not know how to serialize a BigInt
client.setCustomData({
  userId: BigInt("123456789012345678")
});
```

## Testing

```bash
npx jest src/__tests__/helpers.test.ts -t "handles BigInt values without throwing a TypeError"

npx jest src/__tests__/helpers.test.ts
```