### PR TITLE
Tidy up the OpenTelemetry dependencies and propagators

### DIFF
--- a/.changesets/stop-sending-b3-trace-context-headers.md
+++ b/.changesets/stop-sending-b3-trace-context-headers.md
@@ -1,0 +1,8 @@
+---
+bump: patch
+type: fix
+---
+
+Do not emit B3 trace context propagation headers. If you relied on AppSignal to
+send the trace context in the `b3` or `x-b3-*` headers, you can configure that
+yourself by passing your own `textMapPropagator` to the OpenTelemetry SDK.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,22 @@ updates:
       interval: "weekly"
     exclude-paths:
       - "test/**"
+    # Move our version bounds up rather than widening them. The default for a
+    # library is to widen, which turns a bound like `>= 0.213.0 < 0.214.0` into
+    # `>= 0.213.0 < 0.222.0`. That defeats the reason those bounds are narrow:
+    # they exist so that all the OpenTelemetry packages released together
+    # resolve to one version of each, and a widened bound lets npm pick a
+    # different one for each dependent.
+    versioning-strategy: "increase"
+    groups:
+      # The OpenTelemetry packages have to move together, so propose them as one
+      # update. Separately they produce a pull request per package, each of which
+      # leaves the others behind.
+      opentelemetry:
+        patterns:
+          - "@opentelemetry/*"
+          - "@appsignal/opentelemetry-instrumentation-*"
+          - "@prisma/instrumentation"
     ignore:
       - dependency-name: "*"
         # Ignore patch updates

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,19 @@ jobs:
       run: tmp/mono/bin/mono bootstrap
     - name: Node.js Lint (Prettier)
       run: npm run lint
+  check-otel-resolution:
+    name: OpenTelemetry resolution check
+    needs: validation
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout project
+      uses: actions/checkout@v4
+    - name: Install Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: 22
+    - name: Check that one copy of @opentelemetry/api is resolved
+      run: node scripts/check_otel_resolution.js
   integration-tests:
     name: Integration tests (${{matrix.name}})
     needs: validation

--- a/build_matrix.yml
+++ b/build_matrix.yml
@@ -92,6 +92,22 @@ github: # Default `.github/workflows/ci.yml` contents
         - name: "Node.js Lint (Prettier)"
           run: npm run lint
 
+    check-otel-resolution:
+      name: OpenTelemetry resolution check
+      needs: validation
+      runs-on: ubuntu-latest
+      steps:
+        - name: "Checkout project"
+          uses: actions/checkout@v4
+
+        - name: "Install Node.js"
+          uses: actions/setup-node@v4
+          with:
+            node-version: 22
+
+        - name: "Check that one copy of @opentelemetry/api is resolved"
+          run: node scripts/check_otel_resolution.js
+
     integration-tests:
       name: Integration tests (${{matrix.name}})
       needs: validation

--- a/global.d.ts
+++ b/global.d.ts
@@ -3,5 +3,4 @@ import { Client } from "./src/client"
 declare global {
   // eslint-disable-next-line no-var
   var __APPSIGNAL__: Client
-  type BlobPropertyBag = unknown
 }

--- a/scripts/check_otel_resolution.js
+++ b/scripts/check_otel_resolution.js
@@ -1,0 +1,167 @@
+// Checks that a project depending on this package resolves exactly one copy of
+// `@opentelemetry/api`.
+//
+// More than one copy is not a warning, it is a silent failure. The OpenTelemetry
+// API stores its global tracer provider on `globalThis`, keyed by major version,
+// and a copy of the API only reads that global when its own minor version is
+// less than or equal to the minor version that wrote it. So when the integration
+// registers the provider from an older copy than the one an instrumentation
+// reads from, that instrumentation is handed a tracer that does nothing and
+// drops every span it creates. Nothing is logged when this happens, which is why
+// it needs a check rather than a test.
+//
+// The check installs into a throwaway project with a throwaway npm cache. A warm
+// cache can hide a resolution that a customer installing from scratch would get,
+// and the resolution that matters is the one a customer gets, not the one our own
+// `package-lock.json` pins.
+//
+// Copies of other OpenTelemetry packages are reported but do not fail the check.
+// Two copies of those are wasteful rather than broken, because the API package is
+// the only one that shares state between copies through a version-checked global.
+
+"use strict"
+
+const { execFileSync } = require("child_process")
+const fs = require("fs")
+const os = require("os")
+const path = require("path")
+
+const repoRoot = path.resolve(__dirname, "..")
+
+function run(command, args, options) {
+  return execFileSync(command, args, { encoding: "utf8", ...options })
+}
+
+// Walks the installed tree rather than reading `package-lock.json`, so that what
+// is reported is what Node would actually resolve at runtime.
+function findPackages(root) {
+  const found = new Map()
+
+  function walk(dir) {
+    let entries
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true })
+    } catch {
+      return
+    }
+
+    for (const entry of entries) {
+      if (!entry.isDirectory() && !entry.isSymbolicLink()) continue
+
+      const full = path.join(dir, entry.name)
+      const manifest = path.join(full, "package.json")
+
+      if (fs.existsSync(manifest)) {
+        let parsed
+        try {
+          parsed = JSON.parse(fs.readFileSync(manifest, "utf8"))
+        } catch {
+          parsed = null
+        }
+
+        if (parsed && parsed.name && parsed.version) {
+          if (!found.has(parsed.name)) found.set(parsed.name, [])
+          found.get(parsed.name).push({
+            version: parsed.version,
+            path: path.relative(root, full)
+          })
+        }
+      }
+
+      if (entry.name === "node_modules" || entry.name.startsWith("@")) {
+        walk(full)
+      } else {
+        const nested = path.join(full, "node_modules")
+        if (fs.existsSync(nested)) walk(nested)
+      }
+    }
+  }
+
+  walk(path.join(root, "node_modules"))
+  return found
+}
+
+const work = fs.mkdtempSync(path.join(os.tmpdir(), "otel-resolution-"))
+const cache = fs.mkdtempSync(path.join(os.tmpdir(), "otel-resolution-cache-"))
+
+// A full OpenTelemetry tree and its cache are not small, and this runs on every
+// push, so leaving them behind adds up on a machine that is not a fresh runner.
+function cleanUp() {
+  for (const directory of [work, cache]) {
+    fs.rmSync(directory, { recursive: true, force: true })
+  }
+}
+
+process.on("exit", cleanUp)
+
+// Node does not emit `exit` when it is signalled, and a cancelled CI job or an
+// interrupted local run are the times the directories are largest.
+for (const signal of ["SIGINT", "SIGTERM"]) {
+  process.on(signal, () => {
+    cleanUp()
+    process.exit(1)
+  })
+}
+
+console.log("Packing the integration")
+const packed = run("npm", ["pack", "--pack-destination", work], {
+  cwd: repoRoot
+})
+const tarball = packed.trim().split("\n").pop()
+
+fs.writeFileSync(
+  path.join(work, "package.json"),
+  JSON.stringify(
+    {
+      name: "otel-resolution-probe",
+      version: "1.0.0",
+      private: true,
+      dependencies: { "@appsignal/nodejs": `file:${path.join(work, tarball)}` }
+    },
+    null,
+    2
+  )
+)
+
+console.log("Installing it into a throwaway project with an empty npm cache")
+run(
+  "npm",
+  ["install", "--ignore-scripts", "--no-audit", "--no-fund", "--cache", cache],
+  { cwd: work, stdio: "inherit" }
+)
+
+const packages = findPackages(work)
+
+const apiCopies = packages.get("@opentelemetry/api") || []
+console.log(`\n@opentelemetry/api copies: ${apiCopies.length}`)
+for (const copy of apiCopies) console.log(`  ${copy.version}  ${copy.path}`)
+
+console.log("\nOther OpenTelemetry packages resolved to more than one version:")
+let duplicates = 0
+for (const [name, copies] of [...packages.entries()].sort()) {
+  if (name === "@opentelemetry/api") continue
+  if (!name.startsWith("@opentelemetry/")) continue
+
+  const versions = [...new Set(copies.map(copy => copy.version))].sort()
+  if (versions.length < 2) continue
+
+  duplicates += 1
+  console.log(`  ${name} ${versions.join(", ")}`)
+}
+if (duplicates === 0) console.log("  none")
+
+if (apiCopies.length !== 1) {
+  console.error(
+    `\nExpected exactly one copy of @opentelemetry/api, found ${apiCopies.length}.`
+  )
+  console.error(
+    "Adjust the version bounds in package.json until npm resolves a single " +
+      "copy. Widening the @opentelemetry/api bound usually helps more than " +
+      "narrowing it, because every OpenTelemetry package depends on the API as " +
+      "a peer dependency, and a wider bound is what lets npm share one copy " +
+      "with the application."
+  )
+  process.exit(1)
+}
+
+console.log("\nOK")

--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -7,6 +7,12 @@ import { Client } from "../client"
 import { Metrics } from "../metrics"
 import { NoopInternalLogger, NoopLogger, NoopMetrics } from "../noops"
 import { Instrumentation } from "@opentelemetry/instrumentation"
+import {
+  propagation,
+  trace,
+  ROOT_CONTEXT,
+  TraceFlags
+} from "@opentelemetry/api"
 import { BaseInternalLogger } from "../internal_logger"
 import { BaseLogger } from "../logger"
 
@@ -31,6 +37,31 @@ describe("Client", () => {
     const startSpy = jest.spyOn(Extension.prototype, "start")
     client = new Client({ ...DEFAULT_OPTS, active: true })
     expect(startSpy).toHaveBeenCalled()
+  })
+
+  it("propagates baggage, and nothing else", () => {
+    client = new Client({ ...DEFAULT_OPTS, active: true })
+
+    const context = trace.setSpanContext(
+      propagation.setBaggage(
+        ROOT_CONTEXT,
+        propagation.createBaggage({ user_id: { value: "123" } })
+      ),
+      {
+        traceId: "d4cda95b652f4a1592b449d5929fda1b",
+        spanId: "6e0c63257de34c92",
+        traceFlags: TraceFlags.SAMPLED
+      }
+    )
+
+    const carrier: Record<string, string> = {}
+    propagation.inject(context, carrier)
+
+    // A trace context header here means two applications that both report to
+    // AppSignal can end up sharing a trace. `traceparent` was disabled on
+    // purpose; the B3 headers went on sending the trace context anyway, for a
+    // year, because they were configured by accident.
+    expect(Object.keys(carrier).sort()).toEqual(["baggage"])
   })
 
   it("stops the extension when the client is stopped", async () => {

--- a/src/client.ts
+++ b/src/client.ts
@@ -16,7 +16,6 @@ import {
   InstrumentType
 } from "@opentelemetry/sdk-metrics"
 import { CompositePropagator } from "@opentelemetry/core"
-import { B3Propagator, B3InjectEncoding } from "@opentelemetry/propagator-b3"
 import { W3CBaggagePropagator } from "@opentelemetry/core"
 import { OTLPMetricExporter } from "@opentelemetry/exporter-metrics-otlp-proto"
 
@@ -426,12 +425,11 @@ export class Client {
       instrumentations,
       spanProcessor,
       metricReader,
+      // Propagate baggage, but not the trace context. Two applications that
+      // both report to AppSignal must not end up sharing a trace, or the
+      // second one's data is reported against the first one's application.
       textMapPropagator: new CompositePropagator({
-        propagators: [
-          new W3CBaggagePropagator(),
-          new B3Propagator(),
-          new B3Propagator({ injectEncoding: B3InjectEncoding.MULTI_HEADER })
-        ]
+        propagators: [new W3CBaggagePropagator()]
       })
     })
 

--- a/test/express-rabbitmq/app/package-lock.json
+++ b/test/express-rabbitmq/app/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@appsignal/nodejs": "^3.7.3",
-        "@opentelemetry/api": ">= 1.6.0 < 1.7",
+        "@opentelemetry/api": "^1.9.0",
         "amqplib": "^0.10.3",
         "cookie-parser": "^1.4.7",
         "express": "^4.22.1",
@@ -106,14 +106,6 @@
       },
       "engines": {
         "node": ">= 18"
-      }
-    },
-    "node_modules/@appsignal/nodejs/node_modules/@opentelemetry/api": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
-      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
-      "engines": {
-        "node": ">=8.0.0"
       }
     },
     "node_modules/@appsignal/nodejs/node_modules/@opentelemetry/api-logs": {
@@ -301,9 +293,11 @@
       }
     },
     "node_modules/@opentelemetry/api": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.6.0.tgz",
-      "integrity": "sha512-OWlrQAnWn9577PhVgqjUvMr1pg57Bc4jv0iL4w0PRuOSRvq67rvHW9Ie/dZVMvCzhSCB+UxhcY/PmCmFj33Q+g==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -3220,6 +3214,7 @@
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4708,6 +4703,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5793,11 +5789,6 @@
         "winston": "^3.6.0"
       },
       "dependencies": {
-        "@opentelemetry/api": {
-          "version": "1.9.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
-          "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="
-        },
         "@opentelemetry/api-logs": {
           "version": "0.53.0",
           "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.53.0.tgz",
@@ -5931,9 +5922,10 @@
       }
     },
     "@opentelemetry/api": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.6.0.tgz",
-      "integrity": "sha512-OWlrQAnWn9577PhVgqjUvMr1pg57Bc4jv0iL4w0PRuOSRvq67rvHW9Ie/dZVMvCzhSCB+UxhcY/PmCmFj33Q+g=="
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "peer": true
     },
     "@opentelemetry/api-logs": {
       "version": "0.52.1",
@@ -7953,7 +7945,8 @@
     "acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg=="
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "peer": true
     },
     "acorn-import-attributes": {
       "version": "1.9.5",
@@ -9073,7 +9066,8 @@
     "picomatch": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "peer": true
     },
     "pino-abstract-transport": {
       "version": "2.0.0",

--- a/test/express-rabbitmq/app/package.json
+++ b/test/express-rabbitmq/app/package.json
@@ -13,7 +13,7 @@
   "license": "ISC",
   "dependencies": {
     "@appsignal/nodejs": "^3.7.3",
-    "@opentelemetry/api": ">= 1.6.0 < 1.7",
+    "@opentelemetry/api": "^1.9.0",
     "amqplib": "^0.10.3",
     "cookie-parser": "^1.4.7",
     "express": "^4.22.1",

--- a/test/express-redis/app/package-lock.json
+++ b/test/express-redis/app/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@appsignal/nodejs": "^3.7.3",
-        "@opentelemetry/api": ">= 1.6.0 < 1.7",
+        "@opentelemetry/api": "^1.9.0",
         "cookie-parser": "^1.4.7",
         "express": "^4.22.1",
         "ioredis": "^4.28.5",
@@ -68,14 +68,6 @@
       },
       "engines": {
         "node": ">= 18"
-      }
-    },
-    "node_modules/@appsignal/nodejs/node_modules/@opentelemetry/api": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
-      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
-      "engines": {
-        "node": ">=8.0.0"
       }
     },
     "node_modules/@appsignal/nodejs/node_modules/@opentelemetry/api-logs": {
@@ -263,9 +255,11 @@
       }
     },
     "node_modules/@opentelemetry/api": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.6.0.tgz",
-      "integrity": "sha512-OWlrQAnWn9577PhVgqjUvMr1pg57Bc4jv0iL4w0PRuOSRvq67rvHW9Ie/dZVMvCzhSCB+UxhcY/PmCmFj33Q+g==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -3023,6 +3017,7 @@
       "version": "1.5.12",
       "resolved": "https://registry.npmjs.org/@redis/client/-/client-1.5.12.tgz",
       "integrity": "sha512-/ZjE18HRzMd80eXIIUIPcH81UoZpwulbo8FmbElrjPqH0QC0SeIKu1BOU49bO5trM5g895kAjhvalt5h77q+4A==",
+      "peer": true,
       "dependencies": {
         "cluster-key-slot": "1.1.2",
         "generic-pool": "3.9.0",
@@ -3235,6 +3230,7 @@
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4784,6 +4780,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5895,11 +5892,6 @@
         "winston": "^3.6.0"
       },
       "dependencies": {
-        "@opentelemetry/api": {
-          "version": "1.9.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
-          "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="
-        },
         "@opentelemetry/api-logs": {
           "version": "0.53.0",
           "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.53.0.tgz",
@@ -6033,9 +6025,10 @@
       }
     },
     "@opentelemetry/api": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.6.0.tgz",
-      "integrity": "sha512-OWlrQAnWn9577PhVgqjUvMr1pg57Bc4jv0iL4w0PRuOSRvq67rvHW9Ie/dZVMvCzhSCB+UxhcY/PmCmFj33Q+g=="
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "peer": true
     },
     "@opentelemetry/api-logs": {
       "version": "0.52.1",
@@ -7901,6 +7894,7 @@
       "version": "1.5.12",
       "resolved": "https://registry.npmjs.org/@redis/client/-/client-1.5.12.tgz",
       "integrity": "sha512-/ZjE18HRzMd80eXIIUIPcH81UoZpwulbo8FmbElrjPqH0QC0SeIKu1BOU49bO5trM5g895kAjhvalt5h77q+4A==",
+      "peer": true,
       "requires": {
         "cluster-key-slot": "1.1.2",
         "generic-pool": "3.9.0",
@@ -8095,7 +8089,8 @@
     "acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg=="
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "peer": true
     },
     "acorn-import-attributes": {
       "version": "1.9.5",
@@ -9245,7 +9240,8 @@
     "picomatch": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "peer": true
     },
     "pino-abstract-transport": {
       "version": "2.0.0",

--- a/test/express-redis/app/package.json
+++ b/test/express-redis/app/package.json
@@ -12,7 +12,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@opentelemetry/api": ">= 1.6.0 < 1.7",
+    "@opentelemetry/api": "^1.9.0",
     "@appsignal/nodejs": "^3.7.3",
     "cookie-parser": "^1.4.7",
     "express": "^4.22.1",


### PR DESCRIPTION
### [Remove the global `BlobPropertyBag` declaration](https://github.com/appsignal/appsignal-nodejs/commit/bf6d15cea811c5302b50cf0477b3a9a2920d767b)

The declaration stood in for a DOM type the `undici` typings in
`@types/node` no longer refer to. From `@types/node` 25 it breaks the
build, because that version declares `BlobPropertyBag` itself and
TypeScript reports the two as a conflict. The committed lock file pins
`@types/node` 22, so only an install that resolves versions afresh runs
into it.

### [Stop sending the trace context in B3 headers](https://github.com/appsignal/appsignal-nodejs/commit/3c70393ad34b1a608862a906cef172fdc7cc8f70)

Two applications that both report to AppSignal join the same trace when
the trace context travels between them, and the second one's data is
reported against the first one's application. The B3 propagators were
sending it in the `b3` and `x-b3-*` headers. Baggage still propagates,
and the only loss is the span link between a BullMQ publish and the job
that processes it, which the agent does not read.

### [Update two test apps' `@opentelemetry/api` bound](https://github.com/appsignal/appsignal-nodejs/commit/20f9a27eec1034baf28ce7200095f38621265ff4)

`express-redis` and `express-rabbitmq` are the only test apps whose own
code creates spans, so they are the only ones that declare
`@opentelemetry/api` themselves, and their bound was still 1.6. Each
resolved one copy for itself and a second inside the linked integration.
Their spans arrived anyway, because an older copy of the API may read a
global registered by a newer one, so the wrong way round would have
failed both suites with no indication of why.

### [Check for duplicate `@opentelemetry/api` copies](https://github.com/appsignal/appsignal-nodejs/commit/ec6e87436f6a6a1657ce81abe14316a69df9f0b1)

Two copies of `@opentelemetry/api` in one project make the integration
report nothing and log nothing, because the API only reads its global
tracer provider from a copy whose version is compatible, and the copy
that loses is handed a tracer that discards every span. Whether that
happens is decided by npm's resolution rather than by anything in the
source, so the check installs the packed package into a throwaway
project with an empty npm cache: `npm link` and our own lock file both
change the answer, and a warm cache can serve a resolution a fresh
install would not pick.

### [Stop Dependabot from widening version ranges](https://github.com/appsignal/appsignal-nodejs/commit/a04fcdc339be3ba071024b3a5ddbd70e6d125ac0)

Dependabot widens the range for a library by default, so it turned the
`@opentelemetry/sdk-node` bound into `>= 0.213.0 < 0.219.0` and let npm
resolve a different `@opentelemetry/core` for `sdk-node` than for the
rest of the tree. These bounds are narrow so that packages released
together resolve to one version of each other, and they are grouped
because they are only correct as a set.

[skip changeset]
