### PR TITLE
Widen the `@opentelemetry/api` version bound

### DIFF
--- a/.changesets/widen-the-opentelemetry-api-version-bound.md
+++ b/.changesets/widen-the-opentelemetry-api-version-bound.md
@@ -1,0 +1,8 @@
+---
+bump: patch
+type: change
+---
+
+Allow any 1.x version of `@opentelemetry/api` from 1.9.0 onwards. This prevents
+an issue where npm installs a second copy of the package for AppSignal alone,
+which can stop spans from being reported without any error.

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "MIT",
       "dependencies": {
         "@appsignal/opentelemetry-instrumentation-bullmq": ">= 0.8.0 < 0.9.0",
-        "@opentelemetry/api": ">= 1.9.0 < 1.10.0",
+        "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/core": ">= 2.6.0 < 2.9.0",
         "@opentelemetry/exporter-metrics-otlp-proto": ">= 0.213.0 < 0.222.0",
         "@opentelemetry/instrumentation-amqplib": ">= 0.60.0 < 0.61.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@appsignal/opentelemetry-instrumentation-bullmq": ">= 0.8.0 < 0.9.0",
-    "@opentelemetry/api": ">= 1.9.0 < 1.10.0",
+    "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/core": ">= 2.6.0 < 2.9.0",
     "@opentelemetry/exporter-metrics-otlp-proto": ">= 0.213.0 < 0.222.0",
     "@opentelemetry/instrumentation-amqplib": ">= 0.60.0 < 0.61.0",


### PR DESCRIPTION
Stacked on #1495.

Every OpenTelemetry package depends on the API as a peer dependency and
none as a regular one, so the installed version is whatever they all
agree on, and a bound of ours can only narrow that agreement. It becomes
the binding one as soon as we move to an SDK release accepting a newer
API, and a bound left behind then nests a second copy in applications
that resolve the newer version, which the resolution check cannot see
because it installs this package on its own.

