### PR TITLE
Allow pino-abstract-transport v3

### DIFF
--- a/.changesets/support-pino-abstract-transport-v3.md
+++ b/.changesets/support-pino-abstract-transport-v3.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: fix
+---
+
+Add support for `pino-abstract-transport` v3.

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "@prisma/instrumentation": ">= 7.0.0 < 7.5.0",
         "node-addon-api": "^8.3.0",
         "node-gyp": "^11.1.0",
-        "pino-abstract-transport": "^2.0.0",
+        "pino-abstract-transport": "^2.0.0 || ^3.0.0",
         "tslib": "^2.8.0",
         "winston": "^3.6.0"
       },

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@prisma/instrumentation": ">= 7.0.0 < 7.5.0",
     "node-addon-api": "^8.3.0",
     "node-gyp": "^11.1.0",
-    "pino-abstract-transport": "^2.0.0",
+    "pino-abstract-transport": "^2.0.0 || ^3.0.0",
     "tslib": "^2.8.0",
     "winston": "^3.6.0"
   },


### PR DESCRIPTION
The v3 release only drops Node.js 18 from its test matrix and replaces
its test runner. The published `index.js` and `index.d.ts` are
byte-identical to v2, so the transport code works unchanged on both
majors.

This package supports Node.js 18, so raising the floor to v3 alone
would leave those users with no resolvable version. Accepting both
majors also lets everyone else share a single copy with the rest of
their dependency tree instead of installing a duplicate.