### PR TITLE
Run Next.js test app on Node.js 20

### DIFF
--- a/test/nextjs/app/Dockerfile
+++ b/test/nextjs/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18
+FROM node:20
 
 COPY run.sh /
 

--- a/test/nextjs/app/next.config.js
+++ b/test/nextjs/app/next.config.js
@@ -1,7 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  reactStrictMode: true,
-  swcMinify: true
+  reactStrictMode: true
 }
 
 module.exports = nextConfig


### PR DESCRIPTION
The test app was updated to Next.js 16, which requires Node.js 20.9.0
or newer. Its container still ran Node.js 18, so the app crashed on
startup with `features.toSorted is not a function` and the integration
test timed out waiting for it to come up.

Next.js 16 also removed the `swcMinify` option, which now logs an
invalid configuration warning.

[skip changeset]