### PR TITLE
Drop support for Node.js 18

### DIFF
--- a/.changesets/drop-support-for-node-js-18.md
+++ b/.changesets/drop-support-for-node-js-18.md
@@ -1,0 +1,7 @@
+---
+bump: minor
+type: remove
+---
+
+Drop support for Node.js 18. The minimum supported version is now Node.js
+20.6.0, which is what the bundled OpenTelemetry packages require.

--- a/.changesets/support-pino-abstract-transport-v3.md
+++ b/.changesets/support-pino-abstract-transport-v3.md
@@ -1,6 +1,0 @@
----
-bump: patch
-type: fix
----
-
-Add support for `pino-abstract-transport` v3.

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "@prisma/instrumentation": "^7.0.0",
         "node-addon-api": "^8.3.0",
         "node-gyp": "^11.1.0",
-        "pino-abstract-transport": "^2.0.0 || ^3.0.0",
+        "pino-abstract-transport": "^3.0.0",
         "tslib": "^2.8.0",
         "winston": "^3.6.0"
       },
@@ -65,7 +65,7 @@
         "typescript": "^5.7.0"
       },
       "engines": {
-        "node": ">= 18"
+        "node": ">= 20.6.0"
       }
     },
     "node_modules/@appsignal/opentelemetry-instrumentation-bullmq": {
@@ -9075,9 +9075,9 @@
       }
     },
     "node_modules/pino-abstract-transport": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-2.0.0.tgz",
-      "integrity": "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-3.0.0.tgz",
+      "integrity": "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==",
       "license": "MIT",
       "dependencies": {
         "split2": "^4.0.0"

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "lint:write": "eslint --fix ."
   },
   "engines": {
-    "node": ">= 18"
+    "node": ">= 20.6.0"
   },
   "publishConfig": {
     "access": "public"

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@prisma/instrumentation": "^7.0.0",
     "node-addon-api": "^8.3.0",
     "node-gyp": "^11.1.0",
-    "pino-abstract-transport": "^2.0.0 || ^3.0.0",
+    "pino-abstract-transport": "^3.0.0",
     "tslib": "^2.8.0",
     "winston": "^3.6.0"
   },

--- a/test/express-apollo/app/Dockerfile
+++ b/test/express-apollo/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18
+FROM node:20
 
 COPY run.sh /
 

--- a/test/express-knex/app/Dockerfile
+++ b/test/express-knex/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18
+FROM node:20
 
 COPY run.sh /
 

--- a/test/express-mongoose/app/Dockerfile
+++ b/test/express-mongoose/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18
+FROM node:20
 
 RUN apt-get update && apt-get install -y netcat-openbsd
 

--- a/test/express-postgres/app/Dockerfile
+++ b/test/express-postgres/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18
+FROM node:20
 
 COPY run.sh /
 

--- a/test/express-prisma-mongo/app/Dockerfile
+++ b/test/express-prisma-mongo/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18
+FROM node:20
 
 RUN apt-get update && apt-get install -y netcat-openbsd
 

--- a/test/express-prisma-postgres/app/Dockerfile
+++ b/test/express-prisma-postgres/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18
+FROM node:20
 
 RUN apt-get update && apt-get install -y postgresql-client
 

--- a/test/express-rabbitmq/app/Dockerfile
+++ b/test/express-rabbitmq/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18
+FROM node:20
 
 COPY run.sh /
 

--- a/test/express-redis/app/Dockerfile
+++ b/test/express-redis/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18
+FROM node:20
 
 COPY run.sh /
 

--- a/test/express-yoga/app/Dockerfile
+++ b/test/express-yoga/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18
+FROM node:20
 
 COPY run.sh /
 

--- a/test/fastify/app/Dockerfile
+++ b/test/fastify/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18
+FROM node:20
 
 COPY run.sh /
 

--- a/test/koa-mongo/app/Dockerfile
+++ b/test/koa-mongo/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18
+FROM node:20
 
 RUN apt-get update && apt-get install -y netcat-openbsd
 

--- a/test/koa-mysql/app/Dockerfile
+++ b/test/koa-mysql/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18
+FROM node:20
 
 COPY run.sh /
 

--- a/test/nestjs/app/Dockerfile
+++ b/test/nestjs/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18
+FROM node:20
 
 COPY run.sh /
 

--- a/test/restify/app/Dockerfile
+++ b/test/restify/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18
+FROM node:20
 
 COPY run.sh /
 


### PR DESCRIPTION
Stacked on #1497.

### [Drop support for Node.js 18](https://github.com/appsignal/appsignal-nodejs/commit/6759378b190f47b005646235751fca396e920f67)

Node.js 18 reached end of life in April 2025 and CI stopped testing it
in January 2026, while the `engines` range still claimed to support it.
The floor is 20.6.0 rather than 20 because that is what the bundled
OpenTelemetry packages require, and a plain `>= 20` would leave the same
silent gap between 20.0 and 20.5 that `>= 18` left below 18.19.

### [Require `pino-abstract-transport` v3](https://github.com/appsignal/appsignal-nodejs/commit/2d5f1cfb91e310105c8ab9c8ed958e1ffe3466e0)

Version 2 was in the accepted range only so that Node.js 18 users had a
resolvable version, and the floor is now 20.6.0. Accepting a single
major also lets npm share one copy with the rest of an application's
tree instead of installing a duplicate.

