### PR TITLE
Fail the check on unexplained duplicates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,17 +82,23 @@ jobs:
     - name: Node.js Lint (Prettier)
       run: npm run lint
   check-otel-resolution:
-    name: OpenTelemetry resolution check
+    name: OpenTelemetry resolution check (Node.js ${{matrix.nodejs}})
     needs: validation
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        nodejs:
+        - '20'
+        - '24'
     steps:
     - name: Checkout project
       uses: actions/checkout@v4
     - name: Install Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: 22
-    - name: Check that one copy of @opentelemetry/api is resolved
+        node-version: "${{matrix.nodejs}}"
+    - name: Check how the OpenTelemetry packages resolve
       run: node scripts/check_otel_resolution.js
   integration-tests:
     name: Integration tests (${{matrix.name}})

--- a/build_matrix.yml
+++ b/build_matrix.yml
@@ -93,9 +93,18 @@ github: # Default `.github/workflows/ci.yml` contents
           run: npm run lint
 
     check-otel-resolution:
-      name: OpenTelemetry resolution check
+      name: OpenTelemetry resolution check (Node.js ${{matrix.nodejs}})
       needs: validation
       runs-on: ubuntu-latest
+      strategy:
+        fail-fast: false
+        matrix:
+          # npm decides how the tree is laid out, and it is npm that differs
+          # between these two, not Node.js: 20 ships npm 10 and 24 ships npm 11.
+          # Peer dependency resolution changed between those majors, and
+          # `@opentelemetry/api` is a peer dependency of every OpenTelemetry
+          # package.
+          nodejs: ["20", "24"]
       steps:
         - name: "Checkout project"
           uses: actions/checkout@v4
@@ -103,9 +112,9 @@ github: # Default `.github/workflows/ci.yml` contents
         - name: "Install Node.js"
           uses: actions/setup-node@v4
           with:
-            node-version: 22
+            node-version: ${{matrix.nodejs}}
 
-        - name: "Check that one copy of @opentelemetry/api is resolved"
+        - name: "Check how the OpenTelemetry packages resolve"
           run: node scripts/check_otel_resolution.js
 
     integration-tests:

--- a/scripts/check_otel_duplicates.js
+++ b/scripts/check_otel_duplicates.js
@@ -1,0 +1,181 @@
+// Checks the OpenTelemetry packages installed in a project.
+//
+// Usage: check_otel_duplicates.js [project directory] [--api-only]
+//
+// Fails when the project resolves `@opentelemetry/api` at more than one major
+// and minor version, or more than one version of any other OpenTelemetry
+// package that `otel_duplicates_allowed.json` does not account for. Allowlist
+// entries that no longer match anything are reported too, so the file does not
+// accumulate reasons that have stopped being true.
+//
+// `--api-only` restricts the check to `@opentelemetry/api`, which is what the
+// test apps use: they link the integration rather than installing it, so their
+// tree is not a customer's, and only the API duplicate means anything there.
+//
+// This runs in our own CI and in our own test apps. It is deliberately not an
+// install hook in the published package: npm rolls back the whole install when
+// a lifecycle script fails, so a check that failed here would leave an
+// application with no dependencies at all.
+
+"use strict"
+
+const fs = require("fs")
+const path = require("path")
+
+const { findPackages, findDuplicates } = require("./otel_packages")
+
+const ALLOWED_PATH = path.join(__dirname, "otel_duplicates_allowed.json")
+const ALLOWED_NAME = path.basename(ALLOWED_PATH)
+
+// Carrying on without the allowlist would report every duplicate as one nobody
+// has accounted for, and tell whoever is reading to add entries to a file that
+// already has them.
+function readAllowlist() {
+  let parsed
+
+  try {
+    parsed = JSON.parse(fs.readFileSync(ALLOWED_PATH, "utf8"))
+  } catch (error) {
+    throw new Error(`Could not read ${ALLOWED_PATH}: ${error.message}`)
+  }
+
+  // Without this the shape only shows up later, as a TypeError that does not
+  // mention the file.
+  if (!Array.isArray(parsed)) {
+    throw new Error(`${ALLOWED_PATH} must contain an array of entries.`)
+  }
+
+  return parsed
+}
+
+// `quiet` suppresses the inventory and the allowlist maintenance warnings, so
+// that an install that resolved everything correctly prints nothing.
+function check(root, { quiet = false, apiOnly = false } = {}) {
+  const packages = findPackages(root)
+  // Only the full check consults the allowlist, so an unreadable file cannot
+  // print anything during someone else's install.
+  const allowlist = apiOnly ? [] : readAllowlist()
+
+  const problems = []
+  const matched = new Set()
+  const log = quiet ? () => {} : console.log
+
+  const apiCopies = packages.get("@opentelemetry/api") || []
+  // The API decides whether one copy can read another's global by major and
+  // minor version only, so copies that differ just in their patch version are
+  // interchangeable.
+  const apiVersions = [
+    ...new Set(
+      apiCopies.map(copy => copy.version.split(".").slice(0, 2).join("."))
+    )
+  ]
+  // The number of copies alone reads as a problem, and it is not one on its
+  // own: what decides that is how many versions those copies span.
+  const copies =
+    apiCopies.length === 1 ? "1 copy" : `${apiCopies.length} copies`
+  const versions =
+    apiVersions.length === 1 ? "1 version" : `${apiVersions.length} versions`
+  log(`@opentelemetry/api: ${copies}, ${versions}`)
+  for (const copy of apiCopies) log(`  ${copy.version}  ${copy.path}`)
+
+  // Copies of the same version are harmless, because the global the API keeps
+  // its tracer provider on is read whenever the versions are compatible, and a
+  // version is always compatible with itself. `npm link` produces such copies
+  // routinely, so counting copies rather than versions would report a problem
+  // every time.
+  // Nothing to compare means nothing is installed, and a project that cannot
+  // find the API at all reports no spans either.
+  if (apiCopies.length === 0) {
+    problems.push(
+      "No @opentelemetry/api is installed. Nothing here can report a span."
+    )
+  }
+
+  if (apiVersions.length > 1) {
+    // Never allowlisted. Every other duplicate wastes space; this one stops
+    // spans from being reported at all.
+    problems.push(
+      "More than one version of @opentelemetry/api is installed:\n" +
+        apiCopies.map(copy => `    ${copy.version}  ${copy.path}`).join("\n") +
+        "\n  A project resolving this tree has spans dropped with no error.\n" +
+        "  Adjust the `@opentelemetry/api` bound until npm resolves a single\n" +
+        "  copy. The versions above are what it resolved instead."
+    )
+  }
+
+  const duplicates = apiOnly
+    ? []
+    : findDuplicates(packages).filter(
+        duplicate => duplicate.name !== "@opentelemetry/api"
+      )
+
+  if (!apiOnly) {
+    log("\nOpenTelemetry packages resolved to more than one version:")
+    if (duplicates.length === 0) log("  none")
+  }
+
+  for (const duplicate of duplicates) {
+    log(`  ${duplicate.name} ${duplicate.versions.join(", ")}`)
+
+    for (const { version, causes } of duplicate.nested) {
+      const unexplained = causes.filter(cause => {
+        const entry = allowlist.find(
+          allowed =>
+            allowed.package === duplicate.name && allowed.cause === cause
+        )
+        if (entry) matched.add(entry)
+        return !entry
+      })
+
+      const status = unexplained.length === 0 ? "allowed" : "NOT ALLOWED"
+      log(`    ${version} nested in ${causes.join(", ")} (${status})`)
+
+      if (unexplained.length > 0) {
+        problems.push(
+          `${duplicate.name} resolves to ${version} inside ` +
+            `${unexplained.join(", ")}, and to ` +
+            `${duplicate.baseline || "another version"} elsewhere.\n` +
+            "  Move the version bounds until both agree, or add an entry to " +
+            `${ALLOWED_NAME} explaining why they cannot.`
+        )
+      }
+    }
+  }
+
+  if (!quiet && !apiOnly) {
+    for (const entry of allowlist) {
+      if (matched.has(entry)) continue
+
+      console.warn(
+        `\nWarning: ${entry.package} no longer resolves to a separate ` +
+          `version inside ${entry.cause}.\n  Remove that entry from ` +
+          `${ALLOWED_NAME}.`
+      )
+    }
+  }
+
+  if (problems.length === 0) {
+    log("\nOK")
+    return true
+  }
+
+  for (const problem of problems) console.error(`\n${problem}`)
+
+  return false
+}
+
+if (require.main === module) {
+  const args = process.argv.slice(2)
+  const apiOnly = args.includes("--api-only")
+  const root = args.find(arg => !arg.startsWith("--")) || process.cwd()
+
+  try {
+    process.exitCode = check(root, { apiOnly }) ? 0 : 1
+  } catch (error) {
+    // A stack trace says nothing here that the message does not.
+    console.error(error.message)
+    process.exitCode = 1
+  }
+}
+
+module.exports = { check }

--- a/scripts/check_otel_resolution.js
+++ b/scripts/check_otel_resolution.js
@@ -1,23 +1,14 @@
-// Checks that a project depending on this package resolves exactly one copy of
-// `@opentelemetry/api`.
+// Checks how a project that depends on this package resolves its OpenTelemetry
+// packages.
 //
-// More than one copy is not a warning, it is a silent failure. The OpenTelemetry
-// API stores its global tracer provider on `globalThis`, keyed by major version,
-// and a copy of the API only reads that global when its own minor version is
-// less than or equal to the minor version that wrote it. So when the integration
-// registers the provider from an older copy than the one an instrumentation
-// reads from, that instrumentation is handed a tracer that does nothing and
-// drops every span it creates. Nothing is logged when this happens, which is why
-// it needs a check rather than a test.
+// The resolution that matters is the one a customer gets, and that is not the
+// one in our own `node_modules`: `npm link` and our `package-lock.json` both
+// change the answer. So this packs the package and installs it into a throwaway
+// project with a throwaway npm cache. The empty cache matters too, because a
+// populated one can serve a resolution that a fresh install would not pick.
 //
-// The check installs into a throwaway project with a throwaway npm cache. A warm
-// cache can hide a resolution that a customer installing from scratch would get,
-// and the resolution that matters is the one a customer gets, not the one our own
-// `package-lock.json` pins.
-//
-// Copies of other OpenTelemetry packages are reported but do not fail the check.
-// Two copies of those are wasteful rather than broken, because the API package is
-// the only one that shares state between copies through a version-checked global.
+// What counts as a problem, and which duplicates are allowed, lives in
+// `check_otel_duplicates.js` and `otel_duplicates_allowed.json`.
 
 "use strict"
 
@@ -26,59 +17,12 @@ const fs = require("fs")
 const os = require("os")
 const path = require("path")
 
+const { check } = require("./check_otel_duplicates")
+
 const repoRoot = path.resolve(__dirname, "..")
 
 function run(command, args, options) {
   return execFileSync(command, args, { encoding: "utf8", ...options })
-}
-
-// Walks the installed tree rather than reading `package-lock.json`, so that what
-// is reported is what Node would actually resolve at runtime.
-function findPackages(root) {
-  const found = new Map()
-
-  function walk(dir) {
-    let entries
-    try {
-      entries = fs.readdirSync(dir, { withFileTypes: true })
-    } catch {
-      return
-    }
-
-    for (const entry of entries) {
-      if (!entry.isDirectory() && !entry.isSymbolicLink()) continue
-
-      const full = path.join(dir, entry.name)
-      const manifest = path.join(full, "package.json")
-
-      if (fs.existsSync(manifest)) {
-        let parsed
-        try {
-          parsed = JSON.parse(fs.readFileSync(manifest, "utf8"))
-        } catch {
-          parsed = null
-        }
-
-        if (parsed && parsed.name && parsed.version) {
-          if (!found.has(parsed.name)) found.set(parsed.name, [])
-          found.get(parsed.name).push({
-            version: parsed.version,
-            path: path.relative(root, full)
-          })
-        }
-      }
-
-      if (entry.name === "node_modules" || entry.name.startsWith("@")) {
-        walk(full)
-      } else {
-        const nested = path.join(full, "node_modules")
-        if (fs.existsSync(nested)) walk(nested)
-      }
-    }
-  }
-
-  walk(path.join(root, "node_modules"))
-  return found
 }
 
 const work = fs.mkdtempSync(path.join(os.tmpdir(), "otel-resolution-"))
@@ -130,38 +74,14 @@ run(
   { cwd: work, stdio: "inherit" }
 )
 
-const packages = findPackages(work)
+console.log()
 
-const apiCopies = packages.get("@opentelemetry/api") || []
-console.log(`\n@opentelemetry/api copies: ${apiCopies.length}`)
-for (const copy of apiCopies) console.log(`  ${copy.version}  ${copy.path}`)
-
-console.log("\nOther OpenTelemetry packages resolved to more than one version:")
-let duplicates = 0
-for (const [name, copies] of [...packages.entries()].sort()) {
-  if (name === "@opentelemetry/api") continue
-  if (!name.startsWith("@opentelemetry/")) continue
-
-  const versions = [...new Set(copies.map(copy => copy.version))].sort()
-  if (versions.length < 2) continue
-
-  duplicates += 1
-  console.log(`  ${name} ${versions.join(", ")}`)
+// Setting the code rather than calling `process.exit` lets Node drain stdout
+// first. Everything this script is for is in that output, and a pipe, which is
+// what CI gives it, is where a hard exit truncates.
+try {
+  process.exitCode = check(work) ? 0 : 1
+} catch (error) {
+  console.error(error.message)
+  process.exitCode = 1
 }
-if (duplicates === 0) console.log("  none")
-
-if (apiCopies.length !== 1) {
-  console.error(
-    `\nExpected exactly one copy of @opentelemetry/api, found ${apiCopies.length}.`
-  )
-  console.error(
-    "Adjust the version bounds in package.json until npm resolves a single " +
-      "copy. Widening the @opentelemetry/api bound usually helps more than " +
-      "narrowing it, because every OpenTelemetry package depends on the API as " +
-      "a peer dependency, and a wider bound is what lets npm share one copy " +
-      "with the application."
-  )
-  process.exit(1)
-}
-
-console.log("\nOK")

--- a/scripts/otel_duplicates_allowed.json
+++ b/scripts/otel_duplicates_allowed.json
@@ -1,0 +1,26 @@
+[
+  {
+    "package": "@opentelemetry/instrumentation",
+    "cause": "@prisma/instrumentation",
+    "reason": "@prisma/instrumentation depends on ^0.207.0, many minor versions behind the release this package bundles.",
+    "removeWhen": "Prisma widens that range, or we stop depending on @prisma/instrumentation."
+  },
+  {
+    "package": "@opentelemetry/api-logs",
+    "cause": "@prisma/instrumentation",
+    "reason": "api-logs is a dependency of @opentelemetry/instrumentation, so it duplicates wherever that does.",
+    "removeWhen": "The @opentelemetry/instrumentation entry for @prisma/instrumentation is removed."
+  },
+  {
+    "package": "@opentelemetry/instrumentation",
+    "cause": "@opentelemetry/instrumentation-fastify",
+    "reason": "instrumentation-fastify is held at 0.57.0, which depends on ^0.213.0, because the package is deprecated in favour of @fastify/otel.",
+    "removeWhen": "We migrate to @fastify/otel."
+  },
+  {
+    "package": "@opentelemetry/api-logs",
+    "cause": "@opentelemetry/instrumentation-fastify",
+    "reason": "api-logs is a dependency of @opentelemetry/instrumentation, so it duplicates wherever that does.",
+    "removeWhen": "The @opentelemetry/instrumentation entry for @opentelemetry/instrumentation-fastify is removed."
+  }
+]

--- a/scripts/otel_packages.js
+++ b/scripts/otel_packages.js
@@ -1,0 +1,140 @@
+// Finds the OpenTelemetry packages installed in a project and reports which of
+// them resolve to more than one version.
+//
+// Two copies of the same OpenTelemetry package are usually wasteful rather than
+// broken, but two copies of `@opentelemetry/api` are a silent failure. The API
+// keeps its global tracer provider on `globalThis`, keyed by major version, and
+// a copy only reads that global when its own minor version is less than or equal
+// to the minor version that wrote it. The copy that loses that comparison is
+// handed a tracer that discards every span it is given, and nothing is logged.
+
+"use strict"
+
+const fs = require("fs")
+const path = require("path")
+
+// Walks the installed tree rather than reading `package-lock.json`, so that what
+// is reported is what Node would actually resolve at runtime.
+function findPackages(root) {
+  const found = new Map()
+
+  function walk(dir) {
+    let entries
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true })
+    } catch {
+      return
+    }
+
+    for (const entry of entries) {
+      if (!entry.isDirectory() && !entry.isSymbolicLink()) continue
+
+      const full = path.join(dir, entry.name)
+      const manifest = path.join(full, "package.json")
+
+      if (fs.existsSync(manifest)) {
+        let parsed
+        try {
+          parsed = JSON.parse(fs.readFileSync(manifest, "utf8"))
+        } catch {
+          parsed = null
+        }
+
+        if (parsed && parsed.name && parsed.version) {
+          if (!found.has(parsed.name)) found.set(parsed.name, [])
+          found.get(parsed.name).push({
+            version: parsed.version,
+            path: path.relative(root, full)
+          })
+        }
+      }
+
+      if (entry.name === "node_modules" || entry.name.startsWith("@")) {
+        walk(full)
+      } else {
+        const nested = path.join(full, "node_modules")
+        if (fs.existsSync(nested)) walk(nested)
+      }
+    }
+  }
+
+  walk(path.join(root, "node_modules"))
+  return found
+}
+
+// Sorts a version before another when it is older. Plain string order puts
+// 1.10.0 before 1.9.0, and 0.221.0 before 0.56.0, which reads as nonsense in a
+// report about which version came from where.
+function compareVersions(left, right) {
+  const parts = version => version.split(".").map(Number)
+  const a = parts(left)
+  const b = parts(right)
+
+  for (let i = 0; i < Math.max(a.length, b.length); i++) {
+    const difference = (a[i] || 0) - (b[i] || 0)
+    if (difference !== 0) return difference
+  }
+
+  return 0
+}
+
+// npm nests a copy of a package inside whichever dependency asked for a version
+// the hoisted copy cannot satisfy. So the directory a copy is nested in names
+// the dependency responsible for it, and no version range has to be matched to
+// work that out.
+//
+// Returns null for a copy at the top of `node_modules`, which is the one every
+// other copy is a duplicate of.
+function causeOf(copyPath) {
+  const segments = copyPath.split(`node_modules${path.sep}`)
+  if (segments.length < 3) return null
+
+  return segments[segments.length - 2].replace(new RegExp(`\\${path.sep}$`), "")
+}
+
+// A package counts as duplicated when it resolves to more than one version.
+// Copies of the same version in different places cost disk space but behave
+// identically, so they are not reported.
+//
+// The hoisted copy is the one everything resolves by default, so it is the
+// baseline: the versions worth reporting are the ones nested somewhere else, and
+// what is worth naming is the dependency each of those is nested in.
+function findDuplicates(packages) {
+  const duplicates = []
+
+  for (const [name, copies] of [...packages.entries()].sort()) {
+    if (!name.startsWith("@opentelemetry/")) continue
+
+    const versions = [...new Set(copies.map(copy => copy.version))].sort(
+      compareVersions
+    )
+    if (versions.length < 2) continue
+
+    const hoisted = copies.find(copy => causeOf(copy.path) === null)
+    const baseline = hoisted ? hoisted.version : null
+
+    const nested = new Map()
+    for (const copy of copies) {
+      if (copy.version === baseline) continue
+
+      const cause = causeOf(copy.path)
+      if (!cause) continue
+
+      if (!nested.has(copy.version)) nested.set(copy.version, new Set())
+      nested.get(copy.version).add(cause)
+    }
+
+    duplicates.push({
+      name,
+      versions,
+      baseline,
+      nested: [...nested.entries()]
+        .map(([version, causes]) => ({ version, causes: [...causes].sort() }))
+        .sort((a, b) => compareVersions(a.version, b.version))
+    })
+  }
+
+  return duplicates
+}
+
+module.exports = { findPackages, findDuplicates, causeOf, compareVersions }

--- a/test/express-apollo/app/run.sh
+++ b/test/express-apollo/app/run.sh
@@ -21,5 +21,10 @@ npm install
 echo "Linking integration"
 npm link @appsignal/nodejs
 
+echo "Checking that one version of @opentelemetry/api is resolved"
+# Two copies means the app reports nothing and the suite fails with an empty
+# spans file, which says nothing about why.
+node /integration/scripts/check_otel_duplicates.js /app --api-only || exit 1
+
 echo "Starting test app server"
 npm run server

--- a/test/express-knex/app/run.sh
+++ b/test/express-knex/app/run.sh
@@ -27,5 +27,10 @@ npm install knex -g
 echo "Running migrations"
 knex migrate:latest --knexfile ./knexfile.js
 
+echo "Checking that one version of @opentelemetry/api is resolved"
+# Two copies means the app reports nothing and the suite fails with an empty
+# spans file, which says nothing about why.
+node /integration/scripts/check_otel_duplicates.js /app --api-only || exit 1
+
 echo "Starting test app server"
 npm run server

--- a/test/express-mongoose/app/run.sh
+++ b/test/express-mongoose/app/run.sh
@@ -35,5 +35,10 @@ npm run build
 echo "Running seed"
 npm run seed
 
+echo "Checking that one version of @opentelemetry/api is resolved"
+# Two copies means the app reports nothing and the suite fails with an empty
+# spans file, which says nothing about why.
+node /integration/scripts/check_otel_duplicates.js /app --api-only || exit 1
+
 echo "Starting test app server"
 npm run server

--- a/test/express-postgres/app/run.sh
+++ b/test/express-postgres/app/run.sh
@@ -21,5 +21,10 @@ npm install
 echo "Linking integration"
 npm link @appsignal/nodejs
 
+echo "Checking that one version of @opentelemetry/api is resolved"
+# Two copies means the app reports nothing and the suite fails with an empty
+# spans file, which says nothing about why.
+node /integration/scripts/check_otel_duplicates.js /app --api-only || exit 1
+
 echo "Starting test app server"
 npm run server

--- a/test/express-prisma-mongo/app/run.sh
+++ b/test/express-prisma-mongo/app/run.sh
@@ -33,5 +33,10 @@ npm run build
 echo "Running prisma seeds"
 npx prisma db seed
 
+echo "Checking that one version of @opentelemetry/api is resolved"
+# Two copies means the app reports nothing and the suite fails with an empty
+# spans file, which says nothing about why.
+node /integration/scripts/check_otel_duplicates.js /app --api-only || exit 1
+
 echo "Starting test app server"
 npm run server

--- a/test/express-prisma-postgres/app/run.sh
+++ b/test/express-prisma-postgres/app/run.sh
@@ -36,5 +36,10 @@ npm run build
 echo "Running prisma seeds"
 npx prisma db seed
 
+echo "Checking that one version of @opentelemetry/api is resolved"
+# Two copies means the app reports nothing and the suite fails with an empty
+# spans file, which says nothing about why.
+node /integration/scripts/check_otel_duplicates.js /app --api-only || exit 1
+
 echo "Starting test app server"
 npm run server

--- a/test/express-rabbitmq/app/run.sh
+++ b/test/express-rabbitmq/app/run.sh
@@ -19,5 +19,10 @@ npm install
 echo "Linking integration"
 npm link @appsignal/nodejs
 
+echo "Checking that one version of @opentelemetry/api is resolved"
+# Two copies means the app reports nothing and the suite fails with an empty
+# spans file, which says nothing about why.
+node /integration/scripts/check_otel_duplicates.js /app --api-only || exit 1
+
 echo "Starting test app server"
 npm run server

--- a/test/express-redis/app/run.sh
+++ b/test/express-redis/app/run.sh
@@ -19,5 +19,10 @@ npm install
 echo "Linking integration"
 npm link @appsignal/nodejs
 
+echo "Checking that one version of @opentelemetry/api is resolved"
+# Two copies means the app reports nothing and the suite fails with an empty
+# spans file, which says nothing about why.
+node /integration/scripts/check_otel_duplicates.js /app --api-only || exit 1
+
 echo "Starting test app server"
 npm run server

--- a/test/express-yoga/app/run.sh
+++ b/test/express-yoga/app/run.sh
@@ -21,5 +21,10 @@ npm install
 echo "Linking integration"
 npm link @appsignal/nodejs
 
+echo "Checking that one version of @opentelemetry/api is resolved"
+# Two copies means the app reports nothing and the suite fails with an empty
+# spans file, which says nothing about why.
+node /integration/scripts/check_otel_duplicates.js /app --api-only || exit 1
+
 echo "Starting test app server"
 npm run server

--- a/test/fastify/app/run.sh
+++ b/test/fastify/app/run.sh
@@ -21,5 +21,10 @@ npm install
 echo "Linking integration"
 npm link @appsignal/nodejs
 
+echo "Checking that one version of @opentelemetry/api is resolved"
+# Two copies means the app reports nothing and the suite fails with an empty
+# spans file, which says nothing about why.
+node /integration/scripts/check_otel_duplicates.js /app --api-only || exit 1
+
 echo "Starting test app server"
 npm run server

--- a/test/koa-mongo/app/run.sh
+++ b/test/koa-mongo/app/run.sh
@@ -35,5 +35,10 @@ npm run build
 echo "Running seed"
 npm run seed
 
+echo "Checking that one version of @opentelemetry/api is resolved"
+# Two copies means the app reports nothing and the suite fails with an empty
+# spans file, which says nothing about why.
+node /integration/scripts/check_otel_duplicates.js /app --api-only || exit 1
+
 echo "Starting test app server"
 npm run server

--- a/test/koa-mysql/app/run.sh
+++ b/test/koa-mysql/app/run.sh
@@ -21,5 +21,10 @@ npm install
 echo "Linking integration"
 npm link @appsignal/nodejs
 
+echo "Checking that one version of @opentelemetry/api is resolved"
+# Two copies means the app reports nothing and the suite fails with an empty
+# spans file, which says nothing about why.
+node /integration/scripts/check_otel_duplicates.js /app --api-only || exit 1
+
 echo "Starting test app server"
 npm run server

--- a/test/koa3-mysql/app/run.sh
+++ b/test/koa3-mysql/app/run.sh
@@ -21,5 +21,10 @@ npm install
 echo "Linking integration"
 npm link @appsignal/nodejs
 
+echo "Checking that one version of @opentelemetry/api is resolved"
+# Two copies means the app reports nothing and the suite fails with an empty
+# spans file, which says nothing about why.
+node /integration/scripts/check_otel_duplicates.js /app --api-only || exit 1
+
 echo "Starting test app server"
 npm run server

--- a/test/nestjs/app/run.sh
+++ b/test/nestjs/app/run.sh
@@ -24,5 +24,10 @@ npm link @appsignal/nodejs
 echo "Build Nestjs app"
 npm run build
 
+echo "Checking that one version of @opentelemetry/api is resolved"
+# Two copies means the app reports nothing and the suite fails with an empty
+# spans file, which says nothing about why.
+node /integration/scripts/check_otel_duplicates.js /app --api-only || exit 1
+
 echo "Starting test app server"
 npm run start:prod

--- a/test/nextjs/app/run.sh
+++ b/test/nextjs/app/run.sh
@@ -21,5 +21,10 @@ npm install
 echo "Linking integration"
 npm link @appsignal/nodejs
 
+echo "Checking that one version of @opentelemetry/api is resolved"
+# Two copies means the app reports nothing and the suite fails with an empty
+# spans file, which says nothing about why.
+node /integration/scripts/check_otel_duplicates.js /app --api-only || exit 1
+
 echo "Starting test app server"
 npm run start

--- a/test/restify/app/run.sh
+++ b/test/restify/app/run.sh
@@ -21,5 +21,10 @@ npm install
 echo "Linking integration"
 npm link @appsignal/nodejs
 
+echo "Checking that one version of @opentelemetry/api is resolved"
+# Two copies means the app reports nothing and the suite fails with an empty
+# spans file, which says nothing about why.
+node /integration/scripts/check_otel_duplicates.js /app --api-only || exit 1
+
 echo "Starting test app server"
 npm run server


### PR DESCRIPTION
Stacked on #1502.

This check runs in CI and in the test apps only. It is deliberately not
an install hook in the published package, which was the other option
considered.

npm rolls back the whole install when a lifecycle script fails. On
`npm ci` that leaves no `node_modules` at all, so a dependency tree this
check dislikes would stop an application from starting rather than stop
AppSignal from reporting. The way out for whoever hit it would be
`--ignore-scripts`, which also skips the scripts that fetch the agent
extension, trading a failing deploy for an AppSignal that quietly does
nothing. Warning instead of failing does not work either, because npm
hides a dependency's script output unless the script fails.

So an application is not told about its own tree yet. Doing that needs a
check at runtime, where the message goes to the application's own log
### [Fail the check on unexplained duplicates](https://github.com/appsignal/appsignal-nodejs/commit/766623584031faaac6cf4fa4b8659dc08506d799)

Duplicates of every OpenTelemetry package other than the API were listed
and not acted on, which is where a mistake in the version bounds shows
up first. They now fail unless `otel_duplicates_allowed.json` accounts
for them, and an entry that stops matching is reported so the file does
not keep reasons that have stopped being true.

Which dependency causes a duplicate is read from where npm put it, since
npm nests a copy inside whichever dependency asked for a version the
hoisted copy cannot satisfy. The check runs on Node.js 20 and 24 because
they ship npm 10 and npm 11, whose peer dependency resolution differs.

### [Check the test apps for duplicate API copies](https://github.com/appsignal/appsignal-nodejs/commit/8f23d3e534699b8a4929082f0ddad2b49f1b0270)

A test app resolving two incompatible copies of `@opentelemetry/api`
reports nothing, and its suite fails on an empty spans file without
saying why. The apps link the integration rather than installing it, so
`check_otel_resolution.js` cannot stand in for this, and copies that
differ only in their patch version are accepted because the API compares
and minor versions and linking produces such copies routinely.

[skip changeset]
